### PR TITLE
Add metadata builder functions

### DIFF
--- a/src/nanoarrow/metadata.c
+++ b/src/nanoarrow/metadata.c
@@ -21,7 +21,7 @@
 
 #include "nanoarrow.h"
 
-struct ArrowStringView ArrowStringViewCreate(const char* value) {
+struct ArrowStringView ArrowCharView(const char* value) {
   struct ArrowStringView out;
 
   out.data = value;
@@ -131,7 +131,7 @@ ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
 }
 
 char ArrowMetadataHasKey(const char* metadata, const char* key) {
-  struct ArrowStringView value = ArrowStringViewCreate(NULL);
+  struct ArrowStringView value = ArrowCharView(NULL);
   ArrowMetadataGetValue(metadata, key, &value);
   return value.data != NULL;
 }
@@ -194,7 +194,7 @@ static ArrowErrorCode ArrowMetadataBuilderSetInternal(struct ArrowBuffer* buffer
                                                       struct ArrowStringView* key,
                                                       struct ArrowStringView* value) {
   // Inspect the current value to see if we can avoid copying the buffer
-  struct ArrowStringView current_value = ArrowStringViewCreate(NULL);
+  struct ArrowStringView current_value = ArrowCharView(NULL);
   int result =
       ArrowMetadataGetValueInternal((const char*)buffer->data, key, &current_value);
   if (result != NANOARROW_OK) {

--- a/src/nanoarrow/metadata.c
+++ b/src/nanoarrow/metadata.c
@@ -119,3 +119,135 @@ char ArrowMetadataHasKey(const char* metadata, const char* key) {
   ArrowMetadataGetValue(metadata, key, NULL, &value);
   return value.data != NULL;
 }
+
+ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer,
+                                        const char* metadata) {
+  ArrowBufferInit(buffer);
+  int result = ArrowBufferAppend(buffer, metadata, ArrowMetadataSizeOf(metadata));
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowMetadataBuilderAppendView(struct ArrowBuffer* buffer,
+                                              struct ArrowStringView* key,
+                                              struct ArrowStringView* value) {
+  if (value == NULL) {
+    return NANOARROW_OK;
+  }
+
+  int result;
+
+  if (buffer->capacity_bytes == 0) {
+    int32_t zero = 0;
+    result = ArrowBufferAppend(buffer, &zero, sizeof(int32_t));
+    if (result != NANOARROW_OK) {
+      return result;
+    }
+  }
+
+  if (buffer->capacity_bytes < sizeof(int32_t)) {
+    return EINVAL;
+  }
+
+  int32_t n_keys;
+  memcpy(&n_keys, buffer->data, sizeof(int32_t));
+
+  int32_t key_size = key->n_bytes;
+  int32_t value_size = value->n_bytes;
+  result = ArrowBufferReserve(buffer,
+                              sizeof(int32_t) + key_size + sizeof(int32_t) + value_size);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  ArrowBufferAppendUnsafe(buffer, &key_size, sizeof(int32_t));
+  ArrowBufferAppendUnsafe(buffer, key->data, key_size);
+  ArrowBufferAppendUnsafe(buffer, &value_size, sizeof(int32_t));
+  ArrowBufferAppendUnsafe(buffer, value->data, value_size);
+
+  n_keys++;
+  memcpy(buffer->data, &n_keys, sizeof(int32_t));
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer, const char* key,
+                                          const char* value) {
+  struct ArrowStringView key_view = {key, strlen(key)};
+
+  if (value == NULL) {
+    return ArrowMetadataBuilderAppendView(buffer, &key_view, NULL);
+  } else {
+    struct ArrowStringView value_view = {value, strlen(value)};
+    return ArrowMetadataBuilderAppendView(buffer, &key_view, &value_view);
+  }
+}
+
+ArrowErrorCode ArrowMetadataBuilderSetView(struct ArrowBuffer* buffer,
+                                           struct ArrowStringView* key,
+                                           struct ArrowStringView* value) {
+  struct ArrowMetadataReader reader;
+  int result = ArrowMetadataReaderInit(&reader, (const char*)buffer->data);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  struct ArrowBuffer new_buffer;
+  result = ArrowMetadataBuilderInit(&new_buffer, NULL);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  struct ArrowStringView existing_key;
+  struct ArrowStringView existing_value;
+
+  while (reader.remaining_keys > 0) {
+    result = ArrowMetadataReaderRead(&reader, &existing_key, &existing_value);
+    if (result != NANOARROW_OK) {
+      ArrowBufferReset(&new_buffer);
+      return result;
+    }
+
+    if (key->n_bytes == existing_key.n_bytes &&
+        strncmp((const char*)key->data, (const char*)existing_key.data,
+                existing_key.n_bytes) == 0) {
+      result = ArrowMetadataBuilderAppendView(&new_buffer, key, value);
+      value = NULL;
+    } else {
+      result =
+          ArrowMetadataBuilderAppendView(&new_buffer, &existing_key, &existing_value);
+    }
+
+    if (result != NANOARROW_OK) {
+      ArrowBufferReset(&new_buffer);
+      return result;
+    }
+  }
+
+  if (value != NULL) {
+    result = ArrowMetadataBuilderAppendView(&new_buffer, key, value);
+    if (result != NANOARROW_OK) {
+      ArrowBufferReset(&new_buffer);
+      return result;
+    }
+  }
+
+  ArrowBufferReset(buffer);
+  ArrowBufferMove(&new_buffer, buffer);
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer, const char* key,
+                                       const char* value) {
+  struct ArrowStringView key_view = {key, strlen(key)};
+
+  if (value == NULL) {
+    return ArrowMetadataBuilderSetView(buffer, &key_view, NULL);
+  } else {
+    struct ArrowStringView value_view = {value, strlen(value)};
+    return ArrowMetadataBuilderSetView(buffer, &key_view, &value_view);
+  }
+}

--- a/src/nanoarrow/metadata.c
+++ b/src/nanoarrow/metadata.c
@@ -21,19 +21,6 @@
 
 #include "nanoarrow.h"
 
-struct ArrowStringView ArrowCharView(const char* value) {
-  struct ArrowStringView out;
-
-  out.data = value;
-  if (value == NULL) {
-    out.n_bytes = 0;
-  } else {
-    out.n_bytes = (int64_t)strlen(value);
-  }
-
-  return out;
-}
-
 ArrowErrorCode ArrowMetadataReaderInit(struct ArrowMetadataReader* reader,
                                        const char* metadata) {
   reader->metadata = metadata;

--- a/src/nanoarrow/metadata.c
+++ b/src/nanoarrow/metadata.c
@@ -107,17 +107,16 @@ static ArrowErrorCode ArrowMetadataGetValueInternal(const char* metadata,
   return NANOARROW_OK;
 }
 
-ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
+ArrowErrorCode ArrowMetadataGetValue(const char* metadata, struct ArrowStringView key,
                                      struct ArrowStringView* value_out) {
-  if (key == NULL || value_out == NULL) {
+  if (value_out == NULL) {
     return EINVAL;
   }
 
-  struct ArrowStringView key_view = {key, strlen(key)};
-  return ArrowMetadataGetValueInternal(metadata, &key_view, value_out);
+  return ArrowMetadataGetValueInternal(metadata, &key, value_out);
 }
 
-char ArrowMetadataHasKey(const char* metadata, const char* key) {
+char ArrowMetadataHasKey(const char* metadata, struct ArrowStringView key) {
   struct ArrowStringView value = ArrowCharView(NULL);
   ArrowMetadataGetValue(metadata, key, &value);
   return value.data != NULL;
@@ -240,31 +239,19 @@ static ArrowErrorCode ArrowMetadataBuilderSetInternal(struct ArrowBuffer* buffer
   return NANOARROW_OK;
 }
 
-ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer, const char* key,
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key,
                                           struct ArrowStringView value) {
-  if (key == NULL) {
-    return EINVAL;
-  }
-
-  struct ArrowStringView key_view = {key, strlen(key)};
-  return ArrowMetadataBuilderAppendInternal(buffer, &key_view, &value);
+  return ArrowMetadataBuilderAppendInternal(buffer, &key, &value);
 }
 
-ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer, const char* key,
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
+                                       struct ArrowStringView key,
                                        struct ArrowStringView value) {
-  if (key == NULL) {
-    return EINVAL;
-  }
-
-  struct ArrowStringView key_view = {key, strlen(key)};
-  return ArrowMetadataBuilderSetInternal(buffer, &key_view, &value);
+  return ArrowMetadataBuilderSetInternal(buffer, &key, &value);
 }
 
-ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer, const char* key) {
-  if (key == NULL) {
-    return EINVAL;
-  }
-
-  struct ArrowStringView key_view = {key, strlen(key)};
-  return ArrowMetadataBuilderSetInternal(buffer, &key_view, NULL);
+ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key) {
+  return ArrowMetadataBuilderSetInternal(buffer, &key, NULL);
 }

--- a/src/nanoarrow/metadata.c
+++ b/src/nanoarrow/metadata.c
@@ -121,20 +121,18 @@ static ArrowErrorCode ArrowMetadataGetValueInternal(const char* metadata,
 }
 
 ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
-                                     struct ArrowStringView default_value,
                                      struct ArrowStringView* value_out) {
   if (key == NULL || value_out == NULL) {
     return EINVAL;
   }
 
   struct ArrowStringView key_view = {key, strlen(key)};
-  *value_out = default_value;
   return ArrowMetadataGetValueInternal(metadata, &key_view, value_out);
 }
 
 char ArrowMetadataHasKey(const char* metadata, const char* key) {
-  struct ArrowStringView value;
-  ArrowMetadataGetValue(metadata, key, ArrowStringViewCreate(NULL), &value);
+  struct ArrowStringView value = ArrowStringViewCreate(NULL);
+  ArrowMetadataGetValue(metadata, key, &value);
   return value.data != NULL;
 }
 

--- a/src/nanoarrow/metadata_test.cc
+++ b/src/nanoarrow/metadata_test.cc
@@ -79,6 +79,7 @@ TEST(MetadataTest, MetadataBuild) {
       NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
+  // Set an existing key
   ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key", "value3"), NANOARROW_OK);
   ASSERT_EQ(
       ArrowMetadataGetValue((const char*)metadata_builder.data, "key", nullptr, &value),
@@ -89,6 +90,7 @@ TEST(MetadataTest, MetadataBuild) {
       NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
+  // Remove a key that does exist
   ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key", NULL), NANOARROW_OK);
   EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"), false);
   ASSERT_EQ(

--- a/src/nanoarrow/metadata_test.cc
+++ b/src/nanoarrow/metadata_test.cc
@@ -36,14 +36,12 @@ TEST(MetadataTest, Metadata) {
   EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "key"), 1);
   EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "not_a_key"), 0);
 
-  struct ArrowStringView value;
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "key",
-                                  ArrowStringViewCreate("default_val"), &value),
-            NANOARROW_OK);
+  struct ArrowStringView value = ArrowStringViewCreate("default_val");
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "key", &value), NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value");
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "not_a_key",
-                                  ArrowStringViewCreate("default_val"), &value),
-            NANOARROW_OK);
+
+  value = ArrowStringViewCreate("default_val");
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "not_a_key", &value), NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "default_val");
 }
 
@@ -86,9 +84,8 @@ TEST(MetadataTest, MetadataBuild) {
   EXPECT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata) +
                                              sizeof(int32_t) + 4 + sizeof(int32_t) + 6);
 
-  struct ArrowStringView value;
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2",
-                                  ArrowStringViewCreate(nullptr), &value),
+  struct ArrowStringView value = ArrowStringViewCreate(nullptr);
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
@@ -96,20 +93,20 @@ TEST(MetadataTest, MetadataBuild) {
   ASSERT_EQ(
       ArrowMetadataBuilderSet(&metadata_builder, "key", ArrowStringViewCreate("value3")),
       NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key",
-                                  ArrowStringViewCreate(nullptr), &value),
+  value = ArrowStringViewCreate(nullptr);
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value3");
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2",
-                                  ArrowStringViewCreate(nullptr), &value),
+  value = ArrowStringViewCreate(nullptr);
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
   // Remove a key that does exist
   ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"), NANOARROW_OK);
   EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"), false);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2",
-                                  ArrowStringViewCreate(nullptr), &value),
+  value = ArrowStringViewCreate(nullptr);
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 

--- a/src/nanoarrow/metadata_test.cc
+++ b/src/nanoarrow/metadata_test.cc
@@ -33,15 +33,17 @@ TEST(MetadataTest, Metadata) {
   EXPECT_EQ(ArrowMetadataSizeOf(nullptr), 0);
   EXPECT_EQ(ArrowMetadataSizeOf(simple_metadata), sizeof(simple_metadata));
 
-  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "key"), 1);
-  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "not_a_key"), 0);
+  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, ArrowCharView("key")), 1);
+  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, ArrowCharView("not_a_key")), 0);
 
   struct ArrowStringView value = ArrowCharView("default_val");
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "key", &value), NANOARROW_OK);
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, ArrowCharView("key"), &value),
+            NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value");
 
   value = ArrowCharView("default_val");
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "not_a_key", &value), NANOARROW_OK);
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, ArrowCharView("not_a_key"), &value),
+            NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "default_val");
 }
 
@@ -64,54 +66,58 @@ TEST(MetadataTest, MetadataBuild) {
   EXPECT_EQ(metadata_builder.data, nullptr);
 
   // Recreate simple_metadata
-  ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, "key",
-                                       {"value", (int)strlen("value")}),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, ArrowCharView("key"),
+                                       ArrowCharView("value")),
             NANOARROW_OK);
   ASSERT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata));
   EXPECT_EQ(memcmp(metadata_builder.data, simple_metadata, metadata_builder.size_bytes),
             0);
 
   // Remove a key that doesn't exist
-  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key2"), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, ArrowCharView("key2")),
+            NANOARROW_OK);
   ASSERT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata));
   EXPECT_EQ(memcmp(metadata_builder.data, simple_metadata, metadata_builder.size_bytes),
             0);
 
   // Add a new key
-  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2", ArrowCharView("value2")),
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, ArrowCharView("key2"),
+                                    ArrowCharView("value2")),
             NANOARROW_OK);
   EXPECT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata) +
                                              sizeof(int32_t) + 4 + sizeof(int32_t) + 6);
 
   struct ArrowStringView value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data,
+                                  ArrowCharView("key2"), &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
   // Set an existing key
-  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key", ArrowCharView("value3")),
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, ArrowCharView("key"),
+                                    ArrowCharView("value3")),
             NANOARROW_OK);
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key", &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data,
+                                  ArrowCharView("key"), &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value3");
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data,
+                                  ArrowCharView("key2"), &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
   // Remove a key that does exist
-  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"), NANOARROW_OK);
-  EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"), false);
+  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, ArrowCharView("key")),
+            NANOARROW_OK);
+  EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, ArrowCharView("key")),
+            false);
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data,
+                                  ArrowCharView("key2"), &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
-
-  // Attempt a NULL key or value
-  EXPECT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, nullptr, {"x", 1}), EINVAL);
-  EXPECT_EQ(ArrowMetadataBuilderSet(&metadata_builder, nullptr, {"x", 1}), EINVAL);
-  EXPECT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, nullptr), EINVAL);
 
   ArrowBufferReset(&metadata_builder);
 }

--- a/src/nanoarrow/metadata_test.cc
+++ b/src/nanoarrow/metadata_test.cc
@@ -36,11 +36,11 @@ TEST(MetadataTest, Metadata) {
   EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "key"), 1);
   EXPECT_EQ(ArrowMetadataHasKey(simple_metadata, "not_a_key"), 0);
 
-  struct ArrowStringView value = ArrowStringViewCreate("default_val");
+  struct ArrowStringView value = ArrowCharView("default_val");
   EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "key", &value), NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value");
 
-  value = ArrowStringViewCreate("default_val");
+  value = ArrowCharView("default_val");
   EXPECT_EQ(ArrowMetadataGetValue(simple_metadata, "not_a_key", &value), NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "default_val");
 }
@@ -78,26 +78,24 @@ TEST(MetadataTest, MetadataBuild) {
             0);
 
   // Add a new key
-  ASSERT_EQ(
-      ArrowMetadataBuilderSet(&metadata_builder, "key2", ArrowStringViewCreate("value2")),
-      NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2", ArrowCharView("value2")),
+            NANOARROW_OK);
   EXPECT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata) +
                                              sizeof(int32_t) + 4 + sizeof(int32_t) + 6);
 
-  struct ArrowStringView value = ArrowStringViewCreate(nullptr);
+  struct ArrowStringView value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
 
   // Set an existing key
-  ASSERT_EQ(
-      ArrowMetadataBuilderSet(&metadata_builder, "key", ArrowStringViewCreate("value3")),
-      NANOARROW_OK);
-  value = ArrowStringViewCreate(nullptr);
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key", ArrowCharView("value3")),
+            NANOARROW_OK);
+  value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value3");
-  value = ArrowStringViewCreate(nullptr);
+  value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");
@@ -105,7 +103,7 @@ TEST(MetadataTest, MetadataBuild) {
   // Remove a key that does exist
   ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"), NANOARROW_OK);
   EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"), false);
-  value = ArrowStringViewCreate(nullptr);
+  value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2", &value),
             NANOARROW_OK);
   EXPECT_EQ(std::string(value.data, value.n_bytes), "value2");

--- a/src/nanoarrow/metadata_test.cc
+++ b/src/nanoarrow/metadata_test.cc
@@ -50,18 +50,26 @@ TEST(MetadataTest, MetadataBuild) {
   char simple_metadata[] = {'\1', '\0', '\0', '\0', '\3', '\0', '\0', '\0', 'k', 'e',
                             'y',  '\5', '\0', '\0', '\0', 'v',  'a',  'l',  'u', 'e'};
 
+  // Empty metadata
   struct ArrowBuffer metadata_builder;
   ASSERT_EQ(ArrowMetadataBuilderInit(&metadata_builder, nullptr), NANOARROW_OK);
   EXPECT_EQ(metadata_builder.size_bytes, 0);
   EXPECT_EQ(metadata_builder.data, nullptr);
 
+  // Recreate simple_metadata
   ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, "key", "value"), NANOARROW_OK);
   ASSERT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata));
   EXPECT_EQ(memcmp(metadata_builder.data, simple_metadata, metadata_builder.size_bytes),
             0);
 
-  ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, "key2", "value2"),
-            NANOARROW_OK);
+  // Remove a key that doesn't exist
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2", NULL), NANOARROW_OK);
+  ASSERT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata));
+  EXPECT_EQ(memcmp(metadata_builder.data, simple_metadata, metadata_builder.size_bytes),
+            0);
+
+  // Add a new key
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2", "value2"), NANOARROW_OK);
   EXPECT_EQ(metadata_builder.size_bytes, ArrowMetadataSizeOf(simple_metadata) +
                                              sizeof(int32_t) + 4 + sizeof(int32_t) + 6);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -194,12 +194,12 @@ ArrowErrorCode ArrowMetadataReaderRead(struct ArrowMetadataReader* reader,
 int64_t ArrowMetadataSizeOf(const char* metadata);
 
 /// \brief Check for a key in schema metadata
-char ArrowMetadataHasKey(const char* metadata, const char* key);
+char ArrowMetadataHasKey(const char* metadata, struct ArrowStringView key);
 
 /// \brief Extract a value from schema metadata
 ///
 /// If key does not exist in metadata, value_out is unmodified
-ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
+ArrowErrorCode ArrowMetadataGetValue(const char* metadata, struct ArrowStringView key,
                                      struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs
@@ -209,7 +209,8 @@ ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
 ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
 
 /// \brief Append a key/value pair to a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer, const char* key,
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key,
                                           struct ArrowStringView value);
 
 /// \brief Set a key/value pair to a buffer containing serialized metadata
@@ -217,11 +218,13 @@ ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer, const char
 /// Ensures that the only entry for key in the metadata is set to value.
 /// This function maintains the existing position of (the first instance of)
 /// key if present in the data.
-ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer, const char* key,
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
+                                       struct ArrowStringView key,
                                        struct ArrowStringView value);
 
 /// \brief Remove a key from a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer, const char* key);
+ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -87,19 +87,6 @@ const char* ArrowErrorMessage(struct ArrowError* error);
 
 /// \defgroup nanoarrow-utils Utility data structures
 
-/// \brief An non-owning view of a string
-struct ArrowStringView {
-  /// \brief A pointer to the start of the string
-  ///
-  /// If n_bytes is 0, this value may be NULL.
-  const char* data;
-
-  /// \brief The size of the string in bytes,
-  ///
-  /// (Not including the null terminator.)
-  int64_t n_bytes;
-};
-
 /// \brief Arrow time unit enumerator
 ///
 /// These names and values map to the corresponding arrow::TimeUnit::type
@@ -186,9 +173,6 @@ ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
 /// schema must have been allocated using ArrowSchemaInit or
 /// ArrowSchemaDeepCopy.
 ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
-
-/// \brief Create a string view from a null-terminated string
-struct ArrowStringView ArrowCharView(const char* value);
 
 /// \brief Reader for key/value pairs in schema metadata
 struct ArrowMetadataReader {

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -213,8 +213,9 @@ int64_t ArrowMetadataSizeOf(const char* metadata);
 char ArrowMetadataHasKey(const char* metadata, const char* key);
 
 /// \brief Extract a value from schema metadata
+///
+/// If key does not exist in metadata, value_out is unmodified
 ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
-                                     struct ArrowStringView default_value,
                                      struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -188,7 +188,7 @@ ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
 ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
 
 /// \brief Create a string view from a null-terminated string
-struct ArrowStringView ArrowStringViewCreate(const char* value);
+struct ArrowStringView ArrowCharView(const char* value);
 
 /// \brief Reader for key/value pairs in schema metadata
 struct ArrowMetadataReader {

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -63,6 +63,23 @@ void ArrowFree(void* ptr);
 /// ArrowFree().
 struct ArrowBufferAllocator* ArrowBufferAllocatorDefault();
 
+/// \brief An owning mutable view of a buffer
+struct ArrowBuffer {
+  /// \brief A pointer to the start of the buffer
+  ///
+  /// If capacity_bytes is 0, this value may be NULL.
+  uint8_t* data;
+
+  /// \brief The size of the buffer in bytes
+  int64_t size_bytes;
+
+  /// \brief The capacity of the buffer in bytes
+  int64_t capacity_bytes;
+
+  /// \brief The allocator that will be used to reallocate and/or free the buffer
+  struct ArrowBufferAllocator* allocator;
+};
+
 /// }@
 
 /// \defgroup nanoarrow-errors Error handling primitives
@@ -213,6 +230,24 @@ char ArrowMetadataHasKey(const char* metadata, const char* key);
 ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
                                      const char* default_value,
                                      struct ArrowStringView* value_out);
+
+/// \brief Initialize a builder for schema metadata from key/value pairs
+ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
+
+/// \brief Append a key/value pair to a buffer containing serialized metadata
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
+                                          const char* key,
+                                          const char* value);
+
+/// \brief Set a key/value pair to a buffer containing serialized metadata
+///
+/// Ensures that the only entry for key in the metadata is set to value.
+/// If value is NULL, all entries for key will be removed. This function
+/// maintains the existing position of (the first instance of) key if present
+/// in the data.
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
+                                       const char* key,
+                                       const char* value);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -187,6 +187,9 @@ ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
 /// ArrowSchemaDeepCopy.
 ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
 
+/// \brief Create a string view from a null-terminated string
+struct ArrowStringView ArrowStringViewCreate(const char* value);
+
 /// \brief Reader for key/value pairs in schema metadata
 struct ArrowMetadataReader {
   const char* metadata;
@@ -211,7 +214,7 @@ char ArrowMetadataHasKey(const char* metadata, const char* key);
 
 /// \brief Extract a value from schema metadata
 ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
-                                     const char* default_value,
+                                     struct ArrowStringView default_value,
                                      struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs
@@ -221,22 +224,19 @@ ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
 ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
 
 /// \brief Append a key/value pair to a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
-                                          const char* key,
-                                          const char* value);
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer, const char* key,
+                                          struct ArrowStringView value);
 
 /// \brief Set a key/value pair to a buffer containing serialized metadata
 ///
 /// Ensures that the only entry for key in the metadata is set to value.
 /// This function maintains the existing position of (the first instance of)
 /// key if present in the data.
-ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
-                                       const char* key,
-                                       const char* value);
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer, const char* key,
+                                       struct ArrowStringView value);
 
 /// \brief Remove a key from a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
-                                          const char* key);
+ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer, const char* key);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -87,6 +87,9 @@ const char* ArrowErrorMessage(struct ArrowError* error);
 
 /// \defgroup nanoarrow-utils Utility data structures
 
+/// \brief Create a string view from a null-terminated string
+static inline struct ArrowStringView ArrowCharView(const char* value);
+
 /// \brief Arrow time unit enumerator
 ///
 /// These names and values map to the corresponding arrow::TimeUnit::type
@@ -510,6 +513,7 @@ ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
 // Inline function definitions
 #include "bitmap_inline.h"
 #include "buffer_inline.h"
+#include "utils_inline.h"
 
 #ifdef __cplusplus
 }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -215,6 +215,9 @@ ArrowErrorCode ArrowMetadataGetValue(const char* metadata, const char* key,
                                      struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs
+///
+/// metadata can be an existing metadata string or NULL to initialize
+/// an empty metadata string.
 ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
 
 /// \brief Append a key/value pair to a buffer containing serialized metadata
@@ -225,12 +228,15 @@ ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
 /// \brief Set a key/value pair to a buffer containing serialized metadata
 ///
 /// Ensures that the only entry for key in the metadata is set to value.
-/// If value is NULL, all entries for key will be removed. This function
-/// maintains the existing position of (the first instance of) key if present
-/// in the data.
+/// This function maintains the existing position of (the first instance of)
+/// key if present in the data.
 ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
                                        const char* key,
                                        const char* value);
+
+/// \brief Remove a key from a buffer containing serialized metadata
+ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
+                                          const char* key);
 
 /// }@
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -63,23 +63,6 @@ void ArrowFree(void* ptr);
 /// ArrowFree().
 struct ArrowBufferAllocator* ArrowBufferAllocatorDefault();
 
-/// \brief An owning mutable view of a buffer
-struct ArrowBuffer {
-  /// \brief A pointer to the start of the buffer
-  ///
-  /// If capacity_bytes is 0, this value may be NULL.
-  uint8_t* data;
-
-  /// \brief The size of the buffer in bytes
-  int64_t size_bytes;
-
-  /// \brief The capacity of the buffer in bytes
-  int64_t capacity_bytes;
-
-  /// \brief The allocator that will be used to reallocate and/or free the buffer
-  struct ArrowBufferAllocator* allocator;
-};
-
 /// }@
 
 /// \defgroup nanoarrow-errors Error handling primitives

--- a/src/nanoarrow/schema_view.c
+++ b/src/nanoarrow/schema_view.c
@@ -668,8 +668,8 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
     }
   }
 
-  schema_view->extension_name = ArrowStringViewCreate(NULL);
-  schema_view->extension_metadata = ArrowStringViewCreate(NULL);
+  schema_view->extension_name = ArrowCharView(NULL);
+  schema_view->extension_metadata = ArrowCharView(NULL);
   ArrowMetadataGetValue(schema->metadata, "ARROW:extension:name",
                         &schema_view->extension_name);
   ArrowMetadataGetValue(schema->metadata, "ARROW:extension:metadata",

--- a/src/nanoarrow/schema_view.c
+++ b/src/nanoarrow/schema_view.c
@@ -668,10 +668,12 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
     }
   }
 
+  schema_view->extension_name = ArrowStringViewCreate(NULL);
+  schema_view->extension_metadata = ArrowStringViewCreate(NULL);
   ArrowMetadataGetValue(schema->metadata, "ARROW:extension:name",
-                        ArrowStringViewCreate(NULL), &schema_view->extension_name);
+                        &schema_view->extension_name);
   ArrowMetadataGetValue(schema->metadata, "ARROW:extension:metadata",
-                        ArrowStringViewCreate(NULL), &schema_view->extension_metadata);
+                        &schema_view->extension_metadata);
 
   return NANOARROW_OK;
 }

--- a/src/nanoarrow/schema_view.c
+++ b/src/nanoarrow/schema_view.c
@@ -668,10 +668,10 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
     }
   }
 
-  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:name", NULL,
-                        &schema_view->extension_name);
-  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:metadata", NULL,
-                        &schema_view->extension_metadata);
+  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:name",
+                        ArrowStringViewCreate(NULL), &schema_view->extension_name);
+  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:metadata",
+                        ArrowStringViewCreate(NULL), &schema_view->extension_metadata);
 
   return NANOARROW_OK;
 }

--- a/src/nanoarrow/schema_view.c
+++ b/src/nanoarrow/schema_view.c
@@ -670,9 +670,9 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
   schema_view->extension_name = ArrowCharView(NULL);
   schema_view->extension_metadata = ArrowCharView(NULL);
-  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:name",
+  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:name"),
                         &schema_view->extension_name);
-  ArrowMetadataGetValue(schema->metadata, "ARROW:extension:metadata",
+  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:metadata"),
                         &schema_view->extension_metadata);
 
   return NANOARROW_OK;

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -179,21 +179,6 @@ struct ArrowStringView {
   int64_t n_bytes;
 };
 
- /// \brief Create a string view from a null-terminated string
-static inline struct ArrowStringView ArrowCharView(const char* value) {
-  struct ArrowStringView out;
-
-  out.data = value;
-  out.n_bytes = 0;
-  if (value) {
-    while (*value++) {
-      out.n_bytes++;
-    }
-  }
-
-  return out;
-}
-
 /// \brief Array buffer allocation and deallocation
 ///
 /// Container for allocate, reallocate, and free methods that can be used

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -185,7 +185,7 @@ static inline struct ArrowStringView ArrowCharView(const char* value) {
 
   out.data = value;
   out.n_bytes = 0;
-  if (value != NULL) {
+  if (value) {
     while (*value++) {
       out.n_bytes++;
     }

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -166,6 +166,34 @@ enum ArrowType {
   NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO
 };
 
+/// \brief An non-owning view of a string
+struct ArrowStringView {
+  /// \brief A pointer to the start of the string
+  ///
+  /// If n_bytes is 0, this value may be NULL.
+  const char* data;
+
+  /// \brief The size of the string in bytes,
+  ///
+  /// (Not including the null terminator.)
+  int64_t n_bytes;
+};
+
+ /// \brief Create a string view from a null-terminated string
+static inline struct ArrowStringView ArrowCharView(const char* value) {
+  struct ArrowStringView out;
+
+  out.data = value;
+  out.n_bytes = 0;
+  if (value != NULL) {
+    while (*value++) {
+      out.n_bytes++;
+    }
+  }
+
+  return out;
+}
+
 /// \brief Array buffer allocation and deallocation
 ///
 /// Container for allocate, reallocate, and free methods that can be used

--- a/src/nanoarrow/utils_inline.h
+++ b/src/nanoarrow/utils_inline.h
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef NANOARROW_UTILS_INLINE_H_INCLUDED
+#define NANOARROW_UTILS_INLINE_H_INCLUDED
+
+#include <string.h>
+
+#include "typedefs_inline.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline struct ArrowStringView ArrowCharView(const char* value) {
+  struct ArrowStringView out;
+
+  out.data = value;
+  if (value) {
+    out.n_bytes = (int64_t)strlen(value);
+  } else {
+    out.n_bytes = 0;
+  }
+
+  return out;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Fixes #6.

This PR adds functions `ArrowMetadataBuilderAppend()` (for blindly but efficiently adding a key/value pair to the end of some metadata) and `ArrowMetadataBuilderSet()` (to less efficiently replace or remove a value for key).

The use case I had in mind is building extension type metadata from some input (i.e., make an output schema like the input except with new extension type or with new serialized extension type metadata). It's rather difficult to replicate the "replace" or "remove" behaviour otherwise.