### PR TITLE
chore(r): Use cleanup instead of configure to vendor nanoarrow, remove hacks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,13 +35,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      # Probably a better way to do this, but for now do the vendor step manually
-      - name: Vendor nanoarrow into the R package
-        run: |
-          cd r
-          ./configure
-      
+      - uses: actions/checkout@v2      
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -61,12 +61,6 @@ jobs:
         if: matrix.config.r == 'devel'
         run: sudo apt-get install -y valgrind
 
-      # Probably a better way to do this, but for now do the vendor step manually
-      - name: Vendor nanoarrow into the R package
-        run: |
-          cd r
-          bash configure
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/r/cleanup
+++ b/r/cleanup
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This script runs on R CMD build, which means it's the right place
+# to vendor nanoarrow if we're in the nanoarrow repo. If we're not
+# in the nanoarrow repo, this script should do nothing since it
+# may also run in various capacities during R CMD INSTALL; however,
+# we *do* want it to run on R CMD INSTALL *if* we're in the repo
+# (so that the C library and the R package are always in sync).
+
+if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
+  echo "Bundling nanoarrow using cmake ../CMakeLists.txt"
+  rm -f src/nanoarrow.h src/nanoarrow.c
+  if [ -d "cmake" ]; then
+    rm -rf cmake
+  fi
+  mkdir cmake && cd cmake
+  cmake ../.. -DNANOARROW_BUNDLE=ON > output.txt
+  if [ $? -ne 0 ]; then
+    cat output.txt
+    exit 1
+  fi
+
+  cmake --build . && cmake --install . --prefix=../src
+  cd ..
+  rm -rf cmake
+  rm -f src/nanoarrow.hpp
+fi

--- a/r/cleanup
+++ b/r/cleanup
@@ -22,6 +22,8 @@
 # we *do* want it to run on R CMD INSTALL *if* we're in the repo
 # (so that the C library and the R package are always in sync).
 
+echo "cwd:" > ~/Desktop/pak-debug.txt
+
 if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
   # Check for cmake
   cmake --version
@@ -32,7 +34,7 @@ if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "
     cp ../dist/nanoarrow.c ../dist/nanoarrow.h src
     exit 0
   fi
-  
+
   echo "Bundling nanoarrow using cmake ../CMakeLists.txt"
   rm -f src/nanoarrow.h src/nanoarrow.c
   if [ -d "cmake" ]; then

--- a/r/cleanup
+++ b/r/cleanup
@@ -22,14 +22,6 @@
 # we *do* want it to run on R CMD INSTALL *if* we're in the repo
 # (so that the C library and the R package are always in sync).
 
-# Only do this once
-if [ ! -f ~/Desktop/pak-debug.txt ]; then
-  echo "cwd:" > ~/Desktop/pak-debug.txt
-  pwd >> ~/Desktop/pak-debug.txt
-  echo "ls .." >> ~/Desktop/pak-debug.txt
-  ls .. >> ~/Desktop/pak-debug.txt
-fi
-
 if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
   # Check for cmake
   cmake --version

--- a/r/cleanup
+++ b/r/cleanup
@@ -22,10 +22,13 @@
 # we *do* want it to run on R CMD INSTALL *if* we're in the repo
 # (so that the C library and the R package are always in sync).
 
-echo "cwd:" > ~/Desktop/pak-debug.txt
-pwd >> ~/Desktop/pak-debug.txt
-echo "ls .." >> ~/Desktop/pak-debug.txt
-ls .. >> ~/Desktop/pak-debug.txt
+# Only do this once
+if [ ! -f ~/Desktop/pak-debug.txt ]; then
+  echo "cwd:" > ~/Desktop/pak-debug.txt
+  pwd >> ~/Desktop/pak-debug.txt
+  echo "ls .." >> ~/Desktop/pak-debug.txt
+  ls .. >> ~/Desktop/pak-debug.txt
+fi
 
 if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
   # Check for cmake

--- a/r/cleanup
+++ b/r/cleanup
@@ -22,7 +22,7 @@
 # we *do* want it to run on R CMD INSTALL *if* we're in the repo
 # (so that the C library and the R package are always in sync).
 
-if [ -f "../src/nanoarrow/nanoarrow.h" ]; then
+if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
   echo "Bundling nanoarrow using cmake ../CMakeLists.txt"
   rm -f src/nanoarrow.h src/nanoarrow.c
   if [ -d "cmake" ]; then

--- a/r/cleanup
+++ b/r/cleanup
@@ -23,6 +23,16 @@
 # (so that the C library and the R package are always in sync).
 
 if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
+  # Check for cmake
+  cmake --version
+
+  # If there's no cmake, we can use ../dist/nanoarrow.c and ../dist/nanoarrow.h
+  if [ $? -ne 0 ]; then
+    echo "Copying bundled nanoarrow at ../dist"
+    cp ../dist/nanoarrow.c ../dist/nanoarrow.h src
+    exit 0
+  fi
+  
   echo "Bundling nanoarrow using cmake ../CMakeLists.txt"
   rm -f src/nanoarrow.h src/nanoarrow.c
   if [ -d "cmake" ]; then

--- a/r/cleanup
+++ b/r/cleanup
@@ -22,7 +22,7 @@
 # we *do* want it to run on R CMD INSTALL *if* we're in the repo
 # (so that the C library and the R package are always in sync).
 
-if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
+if [ -f "../src/nanoarrow/nanoarrow.h" ]; then
   echo "Bundling nanoarrow using cmake ../CMakeLists.txt"
   rm -f src/nanoarrow.h src/nanoarrow.c
   if [ -d "cmake" ]; then

--- a/r/cleanup
+++ b/r/cleanup
@@ -23,6 +23,9 @@
 # (so that the C library and the R package are always in sync).
 
 echo "cwd:" > ~/Desktop/pak-debug.txt
+pwd >> ~/Desktop/pak-debug.txt
+echo "ls .." >> ~/Desktop/pak-debug.txt
+ls .. >> ~/Desktop/pak-debug.txt
 
 if [ -f "../src/nanoarrow/nanoarrow.h" ] && [ -f "../CMakeLists.txt" ] && [ -f "../r/DESCRIPTION" ]; then
   # Check for cmake

--- a/r/cleanup.win
+++ b/r/cleanup.win
@@ -15,14 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Try running the vendor step. This will do nothing if we're
-# not sitting in the nanoarrow repo.
+# See cleanup for details
 ./cleanup
-
-# Check that we have the vendored files we need to build the package
-if [ -f "src/nanoarrow.h" ] && [ -f "src/nanoarrow.c" ]; then
-  exit 0
-fi
-
-echo "Vendored src/nanoarrow.h and/or src/nanoarrow.c are missing"
-exit 1


### PR DESCRIPTION
There were a few awkward hacks that were required to get this to work before...basically, we don't want to keep a separate vendored copy of nanoarrow.c and nanoarrow.h in the R package, but we need it to compile the R package. That step used to happen in `configure`, but that only runs in "install" and we need this to run at "packaging" to work out of the box with existing tools for installing from github like pak and remotes. Credit to Gábor Csardi for pointing out that `cleanup` runs on R CMD build.