### PR TITLE
[C] Fix some MAP type support issues

### DIFF
--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -648,10 +648,12 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       }
       break;
     case NANOARROW_TYPE_LIST:
-    case NANOARROW_TYPE_MAP:
+    case NANOARROW_TYPE_MAP: {
+      const char* type_name =
+          array_view->storage_type == NANOARROW_TYPE_LIST ? "list" : "map";
       if (array->n_children != 1) {
-        ArrowErrorSet(error, "Expected 1 child of list array but found %d child arrays",
-                      (int)array->n_children);
+        ArrowErrorSet(error, "Expected 1 child of %s array but found %d child arrays",
+                      type_name, (int)array->n_children);
         return EINVAL;
       }
 
@@ -661,13 +663,14 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
         if (array->children[0]->length < last_offset) {
           ArrowErrorSet(
               error,
-              "Expected child of list array with length >= %ld but found array with "
+              "Expected child of %s array with length >= %ld but found array with "
               "length %ld",
-              (long)last_offset, (long)array->children[0]->length);
+              type_name, (long)last_offset, (long)array->children[0]->length);
           return EINVAL;
         }
       }
       break;
+    }
     case NANOARROW_TYPE_LARGE_LIST:
       if (array->n_children != 1) {
         ArrowErrorSet(error,

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -74,13 +74,13 @@ static ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
 
     case NANOARROW_TYPE_FIXED_SIZE_LIST:
     case NANOARROW_TYPE_STRUCT:
-    case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_SPARSE_UNION:
       array->n_buffers = 1;
       break;
 
     case NANOARROW_TYPE_LIST:
     case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_BOOL:
     case NANOARROW_TYPE_UINT8:
     case NANOARROW_TYPE_INT8:
@@ -648,6 +648,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       }
       break;
     case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_MAP:
       if (array->n_children != 1) {
         ArrowErrorSet(error, "Expected 1 child of list array but found %d child arrays",
                       (int)array->n_children);

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -401,6 +401,7 @@ static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array) {
 
   switch (private_data->storage_type) {
     case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_MAP:
       child_length = array->children[0]->length;
       if (child_length > INT32_MAX) {
         return EINVAL;

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -888,7 +888,7 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   array.n_children = 0;
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
-               "Expected 1 child of list array but found 0 child arrays");
+               "Expected 1 child of map array but found 0 child arrays");
   array.n_children = 1;
 
   // Make sure final child size is checked at finish
@@ -896,7 +896,7 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, &error), EINVAL);
   EXPECT_STREQ(
       ArrowErrorMessage(&error),
-      "Expected child of list array with length >= 1 but found array with length 0");
+      "Expected child of map array with length >= 1 but found array with length 0");
 
   array.children[0]->length = array.children[0]->length + 1;
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, &error), NANOARROW_OK);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -857,7 +857,7 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   ASSERT_EQ(ArrowSchemaInit(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(&schema, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaInit(schema.children[0], NANOARROW_TYPE_STRUCT), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetName(schema.children[0], "item"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetName(schema.children[0], "entries"), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateChildren(schema.children[0], 2), NANOARROW_OK);
 
   ASSERT_EQ(ArrowSchemaInit(schema.children[0]->children[0], NANOARROW_TYPE_INT32),

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -875,9 +875,7 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(array.children[0], 1)->capacity_bytes, 0);
 
-  struct ArrowStringView string_value;
-  string_value.data = "foobar";
-  string_value.n_bytes = 6;
+  struct ArrowStringView string_value = ArrowCharView("foobar");
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0]->children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendString(array.children[0]->children[1], string_value),
             NANOARROW_OK);


### PR DESCRIPTION
Generally, make sure MAP is consistent with LIST:
- MAP has 2 buffers (validity + offset)
- MAP must be finished like LIST (we could go further and have FinishElement also finish the child in the case of MAP, since we know it must always be STRUCT)