### PR TITLE
[C] Make sure the data buffer is non-null

### DIFF
--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -363,6 +363,15 @@ TEST(ArrayTest, ArrayTestAppendToStringArray) {
       ArrayFromJSON(utf8(), "[\"1234\", null, null, \"56789\"]")));
 }
 
+TEST(ArrayTest, ArrayTestAppendEmptyToString) {
+  struct ArrowArray array;
+  ASSERT_EQ(ArrowArrayInit(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
+  EXPECT_NE(array.buffers[2], nullptr);
+}
+
 TEST(ArrayTest, ArrayTestAppendToUInt64Array) {
   struct ArrowArray array;
 


### PR DESCRIPTION
Before this PR, the array `[""]` (or any string/binary array whose values were all zero size) were represented in a way that caused Arrow C++ to choke on the result. This PR adds a step to the finish building step that makes sure there's always at least one element in that buffer.