### PR TITLE
[R] Make installation work with default args to `remotes::install_github()`/`pak::pkg_install()`

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# if we are building from within the nanoarrow repo, we want to use cmake
-# to generate the bundled header/source
+# If we are building from within the nanoarrow repo, we want to use cmake
+# to regenerate the bundled header/source
 if [ -f "../src/nanoarrow/nanoarrow.h" ]; then
   echo "Bundling nanoarrow using ../CMakeLists.txt"
   rm -f src/nanoarrow.h src/nanoarrow.c
@@ -32,6 +32,22 @@ fi
 
 if [ -f "src/nanoarrow.h" ] && [ -f "src/nanoarrow.c" ]; then
   echo "Found vendored nanoarrow"
+  exit 0
+fi
+
+# We have a situation where the package has been built via R CMD build
+# but there is no vendored nanoarrow. This occurs with
+# remotes::install_github() with the default arguments. In this case, pull
+# the latest bundled version from GitHub. To ensure commit-level consistency,
+# use remotes::install_github(build = FALSE) (which will run cmake to get
+# a fresh bundle with a specific commit).
+curl -L https://github.com/apache/arrow-nanoarrow/raw/main/dist/nanoarrow.h \
+  --output src/nanoarrow.h
+curl -L https://github.com/apache/arrow-nanoarrow/raw/main/dist/nanoarrow.c \
+  --output src/nanoarrow.c
+
+if [ -f "src/nanoarrow.h" ] && [ -f "src/nanoarrow.c" ]; then
+  echo "Fetched bundled nanoarrow from https://github.com/apache/arrow-nanoarrow/tree/main/dist"
   exit 0
 fi
 

--- a/r/configure
+++ b/r/configure
@@ -42,9 +42,9 @@ fi
 # use remotes::install_github(build = FALSE) (which will run cmake to get
 # a fresh bundle with a specific commit).
 curl -L https://github.com/apache/arrow-nanoarrow/raw/main/dist/nanoarrow.h \
-  --output src/nanoarrow.h
+  --output src/nanoarrow.h --silent
 curl -L https://github.com/apache/arrow-nanoarrow/raw/main/dist/nanoarrow.c \
-  --output src/nanoarrow.c
+  --output src/nanoarrow.c --silent
 
 if [ -f "src/nanoarrow.h" ] && [ -f "src/nanoarrow.c" ]; then
   echo "Fetched bundled nanoarrow from https://github.com/apache/arrow-nanoarrow/tree/main/dist"


### PR DESCRIPTION
This allows `remotes::install_github("apache/arrow-nanoarrow/r")` and `pak::pkg_install("apache/arrow-nanoarrow/r")` to work out-of-the-box without a user having to have cmake installed. This is mostly nice because it allows prototyping of dependencies that have in their DESCRIPTION:

```
Imports: nanoarrow
Remotes: apache/arrow-nanoarrow/r
```

...and nobody has to do anything special to install the nanoarrow dependency. Note that the previous way to make this work was `remotes::install_github("apache/arrow-nanoarrow/r", build = FALSE)`, which does a straight `R CMD INSTALL` instead of an `R CMD build` + `R CMD INSTALL`.