### PR TITLE
[CI] Prefetch/cache R package testing dependencies

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,10 +27,8 @@ on:
       - '.github/workflows/build-and-test.yaml'
       - 'src/nanoarrow/**'
 
-name: Build and Test C Library
-
 jobs:
-  build-and-test:
+  build-and-test-c:
 
     runs-on: ubuntu-latest
 
@@ -142,48 +140,8 @@ jobs:
         with:
           directory: build/cov
 
-  R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-    name: R / ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
-
-    steps:
-      - uses: actions/checkout@v2
-
-      # Probably a better way to do this, but for now do the vendor step manually
-      - name: Vendor nanoarrow into the R package
-        run: |
-          cd r
-          ./configure
-
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-          working-directory: r
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          working-directory: r
-
-  deploy:
-    name: Bundle and deploy
-    needs: build-and-test
+  bundle-dist:
+    needs: build-and-test-c
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: test-c
+
 on:
   push:
     branches:
@@ -28,7 +30,7 @@ on:
       - 'src/nanoarrow/**'
 
 jobs:
-  build-and-test-c:
+  test-c:
 
     runs-on: ubuntu-latest
 
@@ -141,7 +143,7 @@ jobs:
           directory: build/cov
 
   bundle-dist:
-    needs: build-and-test-c
+    needs: test-c
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,19 @@
-name: Build documentation
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 on:
   push:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: docs
+
 on:
   push:
     branches:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/docs.yaml'
+      - 'src/nanoarrow/**'
+      - 'r/**'
 
 jobs:
   docs:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Build and run examples
-
 on:
   push:
     branches:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: examples
+
 on:
   push:
     branches:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -24,6 +24,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'CMakeLists.txt'
+      - '.github/workflows/build-and-test.yaml'
+      - 'src/nanoarrow/**'
 
 jobs:
   examples:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -26,7 +26,7 @@ on:
       - main
     paths:
       - 'CMakeLists.txt'
-      - '.github/workflows/build-and-test.yaml'
+      - '.github/workflows/examples.yaml'
       - 'src/nanoarrow/**'
 
 jobs:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: test-python
+
 on:
   push:
     branches:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Test Python
-
 on:
   push:
     branches:

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: test-r
+
 on:
   push:
     branches: main

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -17,14 +17,13 @@
 
 on:
   push:
-    branches: [main, master]
+    branches: main
   pull_request:
-    branches: [main, master]
+    branches: main
     paths:
       - '.github/workflows/r-check.yaml'
+      - 'src/nanoarrow/**'
       - 'r/**'
-
-name: R-CMD-check
 
 jobs:
 
@@ -79,11 +78,3 @@ jobs:
           upload-snapshots: true
           working-directory: r
 
-      # Something about Arrow installed via GHA doesn't work with valgrind
-      # so we can't run it on CI :(
-      # - name: Run valgrind on r-devel
-      #   if: matrix.config.r == 'devel'
-      #   run: |
-      #     cd r
-      #     R CMD INSTALL .
-      #     echo "testthat::test_local()" | R --no-save -d "valgrind --tool=memcheck --leak-check=full --suppressions ../valgrind.supp"

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -31,7 +31,7 @@ jobs:
 
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
-    name: R / ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
       fail-fast: false

--- a/.github/workflows/verify-source.yaml
+++ b/.github/workflows/verify-source.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           needs: check
-          working-directory: r
+          working-directory: src/r
 
       - name: Run dev/release/verify-release-candidate.sh
         run: |

--- a/.github/workflows/verify-source.yaml
+++ b/.github/workflows/verify-source.yaml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: verify-rc
+
 on:
   push:
     branches:
@@ -23,12 +25,8 @@ on:
     branches:
       - main
     paths:
-      - 'CMakeLists.txt'
       - '.github/workflows/verify-source.yaml'
       - 'dev/release/verify-release-candidate.sh'
-      - 'src/nanoarrow/**'
-
-name: Release Candidate Verification
 
 jobs:
   verify-rc:

--- a/.github/workflows/verify-source.yaml
+++ b/.github/workflows/verify-source.yaml
@@ -58,6 +58,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+          working-directory: r
 
       - name: Run dev/release/verify-release-candidate.sh
         run: |


### PR DESCRIPTION
Installing R dependencies takes the majority of the time in the verification action...using the dependencies action will install them in advance and maintain a cache so that this hopefully doesn't take as long.