### PR TITLE
Add missing include in amalgamated build

### DIFF
--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -19,6 +19,7 @@
 #define NANOARROW_NANOARROW_TYPES_H_INCLUDED
 
 #include <stdint.h>
+#include <string.h>
 
 #include "build_id.h"
 


### PR DESCRIPTION
This is used in ArrowCharView but the include isn't there.