### PR TITLE
Pass the ArrowBufferAllocator by value and implement a custom deallocator

### DIFF
--- a/src/nanoarrow/allocator.c
+++ b/src/nanoarrow/allocator.c
@@ -49,3 +49,26 @@ static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
 struct ArrowBufferAllocator ArrowBufferAllocatorDefault() {
   return ArrowBufferAllocatorMalloc;
 }
+
+static uint8_t* ArrowBufferAllocatorNeverAllocate(struct ArrowBufferAllocator* allocator,
+                                                  int64_t size) {
+  return NULL;
+}
+
+static uint8_t* ArrowBufferAllocatorNeverReallocate(
+    struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
+    int64_t new_size) {
+  return NULL;
+}
+
+struct ArrowBufferAllocator ArrowBufferDeallocator(
+    void (*custom_free)(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                        int64_t size),
+    void* private_data) {
+  struct ArrowBufferAllocator allocator;
+  allocator.allocate = &ArrowBufferAllocatorNeverAllocate;
+  allocator.reallocate = &ArrowBufferAllocatorNeverReallocate;
+  allocator.free = custom_free;
+  allocator.private_data = private_data;
+  return allocator;
+}

--- a/src/nanoarrow/allocator.c
+++ b/src/nanoarrow/allocator.c
@@ -46,6 +46,6 @@ static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
     &ArrowBufferAllocatorMallocAllocate, &ArrowBufferAllocatorMallocReallocate,
     &ArrowBufferAllocatorMallocFree, NULL};
 
-struct ArrowBufferAllocator* ArrowBufferAllocatorDefault() {
-  return &ArrowBufferAllocatorMalloc;
+struct ArrowBufferAllocator ArrowBufferAllocatorDefault() {
+  return ArrowBufferAllocatorMalloc;
 }

--- a/src/nanoarrow/allocator.c
+++ b/src/nanoarrow/allocator.c
@@ -43,8 +43,7 @@ static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocato
 }
 
 static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
-    &ArrowBufferAllocatorMallocAllocate, &ArrowBufferAllocatorMallocReallocate,
-    &ArrowBufferAllocatorMallocFree, NULL};
+    &ArrowBufferAllocatorMallocReallocate, &ArrowBufferAllocatorMallocFree, NULL};
 
 struct ArrowBufferAllocator ArrowBufferAllocatorDefault() {
   return ArrowBufferAllocatorMalloc;
@@ -66,7 +65,6 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
                         int64_t size),
     void* private_data) {
   struct ArrowBufferAllocator allocator;
-  allocator.allocate = &ArrowBufferAllocatorNeverAllocate;
   allocator.reallocate = &ArrowBufferAllocatorNeverReallocate;
   allocator.free = custom_free;
   allocator.private_data = private_data;

--- a/src/nanoarrow/allocator_test.cc
+++ b/src/nanoarrow/allocator_test.cc
@@ -25,16 +25,6 @@
 
 using namespace arrow;
 
-static uint8_t* MemoryPoolAllocate(struct ArrowBufferAllocator* allocator, int64_t size) {
-  MemoryPool* pool = reinterpret_cast<MemoryPool*>(allocator->private_data);
-  uint8_t* out;
-  if (pool->Allocate(size, &out).ok()) {
-    return out;
-  } else {
-    return nullptr;
-  }
-}
-
 static uint8_t* MemoryPoolReallocate(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                                      int64_t old_size, int64_t new_size) {
   MemoryPool* pool = reinterpret_cast<MemoryPool*>(allocator->private_data);
@@ -54,7 +44,6 @@ static void MemoryPoolFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
 
 static void MemoryPoolAllocatorInit(MemoryPool* pool,
                                     struct ArrowBufferAllocator* allocator) {
-  allocator->allocate = &MemoryPoolAllocate;
   allocator->reallocate = &MemoryPoolReallocate;
   allocator->free = &MemoryPoolFree;
   allocator->private_data = pool;
@@ -63,7 +52,7 @@ static void MemoryPoolAllocatorInit(MemoryPool* pool,
 TEST(AllocatorTest, AllocatorTestDefault) {
   struct ArrowBufferAllocator allocator = ArrowBufferAllocatorDefault();
 
-  uint8_t* buffer = allocator.allocate(&allocator, 10);
+  uint8_t* buffer = allocator.reallocate(&allocator, nullptr, 0, 10);
   const char* test_str = "abcdefg";
   memcpy(buffer, test_str, strlen(test_str) + 1);
 
@@ -72,7 +61,8 @@ TEST(AllocatorTest, AllocatorTestDefault) {
 
   allocator.free(&allocator, buffer, 100);
 
-  buffer = allocator.allocate(&allocator, std::numeric_limits<int64_t>::max());
+  buffer =
+      allocator.reallocate(&allocator, nullptr, 0, std::numeric_limits<int64_t>::max());
   EXPECT_EQ(buffer, nullptr);
 
   buffer =
@@ -99,7 +89,7 @@ TEST(AllocatorTest, AllocatorTestDeallocator) {
 
   struct ArrowBufferAllocator deallocator = ArrowBufferDeallocator(&CustomFree, &data);
 
-  EXPECT_EQ(deallocator.allocate(&deallocator, 12), nullptr);
+  EXPECT_EQ(deallocator.reallocate(&deallocator, nullptr, 0, 12), nullptr);
   EXPECT_EQ(deallocator.reallocate(&deallocator, nullptr, 0, 12), nullptr);
   deallocator.free(&deallocator, nullptr, 12);
   EXPECT_EQ(data.pointer_proxy, nullptr);
@@ -111,7 +101,7 @@ TEST(AllocatorTest, AllocatorTestMemoryPool) {
 
   int64_t allocated0 = system_memory_pool()->bytes_allocated();
 
-  uint8_t* buffer = arrow_allocator.allocate(&arrow_allocator, 10);
+  uint8_t* buffer = arrow_allocator.reallocate(&arrow_allocator, nullptr, 0, 10);
   EXPECT_EQ(system_memory_pool()->bytes_allocated() - allocated0, 10);
   memset(buffer, 0, 10);
 
@@ -125,8 +115,8 @@ TEST(AllocatorTest, AllocatorTestMemoryPool) {
   arrow_allocator.free(&arrow_allocator, buffer, 100);
   EXPECT_EQ(system_memory_pool()->bytes_allocated(), allocated0);
 
-  buffer =
-      arrow_allocator.allocate(&arrow_allocator, std::numeric_limits<int64_t>::max());
+  buffer = arrow_allocator.reallocate(&arrow_allocator, nullptr, 0,
+                                      std::numeric_limits<int64_t>::max());
   EXPECT_EQ(buffer, nullptr);
 
   buffer = arrow_allocator.reallocate(&arrow_allocator, buffer, 0,

--- a/src/nanoarrow/allocator_test.cc
+++ b/src/nanoarrow/allocator_test.cc
@@ -61,22 +61,22 @@ static void MemoryPoolAllocatorInit(MemoryPool* pool,
 }
 
 TEST(AllocatorTest, AllocatorTestDefault) {
-  struct ArrowBufferAllocator* allocator = ArrowBufferAllocatorDefault();
+  struct ArrowBufferAllocator allocator = ArrowBufferAllocatorDefault();
 
-  uint8_t* buffer = allocator->allocate(allocator, 10);
+  uint8_t* buffer = allocator.allocate(&allocator, 10);
   const char* test_str = "abcdefg";
   memcpy(buffer, test_str, strlen(test_str) + 1);
 
-  buffer = allocator->reallocate(allocator, buffer, 10, 100);
+  buffer = allocator.reallocate(&allocator, buffer, 10, 100);
   EXPECT_STREQ(reinterpret_cast<const char*>(buffer), test_str);
 
-  allocator->free(allocator, buffer, 100);
+  allocator.free(&allocator, buffer, 100);
 
-  buffer = allocator->allocate(allocator, std::numeric_limits<int64_t>::max());
+  buffer = allocator.allocate(&allocator, std::numeric_limits<int64_t>::max());
   EXPECT_EQ(buffer, nullptr);
 
   buffer =
-      allocator->reallocate(allocator, buffer, 0, std::numeric_limits<int64_t>::max());
+      allocator.reallocate(&allocator, buffer, 0, std::numeric_limits<int64_t>::max());
   EXPECT_EQ(buffer, nullptr);
 }
 

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -45,7 +45,7 @@ static inline void ArrowBufferInit(struct ArrowBuffer* buffer) {
 }
 
 static inline ArrowErrorCode ArrowBufferSetAllocator(
-    struct ArrowBuffer* buffer, struct ArrowBufferAllocator* allocator) {
+    struct ArrowBuffer* buffer, struct ArrowBufferAllocator allocator) {
   if (buffer->data == NULL) {
     buffer->allocator = allocator;
     return NANOARROW_OK;
@@ -56,8 +56,8 @@ static inline ArrowErrorCode ArrowBufferSetAllocator(
 
 static inline void ArrowBufferReset(struct ArrowBuffer* buffer) {
   if (buffer->data != NULL) {
-    buffer->allocator->free(buffer->allocator, (uint8_t*)buffer->data,
-                            buffer->capacity_bytes);
+    buffer->allocator.free(&buffer->allocator, (uint8_t*)buffer->data,
+                           buffer->capacity_bytes);
     buffer->data = NULL;
   }
 
@@ -80,8 +80,8 @@ static inline ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer,
   }
 
   if (new_capacity_bytes > buffer->capacity_bytes || shrink_to_fit) {
-    buffer->data = buffer->allocator->reallocate(
-        buffer->allocator, buffer->data, buffer->capacity_bytes, new_capacity_bytes);
+    buffer->data = buffer->allocator.reallocate(
+        &buffer->allocator, buffer->data, buffer->capacity_bytes, new_capacity_bytes);
     if (buffer->data == NULL && new_capacity_bytes > 0) {
       buffer->capacity_bytes = 0;
       buffer->size_bytes = 0;

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -26,15 +26,10 @@
 // This test allocator guarantees that allocator->reallocate will return
 // a new pointer so that we can test when reallocations happen whilst
 // building buffers.
-static uint8_t* TestAllocatorAllocate(struct ArrowBufferAllocator* allocator,
-                                      int64_t size) {
-  return reinterpret_cast<uint8_t*>(malloc(size));
-}
-
 static uint8_t* TestAllocatorReallocate(struct ArrowBufferAllocator* allocator,
                                         uint8_t* ptr, int64_t old_size,
                                         int64_t new_size) {
-  uint8_t* new_ptr = TestAllocatorAllocate(allocator, new_size);
+  uint8_t* new_ptr = reinterpret_cast<uint8_t*>(malloc(new_size));
 
   int64_t copy_size = std::min<int64_t>(old_size, new_size);
   if (new_ptr != nullptr && copy_size > 0) {
@@ -53,8 +48,8 @@ static void TestAllocatorFree(struct ArrowBufferAllocator* allocator, uint8_t* p
   free(ptr);
 }
 
-static struct ArrowBufferAllocator test_allocator = {
-    &TestAllocatorAllocate, &TestAllocatorReallocate, &TestAllocatorFree, nullptr};
+static struct ArrowBufferAllocator test_allocator = {&TestAllocatorReallocate,
+                                                     &TestAllocatorFree, nullptr};
 
 TEST(BufferTest, BufferTestBasic) {
   struct ArrowBuffer buffer;

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -61,7 +61,7 @@ TEST(BufferTest, BufferTestBasic) {
 
   // Init
   ArrowBufferInit(&buffer);
-  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, test_allocator), NANOARROW_OK);
   EXPECT_EQ(buffer.data, nullptr);
   EXPECT_EQ(buffer.capacity_bytes, 0);
   EXPECT_EQ(buffer.size_bytes, 0);
@@ -109,7 +109,7 @@ TEST(BufferTest, BufferTestMove) {
   struct ArrowBuffer buffer;
 
   ArrowBufferInit(&buffer);
-  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, test_allocator), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppend(&buffer, "1234567", 7), NANOARROW_OK);
   EXPECT_EQ(buffer.size_bytes, 7);
   EXPECT_EQ(buffer.capacity_bytes, 7);
@@ -152,7 +152,7 @@ TEST(BufferTest, BufferTestResize0) {
   struct ArrowBuffer buffer;
 
   ArrowBufferInit(&buffer);
-  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, &test_allocator), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferSetAllocator(&buffer, test_allocator), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppend(&buffer, "1234567", 7), NANOARROW_OK);
   EXPECT_EQ(buffer.size_bytes, 7);
   EXPECT_EQ(buffer.capacity_bytes, 7);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -63,8 +63,15 @@ void ArrowFree(void* ptr);
 /// ArrowFree().
 struct ArrowBufferAllocator ArrowBufferAllocatorDefault();
 
+/// \brief Create a custom deallocator
+///
+/// Creates a buffer allocator with only a free method that can be used to
+/// attach a custom deallocator to an ArrowBuffer. This may be used to
+/// avoid copying an existing buffer that was not allocated using the
+/// infrastructure provided here (e.g., by an R or Python object).
 struct ArrowBufferAllocator ArrowBufferDeallocator(
-    void (*free)(struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t size),
+    void (*custom_free)(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
+                        int64_t size),
     void* private_data);
 
 /// }@

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -63,6 +63,10 @@ void ArrowFree(void* ptr);
 /// ArrowFree().
 struct ArrowBufferAllocator ArrowBufferAllocatorDefault();
 
+struct ArrowBufferAllocator ArrowBufferDeallocator(
+    void (*free)(struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t size),
+    void* private_data);
+
 /// }@
 
 /// \defgroup nanoarrow-errors Error handling primitives

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -61,7 +61,7 @@ void ArrowFree(void* ptr);
 ///
 /// The default allocator uses ArrowMalloc(), ArrowRealloc(), and
 /// ArrowFree().
-struct ArrowBufferAllocator* ArrowBufferAllocatorDefault();
+struct ArrowBufferAllocator ArrowBufferAllocatorDefault();
 
 /// }@
 
@@ -358,7 +358,7 @@ static inline void ArrowBufferInit(struct ArrowBuffer* buffer);
 ///
 /// Returns EINVAL if the buffer has already been allocated.
 static inline ArrowErrorCode ArrowBufferSetAllocator(
-    struct ArrowBuffer* buffer, struct ArrowBufferAllocator* allocator);
+    struct ArrowBuffer* buffer, struct ArrowBufferAllocator allocator);
 
 /// \brief Reset an ArrowBuffer
 ///
@@ -688,8 +688,7 @@ void ArrowArrayViewSetLength(struct ArrowArrayView* array_view, int64_t length);
 
 /// \brief Set buffer sizes and data pointers from an ArrowArray
 ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
-                                      struct ArrowArray* array,
-                                      struct ArrowError* error);
+                                      struct ArrowArray* array, struct ArrowError* error);
 
 /// \brief Reset the contents of an ArrowArrayView and frees resources
 void ArrowArrayViewReset(struct ArrowArrayView* array_view);

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -261,7 +261,7 @@ struct ArrowBuffer {
   int64_t capacity_bytes;
 
   /// \brief The allocator that will be used to reallocate and/or free the buffer
-  struct ArrowBufferAllocator* allocator;
+  struct ArrowBufferAllocator allocator;
 };
 
 /// \brief An owning mutable view of a bitmap

--- a/src/nanoarrow/typedefs_inline.h
+++ b/src/nanoarrow/typedefs_inline.h
@@ -233,9 +233,6 @@ struct ArrowBufferView {
 /// to customize allocation and deallocation of buffers when constructing
 /// an ArrowArray.
 struct ArrowBufferAllocator {
-  /// \brief Allocate a buffer or return NULL if it cannot be allocated
-  uint8_t* (*allocate)(struct ArrowBufferAllocator* allocator, int64_t size);
-
   /// \brief Reallocate a buffer or return NULL if it cannot be reallocated
   uint8_t* (*reallocate)(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                          int64_t old_size, int64_t new_size);


### PR DESCRIPTION
This feature will allow R/Python runtimes to use the built-in `ArrowArrayInit()`/`ArrowArraySetBuffer()` infrastructure rather than roll their own (e.g., an R package could set a custom deallocator that calls `R_ReleaseObject()` on whatever object was protecting the buffer from garbage collection). Clients that are also using Arrow C++ could use this to with a shared pointer to a Buffer to avoid a copy as well.