### PR TITLE
Owning/mutable `struct ArrowArray`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(src)
 add_library(
     nanoarrow
     src/nanoarrow/allocator.c
+    src/nanoarrow/array.c
     src/nanoarrow/error.c
     src/nanoarrow/metadata.c
     src/nanoarrow/schema.c
@@ -59,6 +60,7 @@ if (NANOARROW_BUILD_TESTS)
     add_executable(allocator_test src/nanoarrow/allocator_test.cc)
     add_executable(buffer_test src/nanoarrow/buffer_test.cc)
     add_executable(bitmap_test src/nanoarrow/bitmap_test.cc)
+    add_executable(array_test src/nanoarrow/array_test.cc)
     add_executable(error_test src/nanoarrow/error_test.cc)
     add_executable(metadata_test src/nanoarrow/metadata_test.cc)
     add_executable(schema_test src/nanoarrow/schema_test.cc)
@@ -73,6 +75,7 @@ if (NANOARROW_BUILD_TESTS)
     target_link_libraries(allocator_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(buffer_test nanoarrow GTest::gtest_main)
     target_link_libraries(bitmap_test nanoarrow GTest::gtest_main)
+    target_link_libraries(array_test nanoarrow GTest::gtest_main)
     target_link_libraries(error_test nanoarrow GTest::gtest_main)
     target_link_libraries(metadata_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
     target_link_libraries(schema_test nanoarrow GTest::gtest_main arrow_shared arrow_testing_shared)
@@ -82,9 +85,9 @@ if (NANOARROW_BUILD_TESTS)
     gtest_discover_tests(allocator_test)
     gtest_discover_tests(buffer_test)
     gtest_discover_tests(bitmap_test)
+    gtest_discover_tests(array_test)
     gtest_discover_tests(error_test)
     gtest_discover_tests(metadata_test)
     gtest_discover_tests(schema_test)
     gtest_discover_tests(schema_view_test)
-
 endif()

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -15,9 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "allocator.c"
-#include "array.c"
-#include "error.c"
-#include "metadata.c"
-#include "schema.c"
-#include "schema_view.c"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nanoarrow.h"
+
+ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, struct ArrowSchema* schema) {
+    return NANOARROW_OK;
+}
+

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -22,7 +22,134 @@
 
 #include "nanoarrow.h"
 
-ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, struct ArrowSchema* schema) {
-    return NANOARROW_OK;
+static void ArrowArrayRelease(struct ArrowArray* array) {
+  // Release buffers held by this array
+  struct ArrowArrayPrivateData* data = (struct ArrowArrayPrivateData*)array->private_data;
+  if (data != NULL) {
+    ArrowBufferReset(&data->bitmap);
+    ArrowBufferReset(&data->buffers[0]);
+    ArrowBufferReset(&data->buffers[1]);
+    ArrowFree(data);
+  }
+
+  // This object owns the memory for all the children, but those
+  // children may have been generated elsewhere and might have
+  // their own release() callback.
+  if (array->children != NULL) {
+    for (int64_t i = 0; i < array->n_children; i++) {
+      if (array->children[i] != NULL) {
+        if (array->children[i]->release != NULL) {
+          array->children[i]->release(array->children[i]);
+        }
+
+        ArrowFree(array->children[i]);
+      }
+    }
+
+    ArrowFree(array->children);
+  }
+
+  // This object owns the memory for the dictionary but it
+  // may have been generated somewhere else and have its own
+  // release() callback.
+  if (array->dictionary != NULL) {
+    if (array->dictionary->release != NULL) {
+      array->dictionary->release(array->dictionary);
+    }
+
+    ArrowFree(array->dictionary);
+  }
+
+  // Mark released
+  array->release = NULL;
 }
 
+ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
+                                        enum ArrowType storage_type) {
+  switch (storage_type) {
+    case NANOARROW_TYPE_UNINITIALIZED:
+    case NANOARROW_TYPE_NA:
+      array->n_buffers = 0;
+      break;
+
+    case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_STRUCT:
+    case NANOARROW_TYPE_MAP:
+    case NANOARROW_TYPE_SPARSE_UNION:
+      array->n_buffers = 1;
+      break;
+
+    case NANOARROW_TYPE_BOOL:
+    case NANOARROW_TYPE_UINT8:
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_UINT16:
+    case NANOARROW_TYPE_INT16:
+    case NANOARROW_TYPE_UINT32:
+    case NANOARROW_TYPE_INT32:
+    case NANOARROW_TYPE_UINT64:
+    case NANOARROW_TYPE_INT64:
+    case NANOARROW_TYPE_HALF_FLOAT:
+    case NANOARROW_TYPE_FLOAT:
+    case NANOARROW_TYPE_DOUBLE:
+    case NANOARROW_TYPE_INTERVAL_MONTHS:
+    case NANOARROW_TYPE_INTERVAL_DAY_TIME:
+    case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+    case NANOARROW_TYPE_DENSE_UNION:
+      array->n_buffers = 2;
+      break;
+
+    case NANOARROW_TYPE_STRING:
+    case NANOARROW_TYPE_LARGE_STRING:
+    case NANOARROW_TYPE_BINARY:
+    case NANOARROW_TYPE_LARGE_BINARY:
+      array->n_buffers = 3;
+      break;
+
+    default:
+      return EINVAL;
+  }
+
+  struct ArrowArrayPrivateData* data = (struct ArrowArrayPrivateData*)array->private_data;
+  data->storage_type = storage_type;
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, enum ArrowType storage_type) {
+  array->length = 0;
+  array->null_count = -1;
+  array->offset = 0;
+  array->n_buffers = 0;
+  array->n_children = 0;
+  array->buffers = NULL;
+  array->children = NULL;
+  array->dictionary = NULL;
+  array->release = &ArrowArrayRelease;
+  array->private_data = NULL;
+
+  struct ArrowArrayPrivateData* data =
+      (struct ArrowArrayPrivateData*)ArrowMalloc(sizeof(struct ArrowArrayPrivateData));
+  if (data == NULL) {
+    array->release = NULL;
+    return ENOMEM;
+  }
+
+  ArrowBufferInit(&data->bitmap);
+  ArrowBufferInit(&data->buffers[0]);
+  ArrowBufferInit(&data->buffers[1]);
+  data->buffer_data[0] = NULL;
+  data->buffer_data[1] = NULL;
+  data->buffer_data[2] = NULL;
+
+  array->private_data = data;
+  array->buffers = (const void**)(&data->buffer_data);
+
+  int result = ArrowArraySetStorageType(array, storage_type);
+  if (result != NANOARROW_OK) {
+    array->release(array);
+    return result;
+  }
+
+  return NANOARROW_OK;
+}

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -181,6 +181,7 @@ ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_ch
     array->children[i]->release = NULL;
   }
 
+  array->n_children = n_children;
   return NANOARROW_OK;
 }
 
@@ -206,7 +207,6 @@ ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
     case 0:
       ArrowBufferMove(buffer, &data->bitmap.buffer);
       data->buffer_data[i] = data->bitmap.buffer.data;
-      break;
     case 1:
     case 2:
       ArrowBufferMove(buffer, &data->buffers[i - 1]);

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -26,7 +26,7 @@ static void ArrowArrayRelease(struct ArrowArray* array) {
   // Release buffers held by this array
   struct ArrowArrayPrivateData* data = (struct ArrowArrayPrivateData*)array->private_data;
   if (data != NULL) {
-    ArrowBufferReset(&data->bitmap);
+    ArrowBitmapReset(&data->bitmap);
     ArrowBufferReset(&data->buffers[0]);
     ArrowBufferReset(&data->buffers[1]);
     ArrowFree(data);
@@ -135,7 +135,7 @@ ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, enum ArrowType storage_t
     return ENOMEM;
   }
 
-  ArrowBufferInit(&data->bitmap);
+  ArrowBitmapInit(&data->bitmap);
   ArrowBufferInit(&data->buffers[0]);
   ArrowBufferInit(&data->buffers[1]);
   data->buffer_data[0] = NULL;

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -74,6 +74,7 @@ ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
 
     case NANOARROW_TYPE_LIST:
     case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_FIXED_SIZE_LIST:
     case NANOARROW_TYPE_STRUCT:
     case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_SPARSE_UNION:

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -218,7 +218,7 @@ ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
       break;
     case 1:
     case 2:
-      ArrowBufferMove(buffer, data->buffers + i - 1);
+      ArrowBufferMove(buffer, &data->buffers[i - 1]);
       data->buffer_data[i] = data->buffers[i - 1].data;
       break;
     default:

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -80,3 +80,46 @@ TEST(ArrayTest, ArrayTestAllocateDictionary) {
 
   array.release(&array);
 }
+
+TEST(ArrayTest, ArrayTestSetBitmap) {
+  struct ArrowBitmap bitmap;
+  ArrowBitmapInit(&bitmap);
+  ArrowBitmapAppend(&bitmap, true, 9);
+
+  struct ArrowArray array;
+  ASSERT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ArrowArraySetValidityBitmap(&array, &bitmap);
+  EXPECT_EQ(bitmap.buffer.data, nullptr);
+  const uint8_t* bitmap_buffer = reinterpret_cast<const uint8_t*>(array.buffers[0]);
+  EXPECT_EQ(bitmap_buffer[0], 0xff);
+  EXPECT_EQ(bitmap_buffer[1], 0x01);
+
+  array.release(&array);
+}
+
+TEST(ArrayTest, ArrayTestSetBuffer) {
+  // the array ["a", null, "bc", null, "def", null, "ghij"]
+  uint8_t validity_bitmap[] = {0x05};
+  int32_t offsets[] = {0, 1, 1, 3, 3, 6, 6, 10, 10};
+  const char* data = "abcdefghij";
+
+  struct ArrowBuffer buffer0, buffer1, buffer2;
+  ArrowBufferInit(&buffer0);
+  ArrowBufferAppend(&buffer0, validity_bitmap, 1);
+  ArrowBufferInit(&buffer1);
+  ArrowBufferAppend(&buffer1, offsets, 9 * sizeof(int32_t));
+  ArrowBufferInit(&buffer2);
+  ArrowBufferAppend(&buffer2, data, strlen(data));
+
+  struct ArrowArray array;
+  ASSERT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
+  EXPECT_EQ(ArrowArraySetBuffer(&array, 0, &buffer0), NANOARROW_OK);
+  EXPECT_EQ(ArrowArraySetBuffer(&array, 1, &buffer1), NANOARROW_OK);
+  EXPECT_EQ(ArrowArraySetBuffer(&array, 2, &buffer2), NANOARROW_OK);
+
+  EXPECT_EQ(memcmp(array.buffers[0], validity_bitmap, 1), 0);
+  EXPECT_EQ(memcmp(array.buffers[1], offsets, 8 * sizeof(int32_t)), 0);
+  EXPECT_EQ(memcmp(array.buffers[2], data, 10), 0);
+
+  array.release(&array);
+}

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "allocator.c"
-#include "array.c"
-#include "error.c"
-#include "metadata.c"
-#include "schema.c"
-#include "schema_view.c"
+#include <gtest/gtest.h>
+
+#include "nanoarrow/nanoarrow.h"
+
+TEST(ArrayTest, ArrayTestBasic) {
+  struct ArrowArray array;
+  EXPECT_EQ(ArrowArrayInit(&array, nullptr), NANOARROW_OK);
+}

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -21,5 +21,24 @@
 
 TEST(ArrayTest, ArrayTestBasic) {
   struct ArrowArray array;
-  EXPECT_EQ(ArrowArrayInit(&array, nullptr), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
+  EXPECT_EQ(array.n_buffers, 0);
+  array.release(&array);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
+  EXPECT_EQ(array.n_buffers, 1);
+  array.release(&array);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  EXPECT_EQ(array.n_buffers, 2);
+  array.release(&array);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
+  EXPECT_EQ(array.n_buffers, 3);
+  array.release(&array);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
+  EXPECT_EQ(array.n_buffers, 0);
+  array.release(&array);
 }

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -37,6 +37,8 @@ TEST(ArrayTest, ArrayTestBasic) {
   EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(array.n_buffers, 3);
   array.release(&array);
+
+  EXPECT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_DATE64), EINVAL);
 }
 
 TEST(ArrayTest, ArrayTestAllocateChildren) {
@@ -120,6 +122,9 @@ TEST(ArrayTest, ArrayTestSetBuffer) {
   EXPECT_EQ(memcmp(array.buffers[0], validity_bitmap, 1), 0);
   EXPECT_EQ(memcmp(array.buffers[1], offsets, 8 * sizeof(int32_t)), 0);
   EXPECT_EQ(memcmp(array.buffers[2], data, 10), 0);
+
+  // try to set a buffer that isn't, 0, 1, or 2
+  EXPECT_EQ(ArrowArraySetBuffer(&array, 3, &buffer0), EINVAL);
 
   array.release(&array);
 }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -100,53 +100,6 @@ struct ArrowStringView {
   int64_t n_bytes;
 };
 
-/// \brief Arrow type enumerator
-///
-/// These names are intended to map to the corresponding arrow::Type::type
-/// enumerator; however, the numeric values are specifically not equal
-/// (i.e., do not rely on numeric comparison).
-enum ArrowType {
-  NANOARROW_TYPE_UNINITIALIZED = 0,
-  NANOARROW_TYPE_NA = 1,
-  NANOARROW_TYPE_BOOL,
-  NANOARROW_TYPE_UINT8,
-  NANOARROW_TYPE_INT8,
-  NANOARROW_TYPE_UINT16,
-  NANOARROW_TYPE_INT16,
-  NANOARROW_TYPE_UINT32,
-  NANOARROW_TYPE_INT32,
-  NANOARROW_TYPE_UINT64,
-  NANOARROW_TYPE_INT64,
-  NANOARROW_TYPE_HALF_FLOAT,
-  NANOARROW_TYPE_FLOAT,
-  NANOARROW_TYPE_DOUBLE,
-  NANOARROW_TYPE_STRING,
-  NANOARROW_TYPE_BINARY,
-  NANOARROW_TYPE_FIXED_SIZE_BINARY,
-  NANOARROW_TYPE_DATE32,
-  NANOARROW_TYPE_DATE64,
-  NANOARROW_TYPE_TIMESTAMP,
-  NANOARROW_TYPE_TIME32,
-  NANOARROW_TYPE_TIME64,
-  NANOARROW_TYPE_INTERVAL_MONTHS,
-  NANOARROW_TYPE_INTERVAL_DAY_TIME,
-  NANOARROW_TYPE_DECIMAL128,
-  NANOARROW_TYPE_DECIMAL256,
-  NANOARROW_TYPE_LIST,
-  NANOARROW_TYPE_STRUCT,
-  NANOARROW_TYPE_SPARSE_UNION,
-  NANOARROW_TYPE_DENSE_UNION,
-  NANOARROW_TYPE_DICTIONARY,
-  NANOARROW_TYPE_MAP,
-  NANOARROW_TYPE_EXTENSION,
-  NANOARROW_TYPE_FIXED_SIZE_LIST,
-  NANOARROW_TYPE_DURATION,
-  NANOARROW_TYPE_LARGE_STRING,
-  NANOARROW_TYPE_LARGE_BINARY,
-  NANOARROW_TYPE_LARGE_LIST,
-  NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO
-};
-
 /// \brief Arrow time unit enumerator
 ///
 /// These names and values map to the corresponding arrow::TimeUnit::type
@@ -505,21 +458,6 @@ static inline void ArrowBitmapReset(struct ArrowBitmap* bitmap);
 
 /// \defgroup nanoarrow-array Array producer helpers
 /// These functions allocate, copy, and destroy ArrowArray structures
-
-/// \brief A structure used as the private data member for ArrowArrays allocated here
-struct ArrowArrayPrivateData {
-  /// \brief A validity bitmap if needed (will be a struct ArrowBitmap after #10)
-  struct ArrowBuffer bitmap;
-
-  /// \brief Additional buffers as required
-  struct ArrowBuffer buffers[2];
-
-  /// \brief The array of pointers to data
-  const void* buffer_data[3];
-
-  /// \brief The storage data type, or NANOARROW_TYPE_UNINITIALIZED if unknown
-  enum ArrowType storage_type;
-};
 
 /// \brief Initialize the fields of an array
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -477,6 +477,11 @@ ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_ch
 /// array must have been allocated using ArrowArrayInit
 ArrowErrorCode ArrowArrayAllocateDictionary(struct ArrowArray* array);
 
+/// \brief Set the validity bitmap of an ArrowArray
+///
+/// array must have been allocated using ArrowArrayInit
+void ArrowArraySetValidityBitmap(struct ArrowArray* array, struct ArrowBitmap* bitmap);
+
 /// \brief Set a buffer of an ArrowArray
 ///
 /// array must have been allocated using ArrowArrayInit

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -466,6 +466,23 @@ static inline void ArrowBitmapReset(struct ArrowBitmap* bitmap);
 /// NANOARROW_OK is returned.
 ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, enum ArrowType storage_type);
 
+/// \brief Allocate the array->children array
+///
+/// Includes the memory for each child struct ArrowArray.
+/// schema must have been allocated using ArrowArrayInit.
+ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_children);
+
+/// \brief Allocate the array->dictionary member
+///
+/// array must have been allocated using ArrowArrayInit
+ArrowErrorCode ArrowArrayAllocateDictionary(struct ArrowArray* array);
+
+/// \brief Set a buffer of an ArrowArray
+///
+/// array must have been allocated using ArrowArrayInit
+ArrowErrorCode ArrowArraySetBuffer(struct ArrowArray* array, int64_t i,
+                                   struct ArrowBuffer* buffer);
+
 /// }@
 
 // Inline function definitions

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -503,6 +503,27 @@ static inline void ArrowBitmapReset(struct ArrowBitmap* bitmap);
 
 /// }@
 
+/// \defgroup nanoarrow-array Array producer helpers
+/// These functions allocate, copy, and destroy ArrowArray structures
+
+/// \brief A structure used as the private data member for ArrowArrays allocated here
+struct ArrowArrayPrivateData {
+  /// \brief A validity bitmap if needed (will be a struct ArrowBitmap after #10)
+  struct ArrowBuffer bitmap;
+
+  /// \brief Additional buffers as required
+  struct ArrowBuffer buffers[2];
+};
+
+/// \brief Initialize the fields of an array
+///
+/// Initializes the fields and release callback of array. Caller
+/// is responsible for calling the array->release callback if
+/// NANOARROW_OK is returned.
+ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, struct ArrowSchema* schema);
+
+/// }@
+
 // Inline function definitions
 #include "bitmap_inline.h"
 #include "buffer_inline.h"

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -468,12 +468,17 @@ ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, enum ArrowType storage_t
 
 /// \brief Allocate the array->children array
 ///
-/// Includes the memory for each child struct ArrowArray.
+/// Includes the memory for each child struct ArrowArray,
+/// whose members are marked as released and may be subsequently initialized
+/// with ArrowArrayInit or moved from an existing ArrowArray.
 /// schema must have been allocated using ArrowArrayInit.
 ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_children);
 
 /// \brief Allocate the array->dictionary member
 ///
+/// Includes the memory for the struct ArrowArray, whose contents
+/// is marked as released and may be subsequently initialized
+/// with ArrowArrayInit or moved from an existing ArrowArray.
 /// array must have been allocated using ArrowArrayInit
 ArrowErrorCode ArrowArrayAllocateDictionary(struct ArrowArray* array);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -513,6 +513,12 @@ struct ArrowArrayPrivateData {
 
   /// \brief Additional buffers as required
   struct ArrowBuffer buffers[2];
+
+  /// \brief The array of pointers to data
+  const void* buffer_data[3];
+
+  /// \brief The storage data type, or NANOARROW_TYPE_UNINITIALIZED if unknown
+  enum ArrowType storage_type;
 };
 
 /// \brief Initialize the fields of an array
@@ -520,7 +526,7 @@ struct ArrowArrayPrivateData {
 /// Initializes the fields and release callback of array. Caller
 /// is responsible for calling the array->release callback if
 /// NANOARROW_OK is returned.
-ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, struct ArrowSchema* schema);
+ArrowErrorCode ArrowArrayInit(struct ArrowArray* array, enum ArrowType storage_type);
 
 /// }@
 

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -119,6 +119,53 @@ struct ArrowArrayStream {
 /// \brief Represents an errno-compatible error code
 typedef int ArrowErrorCode;
 
+/// \brief Arrow type enumerator
+///
+/// These names are intended to map to the corresponding arrow::Type::type
+/// enumerator; however, the numeric values are specifically not equal
+/// (i.e., do not rely on numeric comparison).
+enum ArrowType {
+  NANOARROW_TYPE_UNINITIALIZED = 0,
+  NANOARROW_TYPE_NA = 1,
+  NANOARROW_TYPE_BOOL,
+  NANOARROW_TYPE_UINT8,
+  NANOARROW_TYPE_INT8,
+  NANOARROW_TYPE_UINT16,
+  NANOARROW_TYPE_INT16,
+  NANOARROW_TYPE_UINT32,
+  NANOARROW_TYPE_INT32,
+  NANOARROW_TYPE_UINT64,
+  NANOARROW_TYPE_INT64,
+  NANOARROW_TYPE_HALF_FLOAT,
+  NANOARROW_TYPE_FLOAT,
+  NANOARROW_TYPE_DOUBLE,
+  NANOARROW_TYPE_STRING,
+  NANOARROW_TYPE_BINARY,
+  NANOARROW_TYPE_FIXED_SIZE_BINARY,
+  NANOARROW_TYPE_DATE32,
+  NANOARROW_TYPE_DATE64,
+  NANOARROW_TYPE_TIMESTAMP,
+  NANOARROW_TYPE_TIME32,
+  NANOARROW_TYPE_TIME64,
+  NANOARROW_TYPE_INTERVAL_MONTHS,
+  NANOARROW_TYPE_INTERVAL_DAY_TIME,
+  NANOARROW_TYPE_DECIMAL128,
+  NANOARROW_TYPE_DECIMAL256,
+  NANOARROW_TYPE_LIST,
+  NANOARROW_TYPE_STRUCT,
+  NANOARROW_TYPE_SPARSE_UNION,
+  NANOARROW_TYPE_DENSE_UNION,
+  NANOARROW_TYPE_DICTIONARY,
+  NANOARROW_TYPE_MAP,
+  NANOARROW_TYPE_EXTENSION,
+  NANOARROW_TYPE_FIXED_SIZE_LIST,
+  NANOARROW_TYPE_DURATION,
+  NANOARROW_TYPE_LARGE_STRING,
+  NANOARROW_TYPE_LARGE_BINARY,
+  NANOARROW_TYPE_LARGE_LIST,
+  NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO
+};
+
 /// \brief Array buffer allocation and deallocation
 ///
 /// Container for allocate, reallocate, and free methods that can be used
@@ -163,6 +210,20 @@ struct ArrowBitmap {
 
   /// \brief The number of bits that have been appended to the bitmap
   int64_t size_bits;
+};
+
+/// \brief A structure used as the private data member for ArrowArrays allocated here
+struct ArrowArrayPrivateData {
+  struct ArrowBitmap bitmap;
+
+  /// \brief Additional buffers as required
+  struct ArrowBuffer buffers[2];
+
+  /// \brief The array of pointers to data
+  const void* buffer_data[3];
+
+  /// \brief The storage data type, or NANOARROW_TYPE_UNINITIALIZED if unknown
+  enum ArrowType storage_type;
 };
 
 /// }@

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -212,17 +212,22 @@ struct ArrowBitmap {
   int64_t size_bits;
 };
 
-/// \brief A structure used as the private data member for ArrowArrays allocated here
+// Used as the private data member for ArrowArrays allocated here and accessed
+// internally within inline ArrowArray* helpers.
 struct ArrowArrayPrivateData {
+  // Holder for the validity buffer (or first buffer for union types, which are
+  // the only type whose first buffer is not a valdiity buffer)
   struct ArrowBitmap bitmap;
 
-  /// \brief Additional buffers as required
+  // Holder for additional buffers as required
   struct ArrowBuffer buffers[2];
 
-  /// \brief The array of pointers to data
+  // The array of pointers to buffers. This must be updated after a sequence
+  // of appends to synchronize its values with the actual buffer addresses
+  // (which may have ben reallocated uring that time)
   const void* buffer_data[3];
 
-  /// \brief The storage data type, or NANOARROW_TYPE_UNINITIALIZED if unknown
+  // The storage data type, or NANOARROW_TYPE_UNINITIALIZED if unknown
   enum ArrowType storage_type;
 };
 


### PR DESCRIPTION
Fixes #5 by implementing an Array whose buffer lifecycle is handled by `struct ArrowBuffer`.