### PR TITLE
[C] Union Appender support

### DIFF
--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -201,19 +201,12 @@ SEXP nanoarrow_c_schema_parse(SEXP schema_xptr) {
 
   if (schema_view.data_type == NANOARROW_TYPE_DENSE_UNION ||
       schema_view.data_type == NANOARROW_TYPE_SPARSE_UNION) {
-    int num_type_ids = 1;
-    for (int64_t i = 0; i < schema_view.union_type_ids.n_bytes; i++) {
-      num_type_ids += schema_view.union_type_ids.data[i] == ',';
-    }
-
+    int8_t type_ids[128];
+    int num_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids, type_ids);
+    
     SEXP union_type_ids = PROTECT(Rf_allocVector(INTSXP, num_type_ids));
-    const char* ptr = schema_view.union_type_ids.data;
-    char* end_ptr = (char*)ptr;
-    int i = 0;
-    while (*end_ptr != '\0') {
-      INTEGER(union_type_ids)[i] = strtol(ptr, &end_ptr, 10);
-      i++;
-      ptr = end_ptr + 1;
+    for (int i = 0; i < num_type_ids; i++) {
+      INTEGER(union_type_ids)[i] = type_ids[i];
     }
     SET_VECTOR_ELT(result, 10, union_type_ids);
     UNPROTECT(1);

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -203,7 +203,10 @@ SEXP nanoarrow_c_schema_parse(SEXP schema_xptr) {
       schema_view.data_type == NANOARROW_TYPE_SPARSE_UNION) {
     int8_t type_ids[128];
     int num_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids, type_ids);
-    
+    if (num_type_ids == -1) {
+      Rf_error("Invalid type IDs in union type: '%s'", schema_view.union_type_ids);
+    }
+
     SEXP union_type_ids = PROTECT(Rf_allocVector(INTSXP, num_type_ids));
     for (int i = 0; i < num_type_ids; i++) {
       INTEGER(union_type_ids)[i] = type_ids[i];

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -29,9 +29,6 @@ static void ArrowArrayRelease(struct ArrowArray* array) {
     ArrowBitmapReset(&private_data->bitmap);
     ArrowBufferReset(&private_data->buffers[0]);
     ArrowBufferReset(&private_data->buffers[1]);
-    if (private_data->union_child_index_map != NULL) {
-      ArrowFree(private_data->union_child_index_map);
-    }
     ArrowFree(private_data);
   }
 
@@ -162,7 +159,6 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
   }
 
   ArrowLayoutInit(&private_data->layout, storage_type);
-  private_data->union_child_index_map = NULL;
   return NANOARROW_OK;
 }
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -71,7 +71,7 @@ static inline int8_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) 
   char* end_ptr;
   do {
     type_id = strtol(type_ids, &end_ptr, 10);
-    if (end_ptr == type_ids) {
+    if (end_ptr == type_ids || type_id < 0 || type_id > 127) {
       return -1;
     }
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -94,6 +94,23 @@ static inline int8_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) 
   return -1;
 }
 
+static inline int8_t _ArrowUnionTypeIdsWillEqualChildIndices(const char* type_id_str,
+                                                             int64_t n_children) {
+  int8_t type_ids[128];
+  int8_t n_type_ids = _ArrowParseUnionTypeIds(type_id_str, type_ids);
+  if (n_type_ids != n_children) {
+    return 0;
+  }
+
+  for (int8_t i = 0; i < n_type_ids; i++) {
+    if (type_ids[i] != i) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
 static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array) {
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -115,6 +115,20 @@ static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array) 
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
 
+  switch (private_data->storage_type) {
+    case NANOARROW_TYPE_UNINITIALIZED:
+      return EINVAL;
+    case NANOARROW_TYPE_SPARSE_UNION:
+    case NANOARROW_TYPE_DENSE_UNION:
+      // Note that this value could be -1 if the type_ids string was invalid
+      if (private_data->union_type_id_is_child_index != 1) {
+        return EINVAL;
+      } else {
+        break;
+      }
+    default:
+      break;
+  }
   if (private_data->storage_type == NANOARROW_TYPE_UNINITIALIZED) {
     return EINVAL;
   }

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -207,7 +207,7 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
 
       case NANOARROW_BUFFER_TYPE_TYPE_ID:
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
-        // These cases are handled above
+        // These cases return above
         return EINVAL;
     }
   }

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -125,7 +125,7 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
     case NANOARROW_TYPE_DENSE_UNION:
       // Add one null to the first child and append n references to that child
       // (Currently assumes type_id == child_index)
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array->children[0], 1));
+      NANOARROW_RETURN_NOT_OK(_ArrowArrayAppendEmptyInternal(array->children[0], 1, is_valid));
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(ArrowArrayBuffer(array, 0), 0, n));
       for (int64_t i = 0; i < n; i++) {
         NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt32(
@@ -137,7 +137,7 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
     case NANOARROW_TYPE_SPARSE_UNION:
       // Add n nulls to the first child and append n references to that child
       // (Currently assumes type_id == child_index)
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array->children[0], n));
+      NANOARROW_RETURN_NOT_OK(_ArrowArrayAppendEmptyInternal(array->children[0], n, is_valid));
       for (int64_t i = 1; i < array->n_children; i++) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendEmpty(array->children[i], n));
       }
@@ -148,12 +148,12 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_FIXED_SIZE_LIST:
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendEmpty(
           array->children[0], n * private_data->layout.child_size_elements));
       break;
     case NANOARROW_TYPE_STRUCT:
       for (int64_t i = 0; i < array->n_children; i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array->children[i], n));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendEmpty(array->children[i], n));
       }
       break;
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -136,6 +136,10 @@ static inline ArrowErrorCode ArrowArrayAppendNull(struct ArrowArray* array, int6
       // Add n nulls to the first child and append n references to that child
       // (Currently assumes type_id == child_index)
       NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array->children[0], n));
+      for (int64_t i = 1; i < array->n_children; i++) {
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array->children[i], n));
+      }
+
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(ArrowArrayBuffer(array, 0), 0, n));
       array->length += n;
       return NANOARROW_OK;

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -49,7 +49,7 @@ static inline struct ArrowBuffer* ArrowArrayBuffer(struct ArrowArray* array, int
 }
 
 // We don't currently support the case of unions where type_id != child_index;
-// however, these two functions are used to keep track of where that assumption
+// however, these functions are used to keep track of where that assumption
 // is made.
 static inline int8_t _ArrowArrayUnionChildIndex(struct ArrowArray* array,
                                                 int8_t type_id) {
@@ -59,6 +59,39 @@ static inline int8_t _ArrowArrayUnionChildIndex(struct ArrowArray* array,
 static inline int8_t _ArrowArrayUnionTypeId(struct ArrowArray* array,
                                             int8_t child_index) {
   return child_index;
+}
+
+static inline int8_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) {
+  if (*type_ids == '\0') {
+    return 0;
+  }
+
+  int32_t i = 0;
+  long type_id;
+  char* end_ptr;
+  do {
+    type_id = strtol(type_ids, &end_ptr, 10);
+    if (end_ptr == type_ids) {
+      return -1;
+    }
+
+    if (out != NULL) {
+      out[i] = type_id;
+    }
+
+    i++;
+
+    type_ids = end_ptr;
+    if (*type_ids == '\0') {
+      return i;
+    } else if (*type_ids != ',') {
+      return -1;
+    } else {
+      type_ids++;
+    }
+  } while (1);
+
+  return -1;
 }
 
 static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array) {

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1086,6 +1086,18 @@ TEST(ArrayTest, ArrayTestUnionUtils) {
   EXPECT_EQ(type_ids[1], 5);
   EXPECT_EQ(type_ids[2], 6);
   EXPECT_EQ(type_ids[3], 7);
+
+  // Check the "ids will equal child indices" checker
+  EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("", 0));
+  EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("0", 1));
+  EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("0,1", 2));
+  
+  EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,1", 1));
+  EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices(",", 0));
+  EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("1", 1));
+  EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,2", 2));
+  EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,2", 2));
+
 }
 
 TEST(ArrayTest, ArrayTestAppendToDenseUnionArray) {

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1144,11 +1144,14 @@ TEST(ArrayTest, ArrayTestAppendToSparseUnionArray) {
                                                          child_builder_string};
   auto builder = SparseUnionBuilder(default_memory_pool(), children,
                                     arrow_array.ValueUnsafe()->type());
+  // Arrow's SparseUnionBuilder requires explicit empty value appends?
   ARROW_EXPECT_OK(builder.Append(0));
   ARROW_EXPECT_OK(child_builder_int->Append(123));
+  ARROW_EXPECT_OK(child_builder_string->AppendEmptyValue());
   ARROW_EXPECT_OK(builder.AppendNulls(2));
   ARROW_EXPECT_OK(builder.Append(1));
   ARROW_EXPECT_OK(child_builder_string->Append("one twenty four"));
+  ARROW_EXPECT_OK(child_builder_int->AppendEmptyValue());
 
   auto expected_array = builder.Finish();
   ARROW_EXPECT_OK(expected_array);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1226,9 +1226,14 @@ TEST(ArrayTest, ArrayTestAppendToUnionArrayErrors) {
   struct ArrowArray array;
   struct ArrowSchema schema;
 
+  // Make an valid union that won't work during appending (because
+  // the type_id != child_index)
   ArrowSchemaInit(&schema);
-  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:0"), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_DENSE_UNION, 1),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:1"), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), EINVAL);
   schema.release(&schema);
   array.release(&array);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1103,6 +1103,8 @@ TEST(ArrayTest, ArrayTestUnionUtils) {
   // Invalid
   EXPECT_EQ(_ArrowParseUnionTypeIds("0,1,", nullptr), -1);
   EXPECT_EQ(_ArrowParseUnionTypeIds("0,1A", nullptr), -1);
+  EXPECT_EQ(_ArrowParseUnionTypeIds("128", nullptr), -1);
+  EXPECT_EQ(_ArrowParseUnionTypeIds("-1", nullptr), -1);
 
   // Check output
   int8_t type_ids[] = {-1, -1, -1, -1};

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1070,6 +1070,24 @@ TEST(ArrayTest, ArrayTestAppendToStructArray) {
   EXPECT_TRUE(arrow_array.ValueUnsafe()->Equals(expected_array.ValueUnsafe()));
 }
 
+TEST(ArrayTest, ArrayTestUnionUtils) {
+  // Check length calculation with nullptr
+  EXPECT_EQ(_ArrowParseUnionTypeIds("", nullptr), 0);
+  EXPECT_EQ(_ArrowParseUnionTypeIds("0", nullptr), 1);
+  EXPECT_EQ(_ArrowParseUnionTypeIds("0,1", nullptr), 2);
+  // Invalid
+  EXPECT_EQ(_ArrowParseUnionTypeIds("0,1,", nullptr), -1);
+  EXPECT_EQ(_ArrowParseUnionTypeIds("0,1A", nullptr), -1);
+
+  // Check output
+  int8_t type_ids[] = {-1, -1, -1, -1};
+  EXPECT_EQ(_ArrowParseUnionTypeIds("4,5,6,7", type_ids), 4);
+  EXPECT_EQ(type_ids[0], 4);
+  EXPECT_EQ(type_ids[1], 5);
+  EXPECT_EQ(type_ids[2], 6);
+  EXPECT_EQ(type_ids[3], 7);
+}
+
 TEST(ArrayTest, ArrayTestAppendToDenseUnionArray) {
   struct ArrowArray array;
   struct ArrowSchema schema;

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1091,13 +1091,12 @@ TEST(ArrayTest, ArrayTestUnionUtils) {
   EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("", 0));
   EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("0", 1));
   EXPECT_TRUE(_ArrowUnionTypeIdsWillEqualChildIndices("0,1", 2));
-  
+
   EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,1", 1));
   EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices(",", 0));
   EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("1", 1));
   EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,2", 2));
   EXPECT_FALSE(_ArrowUnionTypeIdsWillEqualChildIndices("0,2", 2));
-
 }
 
 TEST(ArrayTest, ArrayTestAppendToDenseUnionArray) {
@@ -1189,6 +1188,18 @@ TEST(ArrayTest, ArrayTestAppendToSparseUnionArray) {
   EXPECT_EQ(arrow_array.ValueUnsafe()->ToString(),
             expected_array.ValueUnsafe()->ToString());
   EXPECT_TRUE(arrow_array.ValueUnsafe()->Equals(expected_array.ValueUnsafe()));
+}
+
+TEST(ArrayTest, ArrayTestAppendToUnionArrayErrors) {
+  struct ArrowArray array;
+  struct ArrowSchema schema;
+
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:0"), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStartAppending(&array), EINVAL);
+  schema.release(&schema);
+  array.release(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestBasic) {

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -502,7 +502,7 @@ struct ArrowSchemaView {
   /// This value is set when parsing a union type and represents
   /// type ids parameter. The ArrowStringView points to
   /// data within the schema and the value is undefined for other types.
-  struct ArrowStringView union_type_ids;
+  const char* union_type_ids;
 };
 
 /// \brief Initialize an ArrowSchemaView

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -845,7 +845,7 @@ static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array);
 /// EINVAL if the underlying storage type is not a union, if type_id is not valid,
 /// or if child sizes after appending are inconsistent.
 static inline ArrowErrorCode ArrowArrayFinishUnionElement(struct ArrowArray* array,
-                                                          int32_t type_id);
+                                                          int8_t type_id);
 
 /// \brief Shrink buffer capacity to the size required
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -835,6 +835,15 @@ static inline ArrowErrorCode ArrowArrayAppendString(struct ArrowArray* array,
 /// length of the child array(s) did not match the expected length.
 static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array);
 
+/// \brief Finish a union array element
+///
+/// Appends an element to the union type ids buffer and increments array->length.
+/// For sparse unions, up to one element is added to non type-id children. Returns
+/// EINVAL if the underlying storage type is not a union, if type_id is not valid,
+/// or if child sizes after appending are inconsistent.
+static inline ArrowErrorCode ArrowArrayFinishUnionElement(struct ArrowArray* array,
+                                                          int32_t type_id);
+
 /// \brief Shrink buffer capacity to the size required
 ///
 /// Also applies shrinking to any child arrays. array must have been allocated using

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -785,6 +785,9 @@ ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
 /// \brief Append a null value to an array
 static inline ArrowErrorCode ArrowArrayAppendNull(struct ArrowArray* array, int64_t n);
 
+/// \brief Append an empty, non-null value to an array
+static inline ArrowErrorCode ArrowArrayAppendEmpty(struct ArrowArray* array, int64_t n);
+
 /// \brief Append a signed integer value to an array
 ///
 /// Returns NANOARROW_OK if value can be exactly represented by

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -520,6 +520,11 @@ struct ArrowArrayPrivateData {
 
   // The buffer arrangement for the storage type
   struct ArrowLayout layout;
+
+  // Flag to indicate if there are non-sequence union type ids.
+  // In the future this could be replaced with a type id<->child mapping
+  // to support constructing unions in append mode where type_id != child_index
+  int8_t union_type_id_is_child_index;
 };
 
 #ifdef __cplusplus

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -520,10 +520,6 @@ struct ArrowArrayPrivateData {
 
   // The buffer arrangement for the storage type
   struct ArrowLayout layout;
-
-  // An ArrowMalloc-ed 128-byte lookup table mapping type_id -> child_index or NULL
-  // if storage_type is not a union type.
-  int8_t* union_child_index_map;
 };
 
 #ifdef __cplusplus

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -520,6 +520,10 @@ struct ArrowArrayPrivateData {
 
   // The buffer arrangement for the storage type
   struct ArrowLayout layout;
+
+  // An ArrowMalloc-ed 128-byte lookup table mapping type_id -> child_index or NULL
+  // if storage_type is not a union type.
+  int8_t* union_child_index_map;
 };
 
 #ifdef __cplusplus

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -752,8 +752,7 @@ static ArrowErrorCode ArrowSchemaViewParse(struct ArrowSchemaView* schema_view,
           }
 
           if (format[3] == ':') {
-            schema_view->union_type_ids.data = format + 4;
-            schema_view->union_type_ids.n_bytes = strlen(format + 4);
+            schema_view->union_type_ids = format + 4;
             *format_end_out = format + strlen(format);
             return NANOARROW_OK;
           } else {
@@ -1185,9 +1184,7 @@ static int64_t ArrowSchemaTypeToStringInternal(struct ArrowSchemaView* schema_vi
       return snprintf(out, n, "%s(%ld)", type_string, (long)schema_view->fixed_size);
     case NANOARROW_TYPE_SPARSE_UNION:
     case NANOARROW_TYPE_DENSE_UNION:
-      return snprintf(out, n, "%s([%.*s])", type_string,
-                      (int)schema_view->union_type_ids.n_bytes,
-                      schema_view->union_type_ids.data);
+      return snprintf(out, n, "%s([%s])", type_string, schema_view->union_type_ids);
     default:
       return snprintf(out, n, "%s", type_string);
   }

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -122,8 +122,7 @@ TEST(SchemaTest, SchemaTestInitNestedStruct) {
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeStruct(&schema, 1), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
-  ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetName(schema.children[0], "item"), NANOARROW_OK);
 
   auto arrow_type = ImportType(&schema);
@@ -314,14 +313,16 @@ TEST(SchemaTest, SchemaInitUnion) {
   schema.release(&schema);
 
   ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 0), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 0),
+            NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+us:");
   EXPECT_EQ(schema.n_children, 0);
   // The zero-case union isn't supported by Arrow C++'s C data inferface implementation
   schema.release(&schema);
-  
+
   ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 1), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 1),
+            NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetName(schema.children[0], "u1"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+us:0");
@@ -332,30 +333,34 @@ TEST(SchemaTest, SchemaInitUnion) {
   EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(sparse_union({field("u1", int32())})));
 
   ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 2), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 2),
+            NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetName(schema.children[0], "u1"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetName(schema.children[1], "u2"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+us:0,1");
   EXPECT_EQ(schema.n_children, 2);
-  
+
   arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
-  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(sparse_union({field("u1", int32()), field("u2", utf8())})));
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(
+      sparse_union({field("u1", int32()), field("u2", utf8())})));
 
   ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_DENSE_UNION, 2), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_DENSE_UNION, 2),
+            NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetName(schema.children[0], "u1"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetName(schema.children[1], "u2"), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+ud:0,1");
   EXPECT_EQ(schema.n_children, 2);
-  
+
   arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
-  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(dense_union({field("u1", int32()), field("u2", utf8())})));
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(
+      dense_union({field("u1", int32()), field("u2", utf8())})));
 }
 
 TEST(SchemaTest, SchemaSetFormat) {
@@ -1192,9 +1197,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 8);
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 32);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
-  EXPECT_EQ(
-      std::string(schema_view.union_type_ids.data, schema_view.union_type_ids.n_bytes),
-      std::string("0"));
+  EXPECT_EQ(std::string(schema_view.union_type_ids), std::string("0"));
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "dense_union([0])<col: int32>");
   schema.release(&schema);
 
@@ -1208,9 +1211,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 8);
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 0);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
-  EXPECT_EQ(
-      std::string(schema_view.union_type_ids.data, schema_view.union_type_ids.n_bytes),
-      std::string("0"));
+  EXPECT_EQ(std::string(schema_view.union_type_ids), std::string("0"));
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "sparse_union([0])<col: int32>");
   schema.release(&schema);
 }

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -1235,6 +1235,20 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnionErrors) {
                "Error parsing schema->format: Expected union format string "
                "+us:<type_ids> or +ud:<type_ids> but found '+us'");
 
+  // bad type_ids (wrong number of children)
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:0"), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error),
+               "Error parsing schema->format: Expected union type_ids parameter to be a "
+               "comma-separated list of 0 values between 0 and 127 but found '0'");
+
+  // bad type_ids (not comma separated integers)
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:,"), NANOARROW_OK);
+  EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error),
+               "Error parsing schema->format: Expected union type_ids parameter to be a "
+               "comma-separated list of 0 values between 0 and 127 but found ','");
+
   schema.release(&schema);
 }
 

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -1197,7 +1197,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 8);
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 32);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
-  EXPECT_EQ(std::string(schema_view.union_type_ids), std::string("0"));
+  EXPECT_STREQ(schema_view.union_type_ids, "0");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "dense_union([0])<col: int32>");
   schema.release(&schema);
 
@@ -1211,7 +1211,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 8);
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 0);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
-  EXPECT_EQ(std::string(schema_view.union_type_ids), std::string("0"));
+  EXPECT_STREQ(schema_view.union_type_ids, "0");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "sparse_union([0])<col: int32>");
   schema.release(&schema);
 }


### PR DESCRIPTION
Adds support for dense and sparse unions in `ArrowArrayAppendNull()` and `ArrowArrayFinishUnionElement()` for #73. Some things I'm not sure about:

- Do we need to support non-standard union IDs in append mode? I don't have a good example of a Union with non-standard TypeIDs on hand and I'm still fuzy on the correct behaviour there.
- Am I constructing the Sparse Union from C++ properly? It seems like I have to manually append to each child which I didn't expect to have to do.
- Is there anything else about Unions that I'm missing?