### PR TITLE
Add example usage to examples/ directory

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           cd examples/cmake-minimal
           mkdir build && cd build
-          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.action_repository }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
+          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.repository }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
           cmake --build .
           ./example_cmake_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           cd examples/cmake-minimal
           mkdir build && cd build
-          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.event.pull_request.head.sha }}
+          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.event.pull_request.head.ref }}
           cmake --build .
           ./example_cmake_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           cd examples/cmake-minimal
           mkdir build && cd build
-          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
+          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.event.pull_request.head.sha }}
           cmake --build .
           ./example_cmake_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -46,4 +46,10 @@ jobs:
           mkdir build && cd build
           cmake ..
           cmake --build .
-          ./example_cmake_minimal_app
+          
+          ./example_cmake_minimal_app 8 2 4 9
+          #> Parsed array with length 4
+          ./example_cmake_minimal_app asd
+          #> Can't parse argument 1 ('asd') to long int
+          ./example_cmake_minimal_app 999999999999999
+          #> Error appending argument 1 ('999999999999999') to array

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           cd examples/cmake-minimal
           mkdir build && cd build
-          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.event.pull_request.head.ref }}
+          cmake ..
           cmake --build .
           ./example_cmake_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -44,6 +44,6 @@ jobs:
         run: |
           cd examples/cmake-minimal
           mkdir build && cd build
-          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.repository }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
+          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
           cmake --build .
           ./example_cmake_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -53,3 +53,24 @@ jobs:
           #> Can't parse argument 1 ('asd') to long int
           ./example_cmake_minimal_app 999999999999999 || true
           #> Error appending argument 1 ('999999999999999') to array
+    
+      - name: Minimal Vendored Example
+        run: |
+          cd examples/cmake-vendored
+          mkdir build && cd build
+          cmake ../../.. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=ExampleVendored
+          cmake --build .
+          cmake --install . --prefix=../src
+
+          cd ../src
+
+          gcc -c library.c nanoarrow.c
+          ar rcs libexample_vendored_minimal_library.a library.o nanoarrow.o
+          gcc -o example_vendored_minimal_app app.c libexample_vendored_minimal_library.a
+          
+          ./example_vendored_minimal_app 8 2 4 9
+          #> Parsed array with length 4
+          ./example_vendored_minimal_app asd || true
+          #> Can't parse argument 1 ('asd') to long int
+          ./example_vendored_minimal_app 999999999999999 || true
+          #> Error appending argument 1 ('999999999999999') to array

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -49,7 +49,7 @@ jobs:
           
           ./example_cmake_minimal_app 8 2 4 9
           #> Parsed array with length 4
-          ./example_cmake_minimal_app asd
+          ./example_cmake_minimal_app asd || true
           #> Can't parse argument 1 ('asd') to long int
-          ./example_cmake_minimal_app 999999999999999
+          ./example_cmake_minimal_app 999999999999999 || true
           #> Error appending argument 1 ('999999999999999') to array

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -56,7 +56,7 @@ jobs:
     
       - name: Minimal Vendored Example
         run: |
-          cd examples/cmake-vendored
+          cd examples/vendored-minimal
           mkdir build && cd build
           cmake ../../.. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=ExampleVendored
           cmake --build .

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -47,12 +47,7 @@ jobs:
           cmake ..
           cmake --build .
           
-          ./example_cmake_minimal_app 8 2 4 9
-          #> Parsed array with length 4
-          ./example_cmake_minimal_app asd || true
-          #> Can't parse argument 1 ('asd') to long int
-          ./example_cmake_minimal_app 999999999999999 || true
-          #> Error appending argument 1 ('999999999999999') to array
+          ./example_cmake_minimal_app
     
       - name: Minimal Vendored Example
         run: |
@@ -68,9 +63,4 @@ jobs:
           ar rcs libexample_vendored_minimal_library.a library.o nanoarrow.o
           gcc -o example_vendored_minimal_app app.c libexample_vendored_minimal_library.a
           
-          ./example_vendored_minimal_app 8 2 4 9
-          #> Parsed array with length 4
-          ./example_vendored_minimal_app asd || true
-          #> Can't parse argument 1 ('asd') to long int
-          ./example_vendored_minimal_app 999999999999999 || true
-          #> Error appending argument 1 ('999999999999999') to array
+          ./example_vendored_minimal_app

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Build and run examples
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  examples:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y cmake
+
+      - name: Minimal CMake Example
+        run: |
+          cd examples/cmake-minimal
+          mkdir build && cd build
+          cmake .. -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO=https://github.com/${{ github.action_repository }}.git -DEXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG=${{ github.sha }}
+          cmake --build .
+          ./example_cmake_minimal_app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,13 +79,16 @@ if(NANOARROW_BUNDLE)
     # Install the amalgamated header and source
     install(FILES ${NANOARROW_H_TEMP} ${NANOARROW_C_TEMP} DESTINATION ".")
 else()
-    include_directories(src)
-    include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
     add_library(
         nanoarrow
         src/nanoarrow/array.c
         src/nanoarrow/schema.c
         src/nanoarrow/utils.c)
+
+    target_include_directories(nanoarrow PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:include>)
+    target_include_directories(nanoarrow PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>)
 
     install(TARGETS nanoarrow DESTINATION lib)
     install(DIRECTORY src/ DESTINATION include FILES_MATCHING PATTERN "*.h")

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -24,7 +24,9 @@ project(NanoArrowExampleCMakeMinimal)
 # When adding nanoarrow's CMake directory to a CMake project that contains a library
 # intended for use by others, set NANOARROW_NAMESPACE to rename symbols in the
 # nanoarrow library such that they do not collide with other libraries that may also
-# link to their own copy of nanoarrow.
+# link to their own copy of nanoarrow. You may wish to include the namespace only
+# on release builds, since the namespace implementation obscures inline help
+# available in many text editors.
 set(NANOARROW_NAMESPACE "ExampleCmakeMinimal")
 
 FetchContent_Declare(

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
   GIT_REPOSITORY ${EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO}
-  GIT_TAG examples-2
+  GIT_TAG ${EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG}
   GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -21,19 +21,33 @@ include(FetchContent)
 
 project(NanoArrowExampleCMakeMinimal)
 
+# When adding nanoarrow's CMake directory to a CMake project that contains a library
+# intended for use by others, set NANOARROW_NAMESPACE to rename symbols in the
+# nanoarrow library such that they do not collide with other libraries that may also
+# link to nanoarrow.
+set(NANOARROW_NAMESPACE "NanoArrowExampleCmakeMinimal")
+
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
+
+  # We use SOURCE_DIR here to point to the version of nanoarrow represented
+  # by this checkout of the repo; however, you can use any of the methods
+  # supported by FetchContent_Declare, e.g.:
+  # GIT_REPOSITORY https://github.com/apache/arrow-nanoarrow.git
+  # GIT_TAG some_commit_hash
+  # GIT_SHALLOW TRUE
   SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 
 FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)
 
+# Add the library and link it against nanoarrow
 include_directories(src)
+add_library(example_cmake_minimal_library src/library.c)
 
-add_library(
-    example_cmake_minimal_library
-    src/library.c)
-
+# Always use PRIVATE when linking to nanoarrow to hide nanoarrow's headers from a
+# library that in turn uses your library.
 target_link_libraries(example_cmake_minimal_library PRIVATE nanoarrow)
 
+# Add the executable and link it against the library
 add_executable(example_cmake_minimal_app src/app.c)
 target_link_libraries(example_cmake_minimal_app example_cmake_minimal_library)

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -23,17 +23,19 @@ project(NanoArrowExampleCMakeMinimal)
 
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
-  GIT_REPOSITORY https://github.com/apache/arrow-nanoarrow.git
-  GIT_TAG main
+  GIT_REPOSITORY https://github.com/paleolimbot/arrow-nanoarrow.git
+  GIT_TAG examples-2
   GIT_SHALLOW TRUE)
 
 FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)
 
 include_directories(src)
-include_directories(${NANOARROW_INCLUDE_DIR})
 
 add_library(
     example_cmake_minimal_library
     src/library.c)
 
 target_link_libraries(example_cmake_minimal_library PRIVATE nanoarrow)
+
+add_executable(example_cmake_minimal_app src/app.c)
+target_link_libraries(example_cmake_minimal_app example_cmake_minimal_library)

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
+cmake_minimum_required(VERSION 3.11)
+include(FetchContent)
+
+project(NanoArrowExampleCMakeMinimal)
+
+FetchContent_Declare(
+  nanoarrow_example_cmake_minimal
+  GIT_REPOSITORY https://github.com/apache/arrow-nanoarrow.git
+  GIT_TAG main
+  GIT_SHALLOW TRUE)
+
+FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)
+
+include_directories(src)
+include_directories(${NANOARROW_INCLUDE_DIR})
+
+add_library(
+    example_cmake_minimal_library
+    src/library.c)
+
+target_link_libraries(example_cmake_minimal_library PRIVATE nanoarrow)

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -24,8 +24,8 @@ project(NanoArrowExampleCMakeMinimal)
 # When adding nanoarrow's CMake directory to a CMake project that contains a library
 # intended for use by others, set NANOARROW_NAMESPACE to rename symbols in the
 # nanoarrow library such that they do not collide with other libraries that may also
-# link to nanoarrow.
-set(NANOARROW_NAMESPACE "NanoArrowExampleCmakeMinimal")
+# link to their own copy of nanoarrow.
+set(NANOARROW_NAMESPACE "ExampleCmakeMinimal")
 
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
@@ -45,7 +45,7 @@ include_directories(src)
 add_library(example_cmake_minimal_library src/library.c)
 
 # Always use PRIVATE when linking to nanoarrow to hide nanoarrow's headers from a
-# library that in turn uses your library.
+# target that in turn uses your library.
 target_link_libraries(example_cmake_minimal_library PRIVATE nanoarrow)
 
 # Add the executable and link it against the library

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -21,23 +21,9 @@ include(FetchContent)
 
 project(NanoArrowExampleCMakeMinimal)
 
-option(EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO
-  "Repo from which nanoarrow should be fetched")
-if (EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO)
-  set(EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO "https://github.com/apache/arrow-nanoarrow.git")
-endif()
-
-option(EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG
-  "A reference or commit sha1 used to pin the version of nanoarrow")
-  if (EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG)
-  set(EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG "main")
-endif()
-
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
-  GIT_REPOSITORY ${EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO}
-  GIT_TAG ${EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG}
-  GIT_SHALLOW TRUE)
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 
 FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)
 

--- a/examples/cmake-minimal/CMakeLists.txt
+++ b/examples/cmake-minimal/CMakeLists.txt
@@ -21,9 +21,21 @@ include(FetchContent)
 
 project(NanoArrowExampleCMakeMinimal)
 
+option(EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO
+  "Repo from which nanoarrow should be fetched")
+if (EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO)
+  set(EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO "https://github.com/apache/arrow-nanoarrow.git")
+endif()
+
+option(EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG
+  "A reference or commit sha1 used to pin the version of nanoarrow")
+  if (EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG)
+  set(EXAMPLE_MINIMAL_CMAKE_NANOARROW_TAG "main")
+endif()
+
 FetchContent_Declare(
   nanoarrow_example_cmake_minimal
-  GIT_REPOSITORY https://github.com/paleolimbot/arrow-nanoarrow.git
+  GIT_REPOSITORY ${EXAMPLE_MINIMAL_CMAKE_NANOARROW_REPO}
   GIT_TAG examples-2
   GIT_SHALLOW TRUE)
 

--- a/examples/cmake-minimal/README.md
+++ b/examples/cmake-minimal/README.md
@@ -47,10 +47,8 @@ parses command line arguments into an int32 array and prints out the
 resulting length (or any error encountered whilst building the array).
 
 ```bash
-./example_cmake_minimal_app 8 2 4 9
-#> Parsed array with length 4
-./example_cmake_minimal_app asd
-#> Can't parse argument 1 ('asd') to long int
-./example_cmake_minimal_app 999999999999999
-#> Error appending argument 1 ('999999999999999') to array
+./example_cmake_minimal_app
+# 1
+# 2
+# 3
 ```

--- a/examples/cmake-minimal/README.md
+++ b/examples/cmake-minimal/README.md
@@ -1,0 +1,38 @@
+
+# Minimal CMake Example
+
+This folder contains a CMake project that links to its own copy of
+nanoarrow using CMake's `FetchContent` module. Whether vendoring or
+using CMake, nanoarrow is intended to be vendored or statically
+linked in a way that does not expose its headers or symbols to other
+projects. To illustrate this, a small library is included (library.h
+and library.c) and built in this way, linked to by a program (app.c)
+that does not use nanoarrow (but does make use of the Arrow C Data
+interface header, since this is ABI stable and intended to be used
+in this way).
+
+To build the project:
+
+```bash
+git clone https://github.com/apache/arrow-nanoarrow.git
+cd arrow-nanoarrow/examples/cmake-minimal
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+You can also open the cmake-minimal folder in VSCode and configure/build
+the project using VSCode's CMake integration.
+
+After building, you can run the app from the build directory. The app
+parses command line arguments into an int32 array and prints out the
+resulting length (or any error encountered whilst building the array).
+
+```bash
+./example_cmake_minimal_app 8 2 4 9
+#> Parsed array with length 4
+./example_cmake_minimal_app asd
+#> Can't parse argument 1 ('asd') to long int
+./example_cmake_minimal_app 999999999999999
+#> Error appending argument 1 ('999999999999999') to array
+```

--- a/examples/cmake-minimal/README.md
+++ b/examples/cmake-minimal/README.md
@@ -1,3 +1,21 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 
 # Minimal CMake Example
 

--- a/examples/cmake-minimal/src/app.c
+++ b/examples/cmake-minimal/src/app.c
@@ -20,6 +20,10 @@
 #include <stdio.h>
 
 int main(int argc, char* argv[]) {
-  printf("The nanoarrow build ID is '%s'", some_function());
+  printf("The nanoarrow build id at runtime is '%s'\n",
+         my_library_nanoarrow_build_id_runtime());
+  printf("The nanoarrow build id at compile time was '%s'\n",
+         my_library_nanoarrow_build_id_compile_time());
+  printf("The nanoarrow namespace is '%s'\n", my_library_nanoarrow_namespace());
   return 0;
 }

--- a/examples/cmake-minimal/src/app.c
+++ b/examples/cmake-minimal/src/app.c
@@ -22,16 +22,19 @@
 int main(int argc, char* argv[]) {
   struct ArrowArray array;
   struct ArrowSchema schema;
+  array.release = NULL;
+  schema.release = NULL;
 
-  int result = my_library_int32_array_from_args(argc - 1, argv + 1, &array, &schema);
+  int result = make_simple_array(&array, &schema);
   if (result != 0) {
-    printf("%s\n", my_library_last_error());
+    if (array.release) array.release(&array);
+    if (schema.release) schema.release(&schema);
     return result;
   }
 
-  printf("Parsed array with length %ld\n", (long)array.length);
-
-  array.release(&array);
-  schema.release(&schema);
-  return 0;
+  result = print_simple_array(&array, &schema);
+  if (array.release) array.release(&array);
+  if (schema.release) schema.release(&schema);
+  
+  return result;
 }

--- a/examples/cmake-minimal/src/app.c
+++ b/examples/cmake-minimal/src/app.c
@@ -20,10 +20,18 @@
 #include <stdio.h>
 
 int main(int argc, char* argv[]) {
-  printf("The nanoarrow build id at runtime is '%s'\n",
-         my_library_nanoarrow_build_id_runtime());
-  printf("The nanoarrow build id at compile time was '%s'\n",
-         my_library_nanoarrow_build_id_compile_time());
-  printf("The nanoarrow namespace is '%s'\n", my_library_nanoarrow_namespace());
+  struct ArrowArray array;
+  struct ArrowSchema schema;
+
+  int result = my_library_int32_array_from_args(argc - 1, argv + 1, &array, &schema);
+  if (result != 0) {
+    printf("%s\n", my_library_last_error());
+    return result;
+  }
+
+  printf("Parsed array with length %ld\n", (long)array.length);
+
+  array.release(&array);
+  schema.release(&schema);
   return 0;
 }

--- a/examples/cmake-minimal/src/app.c
+++ b/examples/cmake-minimal/src/app.c
@@ -15,7 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
+#include "library.h"
 
-const char* some_function();
+#include <stdio.h>
 
+int main(int argc, char* argv[]) {
+  printf("The nanoarrow build ID is '%s'", some_function());
+  return 0;
+}

--- a/examples/cmake-minimal/src/library.c
+++ b/examples/cmake-minimal/src/library.c
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "nanoarrow/nanoarrow.h"
+
+#include "library.h"
+
+

--- a/examples/cmake-minimal/src/library.c
+++ b/examples/cmake-minimal/src/library.c
@@ -19,4 +19,4 @@
 
 #include "library.h"
 
-
+const char* some_function() { return ArrowNanoarrowBuildId(); }

--- a/examples/cmake-minimal/src/library.c
+++ b/examples/cmake-minimal/src/library.c
@@ -19,4 +19,10 @@
 
 #include "library.h"
 
-const char* some_function() { return ArrowNanoarrowBuildId(); }
+const char* my_library_nanoarrow_build_id_runtime() { return ArrowNanoarrowBuildId(); }
+
+const char* my_library_nanoarrow_build_id_compile_time() { return NANOARROW_BUILD_ID; }
+
+// TODO: when namespacing PR is merged, make sure this works
+#define STR(x) #x
+const char* my_library_nanoarrow_namespace() { return STR(NANOARROW_NAMESPACE); }

--- a/examples/cmake-minimal/src/library.c
+++ b/examples/cmake-minimal/src/library.c
@@ -18,59 +18,52 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include <stdio.h>
+
 #include "nanoarrow/nanoarrow.h"
 
 #include "library.h"
 
-static struct ArrowError my_library_last_error_;
+static struct ArrowError global_error;
 
-const char* my_library_last_error() { return ArrowErrorMessage(&my_library_last_error_); }
+const char* my_library_last_error() { return ArrowErrorMessage(&global_error); }
 
-int my_library_int32_array_from_args(int n_args, char* argv[],
-                                     struct ArrowArray* array_out,
-                                     struct ArrowSchema* schema_out) {
-  ArrowErrorSet(&my_library_last_error_, "");
+int make_simple_array(struct ArrowArray* array_out, struct ArrowSchema* schema_out) {
+  ArrowErrorSet(&global_error, "");
+  array_out->release = NULL;
+  schema_out->release = NULL;
 
-  int result = ArrowArrayInit(array_out, NANOARROW_TYPE_INT32);
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInit(array_out, NANOARROW_TYPE_INT32));
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array_out));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array_out, 1));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array_out, 2));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array_out, 3));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuilding(array_out, &global_error));
+  
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32));
+
+  return NANOARROW_OK;
+}
+
+int print_simple_array(struct ArrowArray* array, struct ArrowSchema* schema) {
+  struct ArrowArrayView array_view;
+  NANOARROW_RETURN_NOT_OK(ArrowArrayViewInitFromSchema(&array_view, schema, &global_error));
+
+  if (array_view.storage_type != NANOARROW_TYPE_INT32) {
+    printf("Array has storage that is not int32\n");
+  }
+
+  int result = ArrowArrayViewSetArray(&array_view, array, &global_error);
   if (result != NANOARROW_OK) {
+    ArrowArrayViewReset(&array_view);
     return result;
   }
 
-  result = ArrowArrayStartAppending(array_out);
-  if (result != NANOARROW_OK) {
-    array_out->release(array_out);
-    return result;
+  for (int64_t i = 0; i < array->length; i++) {
+    printf("%d\n", (int)ArrowArrayViewGetIntUnsafe(&array_view, i));
   }
 
-  char* end_char;
-  for (int i = 0; i < n_args; i++) {
-    int64_t value = strtol(argv[i], &end_char, 10);
-    if (end_char != (argv[i] + strlen(argv[i]))) {
-      ArrowErrorSet(&my_library_last_error_, "Can't parse argument %d ('%s') to long int",
-                    i + 1, argv[i]);
-      array_out->release(array_out);
-      return EINVAL;
-    }
-
-    result = ArrowArrayAppendInt(array_out, value);
-    if (result != NANOARROW_OK) {
-      ArrowErrorSet(&my_library_last_error_,
-                    "Error appending argument %d ('%s') to array", i + 1, argv[i]);
-      array_out->release(array_out);
-      return result;
-    }
-  }
-
-  result = ArrowArrayFinishBuilding(array_out, &my_library_last_error_);
-  if (result != NANOARROW_OK) {
-    return result;
-  }
-
-  result = ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32);
-  if (result != NANOARROW_OK) {
-    array_out->release(array_out);
-    return result;
-  }
-
+  ArrowArrayViewReset(&array_view);
   return NANOARROW_OK;
 }

--- a/examples/cmake-minimal/src/library.h
+++ b/examples/cmake-minimal/src/library.h
@@ -17,5 +17,102 @@
 
 #pragma once
 
-const char* some_function();
+#include <stdint.h>
 
+// You can and should use the Arrow C Data interface types in headers
+// that will be included by others; however, you should not include
+// any other parts of the nanoarrow.h header in one of your own that
+// might be accessed by others.
+
+// Extra guard for versions of Arrow without the canonical guard
+#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
+
+struct ArrowArrayStream {
+  // Callback to get the stream type
+  // (will be the same for all arrays in the stream).
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowSchema must be released independently from the stream.
+  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
+
+  // Callback to get the next array
+  // (if no error and the array is released, the stream has ended)
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowArray must be released independently from the stream.
+  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
+
+  // Callback to get optional detailed error information.
+  // This must only be called if the last stream operation failed
+  // with a non-0 return code.
+  //
+  // Return value: pointer to a null-terminated character array describing
+  // the last error, or NULL if no description is available.
+  //
+  // The returned pointer is only valid until the next operation on this stream
+  // (including release).
+  const char* (*get_last_error)(struct ArrowArrayStream*);
+
+  // Release callback: release the stream's own resources.
+  // Note that arrays returned by `get_next` must be individually released.
+  void (*release)(struct ArrowArrayStream*);
+
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_STREAM_INTERFACE
+#endif  // ARROW_FLAG_DICTIONARY_ORDERED
+
+const char* my_library_nanoarrow_build_id_runtime();
+
+const char* my_library_nanoarrow_build_id_compile_time();
+
+const char* my_library_nanoarrow_namespace();

--- a/examples/cmake-minimal/src/library.h
+++ b/examples/cmake-minimal/src/library.h
@@ -1,0 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+

--- a/examples/cmake-minimal/src/library.h
+++ b/examples/cmake-minimal/src/library.h
@@ -111,8 +111,8 @@ struct ArrowArrayStream {
 #endif  // ARROW_C_STREAM_INTERFACE
 #endif  // ARROW_FLAG_DICTIONARY_ORDERED
 
-const char* my_library_nanoarrow_build_id_runtime();
+const char* my_library_last_error();
 
-const char* my_library_nanoarrow_build_id_compile_time();
-
-const char* my_library_nanoarrow_namespace();
+int my_library_int32_array_from_args(int n_args, char* argv[],
+                                     struct ArrowArray* array_out,
+                                     struct ArrowSchema* schema_out);

--- a/examples/cmake-minimal/src/library.h
+++ b/examples/cmake-minimal/src/library.h
@@ -113,6 +113,8 @@ struct ArrowArrayStream {
 
 const char* my_library_last_error();
 
-int my_library_int32_array_from_args(int n_args, char* argv[],
-                                     struct ArrowArray* array_out,
-                                     struct ArrowSchema* schema_out);
+// Creates the integer array [1, 2, 3]
+int make_simple_array(struct ArrowArray* array_out, struct ArrowSchema* schema_out);
+
+// Prints the array created by make_simple_array to the stdout
+int print_simple_array(struct ArrowArray* array, struct ArrowSchema* schema);

--- a/examples/vendored-minimal/README.md
+++ b/examples/vendored-minimal/README.md
@@ -1,0 +1,40 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Minimal Vendored Example
+
+This folder contains a project that uses the bundled nanarrow.c and nanoarrow.h
+files included in the dist/ directory of this repository (or that can be generated
+using `cmake -DNANOARROW_BUNDLE=ON` from the root CMake project). Like the CMake
+example, you must be careful to not expose nanoarrow's header outside your project
+and make use of `#define NANOARROW_NAMESPACE MyProject` to prefix nanoarrow's symbol
+names to ensure they do not collide with another copy of nanoarrow potentially
+linked to by another project.
+
+The nanoarrow.c and nanoarrow.h files included in this example are stubs to illustrate
+how these files could fit in to a library and/or command-line application project.
+The easiest way is to use the pre-generated versions in the dist/ folder of this
+repository:
+
+```bash
+git clone https://github.com/apache/arrow-nanoarrow.git
+cd arrow-nanoarrow/examples/vendored-minimal
+cp ../../dist/nanoarrow.c src/nanoarrow.c
+cp ../../dist/nanoarrow.h src/nanoarrow.h
+```

--- a/examples/vendored-minimal/README.md
+++ b/examples/vendored-minimal/README.md
@@ -35,6 +35,42 @@ repository:
 ```bash
 git clone https://github.com/apache/arrow-nanoarrow.git
 cd arrow-nanoarrow/examples/vendored-minimal
-cp ../../dist/nanoarrow.c src/nanoarrow.c
 cp ../../dist/nanoarrow.h src/nanoarrow.h
+cp ../../dist/nanoarrow.c src/nanoarrow.c
+```
+
+If you use these, you will have to manually `#define NANOARROW_NAMESPACE MyProject`
+manually next to `#define NANOARROW_BUILD_ID` in the header.
+
+You can also generate the bundled versions with the namespace defined using `cmake`:
+
+```bash
+git clone https://github.com/apache/arrow-nanoarrow.git
+cd arrow-nanoarrow
+mkdir build && cd build
+cmake .. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=ExampleVendored
+cmake --build .
+cmake --install . --prefix=../examples/vendored-minimal/src
+```
+
+Then you can build/link the application/library using the build tool of your choosing:
+
+```bash
+cd src
+cc -c library.c nanoarrow.c
+ar rcs libexample_vendored_minimal_library.a library.o nanoarrow.o
+cc -o example_vendored_minimal_app app.c libexample_vendored_minimal_library.a
+```
+
+After building, you can run the app. The app
+parses command line arguments into an int32 array and prints out the
+resulting length (or any error encountered whilst building the array).
+
+```bash
+./example_vendored_minimal_app 8 2 4 9
+#> Parsed array with length 4
+./example_vendored_minimal_app asd
+#> Can't parse argument 1 ('asd') to long int
+./example_vendored_minimal_app 999999999999999
+#> Error appending argument 1 ('999999999999999') to array
 ```

--- a/examples/vendored-minimal/README.md
+++ b/examples/vendored-minimal/README.md
@@ -67,10 +67,8 @@ parses command line arguments into an int32 array and prints out the
 resulting length (or any error encountered whilst building the array).
 
 ```bash
-./example_vendored_minimal_app 8 2 4 9
-#> Parsed array with length 4
-./example_vendored_minimal_app asd
-#> Can't parse argument 1 ('asd') to long int
-./example_vendored_minimal_app 999999999999999
-#> Error appending argument 1 ('999999999999999') to array
+./example_vendored_minimal_app
+# 1
+# 2
+# 3
 ```

--- a/examples/vendored-minimal/src/.gitignore
+++ b/examples/vendored-minimal/src/.gitignore
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+*.o
+*.a
+example_vendored_minimal_app

--- a/examples/vendored-minimal/src/app.c
+++ b/examples/vendored-minimal/src/app.c
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "library.h"
+
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+  struct ArrowArray array;
+  struct ArrowSchema schema;
+
+  int result = my_library_int32_array_from_args(argc - 1, argv + 1, &array, &schema);
+  if (result != 0) {
+    printf("%s\n", my_library_last_error());
+    return result;
+  }
+
+  printf("Parsed array with length %ld\n", (long)array.length);
+
+  array.release(&array);
+  schema.release(&schema);
+  return 0;
+}

--- a/examples/vendored-minimal/src/app.c
+++ b/examples/vendored-minimal/src/app.c
@@ -22,16 +22,19 @@
 int main(int argc, char* argv[]) {
   struct ArrowArray array;
   struct ArrowSchema schema;
+  array.release = NULL;
+  schema.release = NULL;
 
-  int result = my_library_int32_array_from_args(argc - 1, argv + 1, &array, &schema);
+  int result = make_simple_array(&array, &schema);
   if (result != 0) {
-    printf("%s\n", my_library_last_error());
+    if (array.release) array.release(&array);
+    if (schema.release) schema.release(&schema);
     return result;
   }
 
-  printf("Parsed array with length %ld\n", (long)array.length);
-
-  array.release(&array);
-  schema.release(&schema);
-  return 0;
+  result = print_simple_array(&array, &schema);
+  if (array.release) array.release(&array);
+  if (schema.release) schema.release(&schema);
+  
+  return result;
 }

--- a/examples/vendored-minimal/src/library.c
+++ b/examples/vendored-minimal/src/library.c
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 
-#include "nanoarrow/nanoarrow.h"
+#include "nanoarrow.h"
 
 #include "library.h"
 

--- a/examples/vendored-minimal/src/library.c
+++ b/examples/vendored-minimal/src/library.c
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "nanoarrow.h"
+
+#include "library.h"
+
+static struct ArrowError my_library_last_error_;
+
+const char* my_library_last_error() { return ArrowErrorMessage(&my_library_last_error_); }
+
+int my_library_int32_array_from_args(int n_args, char* argv[],
+                                     struct ArrowArray* array_out,
+                                     struct ArrowSchema* schema_out) {
+  ArrowErrorSet(&my_library_last_error_, "");
+
+  int result = ArrowArrayInit(array_out, NANOARROW_TYPE_INT32);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  result = ArrowArrayStartAppending(array_out);
+  if (result != NANOARROW_OK) {
+    array_out->release(array_out);
+    return result;
+  }
+
+  char* end_char;
+  for (int i = 0; i < n_args; i++) {
+    int64_t value = strtol(argv[i], &end_char, 10);
+    if (end_char != (argv[i] + strlen(argv[i]))) {
+      ArrowErrorSet(&my_library_last_error_, "Can't parse argument %d ('%s') to long int",
+                    i + 1, argv[i]);
+      array_out->release(array_out);
+      return EINVAL;
+    }
+
+    result = ArrowArrayAppendInt(array_out, value);
+    if (result != NANOARROW_OK) {
+      ArrowErrorSet(&my_library_last_error_,
+                    "Error appending argument %d ('%s') to array", i + 1, argv[i]);
+      array_out->release(array_out);
+      return result;
+    }
+  }
+
+  result = ArrowArrayFinishBuilding(array_out, &my_library_last_error_);
+  if (result != NANOARROW_OK) {
+    return result;
+  }
+
+  result = ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32);
+  if (result != NANOARROW_OK) {
+    array_out->release(array_out);
+    return result;
+  }
+
+  return NANOARROW_OK;
+}

--- a/examples/vendored-minimal/src/library.h
+++ b/examples/vendored-minimal/src/library.h
@@ -113,6 +113,8 @@ struct ArrowArrayStream {
 
 const char* my_library_last_error();
 
-int my_library_int32_array_from_args(int n_args, char* argv[],
-                                     struct ArrowArray* array_out,
-                                     struct ArrowSchema* schema_out);
+// Creates the integer array [1, 2, 3]
+int make_simple_array(struct ArrowArray* array_out, struct ArrowSchema* schema_out);
+
+// Prints the array created by make_simple_array to the stdout
+int print_simple_array(struct ArrowArray* array, struct ArrowSchema* schema);

--- a/examples/vendored-minimal/src/library.h
+++ b/examples/vendored-minimal/src/library.h
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stdint.h>
+
+// You can and should use the Arrow C Data interface types in headers
+// that will be included by others; however, you should not include
+// any other parts of the nanoarrow.h header in one of your own that
+// might be accessed by others.
+
+// Extra guard for versions of Arrow without the canonical guard
+#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
+
+struct ArrowArrayStream {
+  // Callback to get the stream type
+  // (will be the same for all arrays in the stream).
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowSchema must be released independently from the stream.
+  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
+
+  // Callback to get the next array
+  // (if no error and the array is released, the stream has ended)
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowArray must be released independently from the stream.
+  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
+
+  // Callback to get optional detailed error information.
+  // This must only be called if the last stream operation failed
+  // with a non-0 return code.
+  //
+  // Return value: pointer to a null-terminated character array describing
+  // the last error, or NULL if no description is available.
+  //
+  // The returned pointer is only valid until the next operation on this stream
+  // (including release).
+  const char* (*get_last_error)(struct ArrowArrayStream*);
+
+  // Release callback: release the stream's own resources.
+  // Note that arrays returned by `get_next` must be individually released.
+  void (*release)(struct ArrowArrayStream*);
+
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_STREAM_INTERFACE
+#endif  // ARROW_FLAG_DICTIONARY_ORDERED
+
+const char* my_library_last_error();
+
+int my_library_int32_array_from_args(int n_args, char* argv[],
+                                     struct ArrowArray* array_out,
+                                     struct ArrowSchema* schema_out);

--- a/examples/vendored-minimal/src/nanoarrow.c
+++ b/examples/vendored-minimal/src/nanoarrow.c
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// See the README this directory for how to generate this file

--- a/examples/vendored-minimal/src/nanoarrow.c
+++ b/examples/vendored-minimal/src/nanoarrow.c
@@ -15,4 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// See the README this directory for how to generate this file
+// See the README in this directory for how to generate this file

--- a/examples/vendored-minimal/src/nanoarrow.h
+++ b/examples/vendored-minimal/src/nanoarrow.h
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// See the README this directory for how to generate this file

--- a/examples/vendored-minimal/src/nanoarrow.h
+++ b/examples/vendored-minimal/src/nanoarrow.h
@@ -15,4 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// See the README this directory for how to generate this file
+// See the README in this directory for how to generate this file


### PR DESCRIPTION
Fixes #21. Will demonstrate:

- A minimal CMake configuration that builds + privately links a static nanoarrow build
- A minimal vendored configuration

The principles I'd like to communicate are:

- You must vendor nanoarrow.c/nanoarrow.h or privately link a static library
- You must not expose any parts of nanoarrow.h in one of your library's headers (except the ABI stable Arrow C Data/Stream interface)
- When using the vendored nanoarrow.h/nanoarrow.c version, you should `#define NANOARROW_NAMESPACE SomeNamespace` to avoid symbol collisions (i.e., if somebody else loads your library into the same process or vendors it into another library)
- Maybe bits I'm missing?