### PR TITLE
[R] Make sure `remotes::install_github()` works on Windows

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Provides an R interface to the 'nanoarrow' C library and the
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 URL: https://github.com/apache/arrow-nanoarrow
 BugReports: https://github.com/apache/arrow-nanoarrow/issues
 Suggests: 

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -45,7 +45,7 @@ You can install the development version of nanoarrow from [GitHub](https://githu
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-nanoarrow/r", build = FALSE)
+remotes::install_github("apache/arrow-nanoarrow/r")
 ```
 
 If you can load the package, you're good to go!

--- a/r/README.md
+++ b/r/README.md
@@ -38,7 +38,7 @@ You can install the development version of nanoarrow from
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-nanoarrow/r", build = FALSE)
+remotes::install_github("apache/arrow-nanoarrow/r")
 ```
 
 If you can load the package, you’re good to go!
@@ -101,7 +101,7 @@ as_nanoarrow_array(1:5)
 #>  $ offset    : int 0
 #>  $ buffers   :List of 2
 #>   ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
-#>   ..$ :<nanoarrow_buffer_data_int32[20 b] at 0x135d13c28>
+#>   ..$ :<nanoarrow_buffer_data_int32[20 b] at 0x10d316a68>
 #>  $ dictionary: NULL
 #>  $ children  : list()
 as_nanoarrow_array(arrow::record_batch(col1 = c(1.1, 2.2)))
@@ -118,7 +118,7 @@ as_nanoarrow_array(arrow::record_batch(col1 = c(1.1, 2.2)))
 #>   .. ..$ offset    : int 0
 #>   .. ..$ buffers   :List of 2
 #>   .. .. ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
-#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x13604f0b8>
+#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x11e534bb8>
 #>   .. ..$ dictionary: NULL
 #>   .. ..$ children  : list()
 #>  $ dictionary: NULL
@@ -193,7 +193,7 @@ stream$get_next()
 #>   .. ..$ offset    : int 0
 #>   .. ..$ buffers   :List of 2
 #>   .. .. ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
-#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x136de3538>
+#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x119c35838>
 #>   .. ..$ dictionary: NULL
 #>   .. ..$ children  : list()
 #>  $ dictionary: NULL
@@ -211,7 +211,7 @@ stream$get_next()
 #>   .. ..$ offset    : int 0
 #>   .. ..$ buffers   :List of 2
 #>   .. .. ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
-#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x136de3178>
+#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x119c710b8>
 #>   .. ..$ dictionary: NULL
 #>   .. ..$ children  : list()
 #>  $ dictionary: NULL

--- a/r/configure.win
+++ b/r/configure.win
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Just call the original configure script
+./configure


### PR DESCRIPTION
Before this PR, `remotes::install_github("apache/arrow-nanoarrow/r")` and `pak::pak("apache/arrow-nanoarrow/r")` would fail on Windows because on Windows `configure` isn't run by RTools even for source builds ( https://github.com/pola-rs/r-polars/pull/5#issuecomment-1378755004 ).