### PR TITLE
[C] Add read support for unions in the `ArrowArrayView`

### DIFF
--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -540,10 +540,12 @@ ArrowErrorCode ArrowArrayViewInitFromSchema(struct ArrowArrayView* array_view,
       return ENOMEM;
     }
 
+    memset(array_view->union_type_id_map, -1, 256);
     int8_t n_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids,
-                                                array_view->union_type_id_map);
-    for (int8_t i = 0; i < n_type_ids; i++) {
-      array_view->union_type_id_map[128 + array_view->union_type_id_map[i]] = i;
+                                                array_view->union_type_id_map + 128);
+    for (int8_t child_index = 0; child_index < n_type_ids; child_index++) {
+      int8_t type_id = array_view->union_type_id_map[128 + child_index];
+      array_view->union_type_id_map[type_id] = child_index;
     }
   }
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -647,6 +647,18 @@ static inline int8_t ArrowArrayViewUnionChildIndex(struct ArrowArrayView* array_
   }
 }
 
+static inline int64_t ArrowArrayViewUnionChildOffset(struct ArrowArrayView* array_view,
+                                                     int64_t i) {
+  switch (array_view->storage_type) {
+    case NANOARROW_TYPE_DENSE_UNION:
+      return array_view->buffer_views[1].data.as_int32[i];
+    case NANOARROW_TYPE_SPARSE_UNION:
+      return i;
+    default:
+      return -1;
+  }
+}
+
 static inline int64_t ArrowArrayViewGetIntUnsafe(struct ArrowArrayView* array_view,
                                                  int64_t i) {
   struct ArrowBufferView* data_view = &array_view->buffer_views[1];

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -619,10 +619,31 @@ static inline int8_t ArrowArrayViewIsNull(struct ArrowArrayView* array_view, int
       return 0x01;
     case NANOARROW_TYPE_DENSE_UNION:
     case NANOARROW_TYPE_SPARSE_UNION:
-      // Not supported yet
-      return -1;
+      // Unions are "never null" in Arrow land
+      return 0x00;
     default:
       return validity_buffer != NULL && !ArrowBitGet(validity_buffer, i);
+  }
+}
+
+static inline int8_t ArrowArrayViewUnionTypeId(struct ArrowArrayView* array_view,
+                                               int64_t i) {
+  switch (array_view->storage_type) {
+    case NANOARROW_TYPE_DENSE_UNION:
+    case NANOARROW_TYPE_SPARSE_UNION:
+      return array_view->buffer_views[0].data.as_int8[i];
+    default:
+      return -1;
+  }
+}
+
+static inline int8_t ArrowArrayViewUnionChildIndex(struct ArrowArrayView* array_view,
+                                                   int64_t i) {
+  int8_t type_id = ArrowArrayViewUnionTypeId(array_view, i);
+  if (array_view->union_type_id_map == NULL) {
+    return type_id;
+  } else {
+    return array_view->union_type_id_map[type_id];
   }
 }
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1653,6 +1653,16 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 1), 0);
 
   ArrowArrayViewReset(&array_view);
+
+  // Check the raw mapping in the array view for numbers that are easier to check
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+ud:6,2"), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
+  EXPECT_EQ(array_view.union_type_id_map[6], 0);
+  EXPECT_EQ(array_view.union_type_id_map[2], 1);
+  EXPECT_EQ(array_view.union_type_id_map[128 + 0], 6);
+  EXPECT_EQ(array_view.union_type_id_map[128 + 1], 2);
+
+  ArrowArrayViewReset(&array_view);
   schema.release(&schema);
   array.release(&array);
 }

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1594,6 +1594,69 @@ TEST(ArrayTest, ArrayViewTestFixedSizeListArray) {
   array.release(&array);
 }
 
+TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
+  struct ArrowArrayView array_view;
+  struct ArrowArray array;
+  struct ArrowSchema schema;
+
+  // Build a simple union with one int and one string
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_DENSE_UNION, 2),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
+
+  // The ArrayView for a union could in theroy be created without a schema,
+  // in which case the type_ids are assumed to equal child indices
+  ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_DENSE_UNION);
+  ASSERT_EQ(ArrowArrayViewAllocateChildren(&array_view, 2), NANOARROW_OK);
+  ArrowArrayViewInitFromType(array_view.children[0], NANOARROW_TYPE_INT32);
+  ArrowArrayViewInitFromType(array_view.children[1], NANOARROW_TYPE_STRING);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 1), 1);
+
+  ArrowArrayViewReset(&array_view);
+
+  // The test schema explicitly sets the type_ids 0,1 and this should work too
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 1), 1);
+
+  ArrowArrayViewReset(&array_view);
+
+  // Reversing the type ids should result in the same type ids but
+  // reversed child indices
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+ud:1,0"), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 1);
+  EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 1), 0);
+
+  ArrowArrayViewReset(&array_view);
+  schema.release(&schema);
+  array.release(&array);
+}
+
 template <typename TypeClass>
 void TestGetFromNumericArrayView() {
   struct ArrowArray array;

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -911,6 +911,10 @@ static inline int8_t ArrowArrayViewUnionTypeId(struct ArrowArrayView* array_view
 /// \brief Get the child index of a union array element
 static inline int8_t ArrowArrayViewUnionChildIndex(struct ArrowArrayView* array_view, int64_t i);
 
+/// \brief Get the index to use into the relevant union child array
+static inline int64_t ArrowArrayViewUnionChildOffset(struct ArrowArrayView* array_view,
+                                                     int64_t i);
+
 /// \brief Get an element in an ArrowArrayView as an integer
 ///
 /// This function does not check for null values, that values are actually integers, or

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -905,6 +905,12 @@ void ArrowArrayViewReset(struct ArrowArrayView* array_view);
 /// \brief Check for a null element in an ArrowArrayView
 static inline int8_t ArrowArrayViewIsNull(struct ArrowArrayView* array_view, int64_t i);
 
+/// \brief Get the type id of a union array element
+static inline int8_t ArrowArrayViewUnionTypeId(struct ArrowArrayView* array_view, int64_t i);
+
+/// \brief Get the child index of a union array element
+static inline int8_t ArrowArrayViewUnionChildIndex(struct ArrowArrayView* array_view, int64_t i);
+
 /// \brief Get an element in an ArrowArrayView as an integer
 ///
 /// This function does not check for null values, that values are actually integers, or

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -498,6 +498,13 @@ struct ArrowArrayView {
 
   /// \brief Pointers to views of this array's children
   struct ArrowArrayView** children;
+
+  /// \brief Union type id to child index mapping
+  ///
+  /// If storage_type is a union type, a 256-byte ArrowMalloc()ed buffer
+  /// such that child_index == union_type_id_map[type_id] and
+  /// type_id == union_type_id_map[128 + child_index]
+  int8_t* union_type_id_map;
 };
 
 // Used as the private data member for ArrowArrays allocated here and accessed


### PR DESCRIPTION
Ok, I think this has everything one would need to inspect union types without having to remember the spec. Given a valid union schema, one can:

```c
ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr);
int8_t child_index = ArrowArrayViewUnionChildIndex(&array_view, i);
int64_t child_offset = ArrowArrayViewUnionChildOffset(&array_view, i);
// Figure out which accessor you need. If it's an int, you could
struct ArrowArrayView* child = array_view.children[child_index];
ArrowArrayViewGetIntUnsafe(child, child_offset);
```

Fixes #73.