### PR TITLE
[Documentation] Add missing group titles

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -109,7 +109,7 @@
 extern "C" {
 #endif
 
-/// \defgroup nanoarrow
+/// \defgroup nanoarrow Nanoarrow C library
 ///
 /// Except where noted, objects are not thread-safe and clients should
 /// take care to serialize accesses to methods.

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -22,7 +22,7 @@
 #ifndef NANOARROW_HPP_INCLUDED
 #define NANOARROW_HPP_INCLUDED
 
-/// \defgroup nanoarrow_hpp
+/// \defgroup nanoarrow_hpp Nanoarrow C++ Helpers
 ///
 /// The utilities provided in this file are intended to support C++ users
 /// of the nanoarrow C library such that C++-style resource allocation
@@ -156,7 +156,7 @@ class Unique {
 
 }  // namespace internal
 
-/// \defgroup nanoarrow_hpp-unique
+/// \defgroup nanoarrow_hpp-unique Unique object wrappers
 ///
 /// The Arrow C Data interface, the Arrow C Stream interface, and the
 /// nanoarrow C library use stack-allocatable objects, some of which

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -30,7 +30,7 @@ extern "C" {
 // Extra guard for versions of Arrow without the canonical guard
 #ifndef ARROW_FLAG_DICTIONARY_ORDERED
 
-/// \defgroup nanoarrow-arrow-cdata
+/// \defgroup nanoarrow-arrow-cdata Arrow C Data interface
 ///
 /// The Arrow C Data (https://arrow.apache.org/docs/format/CDataInterface.html)
 /// and Arrow C Stream (https://arrow.apache.org/docs/format/CStreamInterface.html)


### PR DESCRIPTION
This was causing old versions of doxygen to capitalize defgroup names, causing breathe not to be able to find them!