### PR TITLE
chore: Port release infrastructure from ADBC

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -131,7 +131,7 @@ jobs:
       - name: Compress docs
         shell: bash
         run: |
-          pushd nanoarrow/docs
+          pushd nanoarrow
           tar -czf ../docs.tgz docs
           popd
 
@@ -196,4 +196,4 @@ jobs:
           name: source
           retention-days: 7
           path: |
-            nanoarrow/nanoarrow_0.1.0.9000.tar.gz
+            nanoarrow/nanoarrow_0.0.0.9000.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -149,7 +149,7 @@ jobs:
         run: |
           sudo apt-get install doxygen
           python -m pip install --upgrade pip
-          pip install -r docs/requirements.txt
+          pip install -r nanoarrow/docs/requirements.txt
 
       - name: Run doxygen
         run: |

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -131,7 +131,7 @@ jobs:
       - name: Compress docs
         shell: bash
         run: |
-          pushd docs
+          pushd nanoarrow/docs
           tar -czf ../docs.tgz docs
           popd
 
@@ -178,22 +178,22 @@ jobs:
         with:
           extra-packages: any::pkgbuild
           needs: build
-          working-directory: r
+          working-directory: nanoarrow/r
 
       - name: Build R Source Package
         shell: bash
         run : |
           # Probably easiest to let bootstrap.R take care of ensuring
           # that the version in DESCRIPTION matches ${VERSION} here
-          pushd r
+          pushd nanoarrow/r
           ./configure
           popd
 
-          Rscript -e 'pkgbuild::build("r")'
+          Rscript -e 'pkgbuild::build("nanoarrow/r")'
 
       - uses: actions/upload-artifact@v3
         with:
           name: source
           retention-days: 7
           path: |
-            nanoarrow_0.1.0.9000.tar.gz
+            nanoarrow/nanoarrow_0.1.0.9000.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -126,13 +126,55 @@ jobs:
           echo "schedule: ${{ github.event.schedule }}"
           echo "ref: ${{ github.ref }}"
 
-      # Until there is a more formalized documentation build, the 'docs'
-      # are just the 'docs' source directory
+      # Probably a better way to do this, but for now do the vendor step manually
+      - name: Vendor nanoarrow into the R package
+        run: |
+          cd nanoarrow/r
+          ./configure
+
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+          working-directory: nanoarrow/r
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install doxygen
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Run doxygen
+        run: |
+          cd nanoarrow/src/apidoc
+          doxygen
+
+      - name: Regenerate index content from README
+        run: |
+          cd nanoarrow/docs
+          pandoc ../README.md --from markdown --to rst -s -o source/README_generated.rst
+
+      - name: Run sphinx
+        run: |
+          cd nanoarrow/docs
+          sphinx-build source _build/html
+
+      - name: Run pkgdown
+        run: pkgdown::build_site_github_pages("nanoarrow/r", dest_dir = "../docs/_build/html/r", new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
       - name: Compress docs
         shell: bash
         run: |
           pushd nanoarrow
-          tar -czf ../docs.tgz docs
+          tar --transform "s|docs/_build/html|nanoarrow-docs|" -czf ../docs.tgz docs/_build/html
           popd
 
       - name: Archive docs

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -193,6 +193,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: r-source
           retention-days: 7
           path: |
             nanoarrow/nanoarrow_0.0.0.9000.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -1,0 +1,198 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: packaging
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "CMakeLists.txt"
+      - "src/nanoarrow/**"
+      - "r/**"
+      - ".github/workflows/packaging.yml"
+
+  push:
+    # Automatically build on RC tags
+    branches-ignore:
+      - '**'
+    tags:
+      - 'apache-arrow-nanoarrow-*-rc*'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  source:
+    name: Source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
+
+      - name: Prepare version
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION=${GITHUB_REF_NAME#apache-arrow-nanoarrow-}
+            VERSION=${VERSION%-rc*}
+          else
+            VERSION=$(grep 'set(NANOARROW_VERSION' CMakeLists.txt | \
+                        grep -E -o '[0-9]+\.[0-9]+\.[0-9]+')
+            description=$(git describe \
+                            --always \
+                            --dirty \
+                            --long \
+                            --match "apache-arrow-nanoarrow-[0-9]*.*" \
+                            --tags)
+            case "${description}" in
+              # apache-arrow-nanoarrow-0.1.0-10-1234567-dirty
+              apache-arrow-nanoarrow-*)
+                # 10-1234567-dirty
+                distance="${description#apache-arrow-nanoarrow-*.*.*-}"
+                # 10-1234567
+                distance="${distance%-dirty}"
+                # 10
+                distance="${distance%-*}"
+                ;;
+              *)
+                distance=$(git log --format=oneline | wc -l)
+                ;;
+            esac
+            VERSION="${VERSION}.dev${distance}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create archive
+        shell: bash
+        run: |
+          dev/release/source_build.sh \
+            apache-arrow-nanoarrow-${VERSION} \
+            $(git log -n 1 --format=%h)
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: source
+          retention-days: 7
+          path: |
+            apache-arrow-nanoarrow-${{ env.VERSION }}.tar.gz
+
+  docs:
+    name: "Documentation"
+    runs-on: ubuntu-latest
+    needs:
+      - source
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: source
+
+      - name: Extract source archive
+        run: |
+          source_archive=$(echo apache-arrow-nanoarrow-*.tar.gz)
+          VERSION=${source_archive#apache-arrow-nanoarrow-}
+          VERSION=${VERSION%.tar.gz}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          tar xf apache-arrow-nanoarrow-${VERSION}.tar.gz
+          mv apache-arrow-nanoarrow-${VERSION} nanoarrow
+
+      - name: Show inputs
+        shell: bash
+        run: |
+          echo "upload_artifacts: ${{ inputs.upload_artifacts }}"
+          echo "schedule: ${{ github.event.schedule }}"
+          echo "ref: ${{ github.ref }}"
+
+      # Until there is a more formalized documentation build, the 'docs'
+      # are just the 'docs' source directory
+      - name: Compress docs
+        shell: bash
+        run: |
+          pushd docs
+          tar -czf ../docs.tgz docs
+          popd
+
+      - name: Archive docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          retention-days: 2
+          path: |
+            docs.tgz
+
+  r:
+    name: "R"
+    runs-on: ubuntu-latest
+    needs:
+      - source
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: source
+
+      - name: Extract source archive
+        run: |
+          source_archive=$(echo apache-arrow-nanoarrow-*.tar.gz)
+          VERSION=${source_archive#apache-arrow-nanoarrow-}
+          VERSION=${VERSION%.tar.gz}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          tar xf apache-arrow-nanoarrow-${VERSION}.tar.gz
+          mv apache-arrow-nanoarrow-${VERSION} nanoarrow
+
+      - name: Show inputs
+        shell: bash
+        run: |
+          echo "upload_artifacts: ${{ inputs.upload_artifacts }}"
+          echo "schedule: ${{ github.event.schedule }}"
+          echo "ref: ${{ github.ref }}"
+
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgbuild
+          needs: build
+          working-directory: r
+
+      - name: Build R Source Package
+        shell: bash
+        run : |
+          # Probably easiest to let bootstrap.R take care of ensuring
+          # that the version in DESCRIPTION matches ${VERSION} here
+          pushd r
+          ./configure
+          popd
+
+          Rscript -e 'pkgbuild::build("r")'
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: source
+          retention-days: 7
+          path: |
+            nanoarrow_0.1.0.9000.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -25,7 +25,8 @@ on:
       - "CMakeLists.txt"
       - "src/nanoarrow/**"
       - "r/**"
-      - ".github/workflows/packaging.yml"
+      - "dev/release/**"
+      - ".github/workflows/packaging.yaml"
 
   push:
     # Automatically build on RC tags

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -193,7 +193,6 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: source
           retention-days: 7
           path: |
             nanoarrow/nanoarrow_0.0.0.9000.tar.gz

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -48,11 +48,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Update tags
-        shell: bash
-        run: |
-          git fetch --tags --force origin
-
       - name: Prepare version
         shell: bash
         run: |
@@ -218,16 +213,17 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgbuild
+          extra-packages: any::pkgbuild, any::desc
           needs: build
           working-directory: nanoarrow/r
 
       - name: Build R Source Package
         shell: bash
         run : |
-          # Probably easiest to let bootstrap.R take care of ensuring
-          # that the version in DESCRIPTION matches ${VERSION} here
           pushd nanoarrow/r
+          # If we're about to build a non-SNAPSHOT version, update the
+          # Version: field in DESCRIPTION
+          Rscript -e 'if (grepl("-SNAPSHOT$", Sys.getenv("VERSION"))) desc::desc_set(Version = Sys.getenv("VERSION"))'
           ./configure
           popd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# nanoarrow Changelog

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,5 @@
+Apache Arrow ADBC
+Copyright 2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
-Apache Arrow ADBC
-Copyright 2022 The Apache Software Foundation
+Apache Arrow nanoarrow
+Copyright 2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -21,19 +21,20 @@ set -ue
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ "$#" -ne 4 ]; then
-  echo "Usage: $0 <arrow-dir> <version> <next_version> <rc-num>"
-  echo "Usage: $0 ../arrow 0.1.0 1.0.0 0"
+if [ "$#" -ne 5 ]; then
+  echo "Usage: $0 <arrow-dir> <prev_veresion> <version> <next_version> <rc-num>"
+  echo "Usage: $0 ../arrow 0.1.0 0.2.0 0.3.0 0"
   exit 1
 fi
 
 . $SOURCE_DIR/utils-prepare.sh
 
 arrow_dir=$1
-version=$2
-next_version=$3
+prev_version=$2
+version=$3
+next_version=$4
 next_version_snapshot="${next_version}-SNAPSHOT"
-rc_number=$4
+rc_number=$5
 
 export ARROW_SOURCE="$(cd "${arrow_dir}" && pwd)"
 
@@ -54,7 +55,13 @@ fi
 
 echo "Updating changelog for $version"
 # Update changelog
-cz ch --incremental --unreleased-version "nanoarrow ${version}"
+# XXX: commitizen doesn't respect --tag-format with --incremental, so mimic
+# it by hand.
+(
+    echo ;
+    # Strip trailing blank line
+    printf '%s\n' "$(cz ch --dry-run --unreleased-version "nanoarrow ${version}" --start-rev apache-arrow-nanoarrow-${prev_version})"
+) >> ${SOURCE_DIR}/../../CHANGELOG.md
 git add ${SOURCE_DIR}/../../CHANGELOG.md
 git commit -m "chore: update CHANGELOG.md for $version"
 

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -ue
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <arrow-dir> <version> <next_version> <rc-num>"
+  echo "Usage: $0 ../arrow 0.1.0 1.0.0 0"
+  exit 1
+fi
+
+. $SOURCE_DIR/utils-prepare.sh
+
+arrow_dir=$1
+version=$2
+next_version=$3
+next_version_snapshot="${next_version}-SNAPSHOT"
+rc_number=$4
+
+export ARROW_SOURCE="$(cd "${arrow_dir}" && pwd)"
+
+release_candidate_tag="apache-arrow-nanoarrow-${version}-rc${rc_number}"
+
+if [[ $(git tag -l "${release_candidate_tag}") ]]; then
+    next_rc_number=$(($rc_number+1))
+    echo "Tag ${release_candidate_tag} already exists, so create a new release candidate:"
+    echo "1. Create or checkout maint-<version>."
+    echo "2. Execute the script again with bumped RC number."
+    echo "Commands:"
+    echo "   git checkout maint-${version}"
+    echo "   dev/release/01-prepare.sh ${version} ${next_version} ${next_rc_number}"
+    exit 1
+fi
+
+############################## Pre-Tag Commits ##############################
+
+echo "Updating changelog for $version"
+# Update changelog
+cz ch --incremental --unreleased-version "nanoarrow ${version}"
+git add ${SOURCE_DIR}/../../CHANGELOG.md
+git commit -m "chore: update CHANGELOG.md for $version"
+
+echo "Prepare release ${version} on tag ${release_candidate_tag}"
+
+update_versions "${version}" "${next_version}" "release"
+# --allow-empty required for RCs after the first
+git commit -m "chore: update versions for ${version}" --allow-empty
+
+######################### Tag the Release Candidate #########################
+
+git tag -a "${release_candidate_tag}" -m "nanoarrow ${version} RC ${rc_number}"
+
+echo "Created release candidate tag: ${release_candidate_tag}"
+echo "Push this tag before continuing!"

--- a/dev/release/02-sign.sh
+++ b/dev/release/02-sign.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eu
+
+main() {
+    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+    pushd "${source_top_dir}"
+
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: $0 <version> <rc-num>"
+        exit 1
+    fi
+
+    local -r version="$1"
+    local -r rc_number="$2"
+    local -r tag="apache-arrow-nanoarrow-${version}-rc${rc_number}"
+    local -r tarball="apache-arrow-nanoarrow-${version}"
+
+    : ${REPOSITORY:="apache/arrow-nanoarrow"}
+
+    if [[ ! -f "${source_dir}/.env" ]]; then
+        echo "You must create ${source_dir}/.env"
+        echo "You can use ${source_dir}/.env.example as a template"
+    fi
+
+    source "${source_dir}/.env"
+
+    header "Looking for GitHub Actions workflow on ${REPOSITORY}:${tag}"
+    local run_id=""
+    while [[ -z "${run_id}" ]]
+    do
+        echo "Waiting for run to start..."
+        run_id=$(gh run list \
+                    --repo "${REPOSITORY}" \
+                    --workflow=packaging.yaml \
+                    --json 'databaseId,event,headBranch,status' \
+                    --jq ".[] | select(.event == \"push\" and .headBranch == \"${tag}\") | .databaseId")
+        sleep 1
+    done
+
+    header "Found GitHub Actions workflow with ID: ${run_id}"
+    gh run watch --repo "${REPOSITORY}" --exit-status ${run_id}
+    gh run view --repo "${REPOSITORY}" "${run_id}"
+
+    header "Downloading assets from release"
+    local -r download_dir="packages/${tag}"
+    mkdir -p "${download_dir}"
+    gh release download \
+       "${tag}" \
+       --repo "${REPOSITORY}" \
+       --dir "${download_dir}" \
+       --skip-existing
+
+    header "Adding release notes"
+    local -r release_notes=$(cz ch --dry-run "${tag}" --unreleased-version "nanoarrow ${version}")
+    echo "${release_notes}"
+    gh release edit \
+       "${tag}" \
+       --repo "${REPOSITORY}" \
+       --notes "${release_notes}"
+
+    header "Upload signatures for source"
+    upload_asset_signatures "${tag}" $(find "${download_dir}" -type f \( -name 'apache-arrow-nanoarrow-*.tar.gz' \))
+
+    header "Upload signatures for R"
+    upload_asset_signatures "${tag}" $(find "${download_dir}" -type f \( -name 'nanoarrow_*.tar.gz' \))
+
+    header "Upload signatures for docs"
+    upload_asset_signatures "${tag}" "${download_dir}/docs.tgz"
+
+    popd
+}
+
+header() {
+    echo "============================================================"
+    echo "${1}"
+    echo "============================================================"
+}
+
+sign_asset() {
+    local -r asset="$1"
+    local -r sigfile="${asset}.asc"
+
+    if [[ -f "${sigfile}" ]]; then
+        if env LANG=C gpg --verify "${sigfile}" "${asset}" >/dev/null 2>&1; then
+            echo "Valid signature at $(basename "${sigfile}"), skipping"
+            return
+        fi
+        rm "${sigfile}"
+    fi
+
+    gpg \
+        --armor \
+        --detach-sign \
+        --local-user "${GPG_KEY_ID}" \
+        --output "${sigfile}" \
+        "${asset}"
+    echo "Generated $(basename "${sigfile}")"
+}
+
+sum_asset() {
+    local -r asset="$1"
+    local -r sumfile="${asset}.sha512"
+
+    local -r digest=$(cd $(dirname "${asset}"); shasum --algorithm 512 $(basename "${asset}"))
+    if [[ -f "${sumfile}" ]]; then
+        if [[ "${digest}" = $(cat "${sumfile}") ]]; then
+            echo "Valid digest at $(basename "${sumfile}"), skipping"
+            return
+        fi
+    fi
+
+    echo "${digest}" > "${sumfile}"
+    echo "Generated $(basename "${sumfile}")"
+}
+
+upload_asset_signatures() {
+    local -r tag="${1}"
+    shift 1
+
+    local -r assets=("$@")
+
+    for asset in "${assets[@]}"; do
+        sign_asset "${asset}"
+        sum_asset "${asset}"
+    done
+
+    gh release upload \
+       --repo "${REPOSITORY}" \
+       "${tag}" \
+       "${assets[@]/%/.asc}" \
+       "${assets[@]/%/.sha512}"
+}
+
+main "$@"

--- a/dev/release/03-source.sh
+++ b/dev/release/03-source.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eu
+
+main() {
+    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: $0 <version> <rc-num>"
+        exit 1
+    fi
+    local -r version="$1"
+    local -r rc_number="$2"
+    local -r tag="apache-arrow-nanoarrow-${version}-rc${rc_number}"
+    local -r tarball="apache-arrow-nanoarrow-${version}.tar.gz"
+
+    : ${REPOSITORY:="apache/arrow-nanoarrow"}
+
+    if [[ ! -f "${source_dir}/.env" ]]; then
+        echo "You must create ${source_dir}/.env"
+        echo "You can use ${source_dir}/.env.example as a template"
+    fi
+
+    source "${source_dir}/.env"
+
+    header "Downloading assets from release"
+    local -r download_dir="packages/${tag}"
+    mkdir -p "${download_dir}"
+    gh release download \
+       "${tag}" \
+       --dir "${download_dir}" \
+       --pattern "${tarball}*" \
+       --repo "${REPOSITORY}" \
+       --skip-existing
+
+    echo "Uploading to dist.apache.org"
+
+    # check out the arrow RC folder
+    svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow tmp
+
+    # add the release candidate for the tag
+    mkdir -p "tmp/${tag}"
+
+    # copy the rc tarball into the tmp dir
+    cp ${download_dir}/${tarball}* "tmp/${tag}"
+
+    # commit to svn
+    svn add "tmp/${tag}"
+    svn ci -m "Apache Arrow nanoarrow ${version} RC${rc_number}" "tmp/${tag}"
+
+    # clean up
+    rm -rf tmp
+
+    echo "Uploaded at https://dist.apache.org/repos/dist/dev/arrow/${tag}"
+
+    popd
+}
+
+main "$@"

--- a/dev/release/check-rat-report.py
+++ b/dev/release/check-rat-report.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+##############################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+##############################################################################
+import fnmatch
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+if len(sys.argv) != 3:
+    sys.stderr.write("Usage: %s exclude_globs.lst rat_report.xml\n" % sys.argv[0])
+    sys.exit(1)
+
+exclude_globs_filename = sys.argv[1]
+xml_filename = sys.argv[2]
+
+globs = [line.strip() for line in open(exclude_globs_filename, "r")]
+
+tree = ET.parse(xml_filename)
+root = tree.getroot()
+resources = root.findall("resource")
+
+all_ok = True
+for r in resources:
+    approvals = r.findall("license-approval")
+    if not approvals or approvals[0].attrib["name"] == "true":
+        continue
+    clean_name = re.sub("^[^/]+/", "", r.attrib["name"])
+    excluded = False
+    for g in globs:
+        if fnmatch.fnmatch(clean_name, g):
+            excluded = True
+            break
+    if not excluded:
+        sys.stdout.write(
+            "NOT APPROVED: %s (%s): %s\n"
+            % (clean_name, r.attrib["name"], approvals[0].attrib["name"])
+        )
+        all_ok = False
+
+if not all_ok:
+    sys.exit(1)
+
+print("OK")
+sys.exit(0)

--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eu
+
+main() {
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: $0 <version> <rc-num>"
+        exit 1
+    fi
+    local -r version="$1"
+    local -r rc_number="$2"
+    local -r tag="apache-arrow-nanoarrow-${version}-rc${rc_number}"
+
+    rc_id="apache-arrow-nanoarrow-${version}-rc${rc_number}"
+    release_id="apache-arrow-nanoarrow-${version}"
+    echo "Copying dev/ to release/"
+    svn \
+        cp \
+        -m "Apache Arrow nanoarrow ${version}" \
+        https://dist.apache.org/repos/dist/dev/arrow/${rc_id} \
+        https://dist.apache.org/repos/dist/release/arrow/${release_id}
+
+    echo "Create final tag"
+    git tag -a "apache-arrow-nanoarrow-${version}" -m "nanoarrow ${version}" "${tag}^{}"
+
+    echo "Success! The release is available here:"
+    echo "  https://dist.apache.org/repos/dist/release/arrow/${release_id}"
+    echo "Please push the tag apache-arrow-nanoarrow-${version}!"
+}
+
+main "$@"

--- a/dev/release/post-02-bump-versions.sh
+++ b/dev/release/post-02-bump-versions.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -ue
+
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <arrow-dir> <version> <next_version>"
+  echo "Usage: $0 ../arrow 0.1.0 1.0.0"
+  exit 1
+fi
+
+. $SOURCE_DIR/utils-prepare.sh
+
+arrow_dir=$1
+version=$2
+next_version=$3
+next_version_snapshot="${next_version}-SNAPSHOT"
+
+export ARROW_SOURCE="$(cd "${arrow_dir}" && pwd)"
+
+########################## Update Snapshot Version ##########################
+
+git fetch --all --prune --tags --force -j$(nproc)
+git switch main
+git rebase apache/main
+
+echo "Updating versions for ${next_version_snapshot}"
+update_versions "${version}" "${next_version}" "snapshot"
+git commit -m "chore: update versions for ${next_version_snapshot}"
+echo "Bumped versions on branch."
+
+############################# Update Changelog ##############################
+
+git checkout apache-arrow-nanoarrow-${version} -- CHANGELOG.md
+git commit -m "chore: update changelog for ${version}"
+echo "Updated changelog on branch."
+
+echo "Pushing changes to apache/arrow-nanoarrow:main"
+git push apache main

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -1,0 +1,6 @@
+*.json
+dev/release/rat_exclude_files.txt
+filtered_rat.txt
+rat.txt
+r/DESCRIPTION
+r/NAMESPACE

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -5,3 +5,6 @@ filtered_rat.txt
 rat.txt
 r/DESCRIPTION
 r/NAMESPACE
+r/.Rbuildignore
+r/nanoarrow.Rproj
+*.Rd

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -1,4 +1,5 @@
 *.json
+*.json.example
 dev/release/rat_exclude_files.txt
 filtered_rat.txt
 rat.txt

--- a/dev/release/run-rat.sh
+++ b/dev/release/run-rat.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+RAT_VERSION=0.13
+
+# download apache rat
+if [ ! -f apache-rat-${RAT_VERSION}.jar ]; then
+  curl -s https://repo1.maven.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar > apache-rat-${RAT_VERSION}.jar
+fi
+
+RAT="java -jar apache-rat-${RAT_VERSION}.jar -x "
+
+RELEASE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+
+# generate the rat report
+$RAT $1 > rat.txt
+python $RELEASE_DIR/check-rat-report.py $RELEASE_DIR/rat_exclude_files.txt rat.txt > filtered_rat.txt
+cat filtered_rat.txt
+UNAPPROVED=`cat filtered_rat.txt  | grep "NOT APPROVED" | wc -l`
+
+if [ "0" -eq "${UNAPPROVED}" ]; then
+  echo "No unapproved licenses"
+else
+  echo "${UNAPPROVED} unapproved licences. Check rat report: rat.txt"
+  exit 1
+fi

--- a/dev/release/source_build.sh
+++ b/dev/release/source_build.sh
@@ -49,6 +49,10 @@ main() {
     # Remove components that are not yet ready for packaging
     rm -rf "${base_name}/extensions"
     rm -rf "${base_name}/python"
+    rm -rf "${base_name}/dist/flatcc"
+    rm -f "${base_name}/dist/flatcc.c"
+    rm -f "${base_name}/dist/nanoarrow_ipc.c"
+    rm -f "${base_name}/dist/nanoarrow_ipc.h"
 
     # Create new tarball
     tar czf "${tar_ball}" "${base_name}/"

--- a/dev/release/source_build.sh
+++ b/dev/release/source_build.sh
@@ -46,6 +46,10 @@ main() {
     cp -R -L "${base_name}.tmp" "${base_name}"
     rm -rf "${base_name}.tmp/"
 
+    # Remove components that are not yet ready for packaging
+    rm -rf "${base_name}/extensions"
+    rm -rf "${base_name}/python"
+
     # Create new tarball
     tar czf "${tar_ball}" "${base_name}/"
     rm -rf "${base_name}/"

--- a/dev/release/source_build.sh
+++ b/dev/release/source_build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eu
+
+main() {
+    local -r source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local -r source_top_dir="$(cd "${source_dir}/../../" && pwd)"
+
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: $0 <base-name> <revision>"
+        echo "Usage: $0 apache-arrow-nanoarrow-1.0.0 1234567"
+        exit 1
+    fi
+    local -r base_name="$1"
+    local -r revision="$2"
+
+    echo "Using commit ${revision}"
+
+    local -r tar_ball="${base_name}.tar.gz"
+
+    pushd "${source_top_dir}"
+
+    rm -rf "${base_name}/"
+    git archive "${revision}" --prefix "${base_name}/" | tar xf -
+
+    # Resolve all hard and symbolic links
+    rm -rf "${base_name}.tmp/"
+    mv "${base_name}/" "${base_name}.tmp/"
+    cp -R -L "${base_name}.tmp" "${base_name}"
+    rm -rf "${base_name}.tmp/"
+
+    # Create new tarball
+    tar czf "${tar_ball}" "${base_name}/"
+    rm -rf "${base_name}/"
+
+    # check licenses
+    "${source_top_dir}/dev/release/run-rat.sh" "${tar_ball}"
+
+    echo "Commit SHA1: ${revision}"
+
+    popd
+}
+
+main "$@"

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+NANOARROW_DIR="${SOURCE_DIR}/../.."
+
+update_versions() {
+  local base_version=$1
+  local next_version=$2
+  local type=$3
+
+  case ${type} in
+    release)
+      local version=${base_version}
+      local conda_version=${base_version}
+      local docs_version=${base_version}
+      ;;
+    snapshot)
+      local version=${next_version}-SNAPSHOT
+      local conda_version=${next_version}
+      local docs_version="${next_version} (dev)"
+      ;;
+  esac
+  local major_version=${version%%.*}
+
+  pushd "${NANOARROW_DIR}"
+  sed -i.bak -E "s/set\(NANOARROW_VERSION \".+\"\)/set(NANOARROW_VERSION \"${version}\")/g" CMakeLists.txt
+  rm CMakeLists.txt
+  git add CMakeLists.txt
+  popd
+
+  pushd "${NANOARROW_DIR}/r"
+  Rscript -e "desc::desc_set(Version = '${base_version}.9000')"
+  popd
+}
+
+set_resolved_issues() {
+    # TODO: this needs to work with open milestones
+    local -r version="${1}"
+    local -r milestone_info=$(gh api \
+                                 /repos/apache/arrow-nanoarrow/milestones \
+                                 -X GET \
+                                 -F state=all \
+                                 --jq ".[] | select(.title | test(\"nanoarrow ${version}\$\"))")
+    local -r milestone_number=$(echo "${milestone_info}" | jq -r '.number')
+
+    local -r graphql_query="query {
+    repository(owner: \"apache\", name: \"arrow-nanoarrow\") {
+        milestone(number: ${milestone_number}) {
+            issues(states: CLOSED) {
+                totalCount
+            }
+        }
+    }
+}
+"
+
+    export MILESTONE_URL=$(echo "${milestone_info}" | jq -r '.html_url')
+    export RESOLVED_ISSUES=$(gh api graphql \
+                            -f query="${graphql_query}" \
+                            --jq '.data.repository.milestone.issues.totalCount')
+}

--- a/r/.covrignore
+++ b/r/.covrignore
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 src/nanoarrow.c
 src/nanoarrow.h

--- a/r/.gitignore
+++ b/r/.gitignore
@@ -1,4 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 .Rproj.user
 .Rhistory
 docs
-../docs/_build/html

--- a/r/R/altrep.R
+++ b/r/R/altrep.R
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # For testing the altrep chr conversion
 nanoarrow_altrep_chr <- function(array) {

--- a/r/R/type.R
+++ b/r/R/type.R
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 #' Create type objects
 #'

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 url: ~
 template:
   bootstrap: 5

--- a/r/src/pointers_cpp.cc
+++ b/r/src/pointers_cpp.cc
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include <cstring>
 #include <string>

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 test_that("nanoarrow_altrep_chr() returns NULL for unsupported types", {
   expect_null(nanoarrow_altrep_chr(as_nanoarrow_array(1:10)))

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 test_that("type constructors for parameter-free types work", {
   # Some of these types have parameters but also have default values


### PR DESCRIPTION
Closes #95.

I don't think this is *everything* that is needed for release but I think it is close! There is still a few features that are needed in the R package before a release candidate can go out, but I want to make sure that enough of the infrastructure is in place that generating the release candidate isn't the hold up.