### PR TITLE
fix: make sure bundled nanoarrow is also valid C++

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,9 +40,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {label: default-build}
-          - {label: namespaced-build}
-          - {label: bundled-build}
+          - {label: default-build, cmake_args: "-DNANOARROW_CODE_COVERAGE=ON"}
+          - {label: namespaced-build, cmake_args: "-DNANOARROW_NAMESPACE=SomeUserNamespace"}
+          - {label: bundled-build, cmake_args: "-DNANOARROW_BUNDLE=ON"}
+          - {label: bundled-cpp-build, cmake_args: "-DNANOARROW_BUNDLE=ON -DNANOARROW_BUNDLE_AS_CPP=ON"}
 
     steps:
       - name: Checkout repo
@@ -60,34 +61,13 @@ jobs:
           sudo apt-get install -y -V libarrow-dev
           rm apache-arrow-apt-*.deb
 
-      - name: Build nanoarrow (default)
-        if: matrix.config.label == 'default-build'
+      - name: Build nanoarrow
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_CODE_COVERAGE=ON -DNANOARROW_BUILD_TESTS=ON
-          cmake --build .
-
-      - name: Build nanoarrow (namespaced)
-        if: matrix.config.label == 'namespaced-build'
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
-          sudo ldconfig
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_CODE_COVERAGE=ON -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_NAMESPACE=SomeUserNamespace
-          cmake --build .
-
-      - name: Build nanoarrow (bundled)
-        if: matrix.config.label == 'bundled-build'
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
-          sudo ldconfig
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_CODE_COVERAGE=ON -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_BUNDLE=ON
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_BUILD_TESTS=ON ${{ matrix.config.cmake_args }}
           cmake --build .
 
       - name: Check for non-namespaced symbols in namespaced build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(NANOARROW_VERSION_PATCH "${nanoarrow_VERSION_PATCH}")
 
 option(NANOARROW_BUILD_TESTS "Build tests" OFF)
 option(NANOARROW_BUNDLE "Create bundled nanoarrow.h and nanoarrow.c" OFF)
+option(NANOARROW_BUNDLE_AS_CPP "Bundle nanoarrow source file as nanoarrow.cc" OFF)
 option(NANOARROW_NAMESPACE "A prefix for exported symbols" OFF)
 
 if (NANOARROW_NAMESPACE)
@@ -68,7 +69,11 @@ if(NANOARROW_BUNDLE)
     file(WRITE ${NANOARROW_HPP_TEMP} "${SRC_FILE_CONTENTS}")
 
     # Combine all source files into amalgamation/nanoarrow.c in the build directory
-    set(NANOARROW_C_TEMP ${CMAKE_BINARY_DIR}/amalgamation/nanoarrow/nanoarrow.c)
+    if(NANOARROW_BUNDLE_AS_CPP)
+        set(NANOARROW_C_TEMP ${CMAKE_BINARY_DIR}/amalgamation/nanoarrow/nanoarrow.cc)
+    else()
+        set(NANOARROW_C_TEMP ${CMAKE_BINARY_DIR}/amalgamation/nanoarrow/nanoarrow.c)
+    endif()
     file(READ src/nanoarrow/utils.c SRC_FILE_CONTENTS)
     file(WRITE ${NANOARROW_C_TEMP} "${SRC_FILE_CONTENTS}")
     file(READ src/nanoarrow/schema.c SRC_FILE_CONTENTS)
@@ -81,7 +86,7 @@ if(NANOARROW_BUNDLE)
     # Add a library that the tests can link against (but don't install it)
     if(NANOARROW_BUILD_TESTS)
         include_directories(${CMAKE_BINARY_DIR}/amalgamation)
-        add_library(nanoarrow ${CMAKE_BINARY_DIR}/amalgamation/nanoarrow/nanoarrow.c)
+        add_library(nanoarrow ${NANOARROW_C_TEMP})
     endif()
 
     # Install the amalgamated header and source

--- a/src/nanoarrow/array_stream.c
+++ b/src/nanoarrow/array_stream.c
@@ -32,9 +32,9 @@ static int ArrowBasicArrayStreamGetSchema(struct ArrowArrayStream* array_stream,
     return EINVAL;
   }
 
-  struct BasicArrayStreamPrivate* private =
+  struct BasicArrayStreamPrivate* private_data =
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
-  return ArrowSchemaDeepCopy(&private->schema, schema);
+  return ArrowSchemaDeepCopy(&private_data->schema, schema);
 }
 
 static int ArrowBasicArrayStreamGetNext(struct ArrowArrayStream* array_stream,
@@ -43,15 +43,15 @@ static int ArrowBasicArrayStreamGetNext(struct ArrowArrayStream* array_stream,
     return EINVAL;
   }
 
-  struct BasicArrayStreamPrivate* private =
+  struct BasicArrayStreamPrivate* private_data =
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
 
-  if (private->arrays_i == private->n_arrays) {
+  if (private_data->arrays_i == private_data->n_arrays) {
     array->release = NULL;
     return NANOARROW_OK;
   }
 
-  ArrowArrayMove(&private->arrays[private->arrays_i++], array);
+  ArrowArrayMove(&private_data->arrays[private_data->arrays_i++], array);
   return NANOARROW_OK;
 }
 
@@ -65,81 +65,81 @@ static void ArrowBasicArrayStreamRelease(struct ArrowArrayStream* array_stream) 
     return;
   }
 
-  struct BasicArrayStreamPrivate* private =
+  struct BasicArrayStreamPrivate* private_data =
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
 
-  if (private->schema.release != NULL) {
-    private->schema.release(&private->schema);
+  if (private_data->schema.release != NULL) {
+    private_data->schema.release(&private_data->schema);
   }
 
-  for (int64_t i = 0; i < private->n_arrays; i++) {
-    if (private->arrays[i].release != NULL) {
-      private->arrays[i].release(&private->arrays[i]);
+  for (int64_t i = 0; i < private_data->n_arrays; i++) {
+    if (private_data->arrays[i].release != NULL) {
+      private_data->arrays[i].release(&private_data->arrays[i]);
     }
   }
 
-  if (private->arrays != NULL) {
-    ArrowFree(private->arrays);
+  if (private_data->arrays != NULL) {
+    ArrowFree(private_data->arrays);
   }
 
-  ArrowFree(private);
+  ArrowFree(private_data);
   array_stream->release = NULL;
 }
 
 ArrowErrorCode ArrowBasicArrayStreamInit(struct ArrowArrayStream* array_stream,
                                          struct ArrowSchema* schema, int64_t n_arrays) {
-  struct BasicArrayStreamPrivate* private = (struct BasicArrayStreamPrivate*)ArrowMalloc(
+  struct BasicArrayStreamPrivate* private_data = (struct BasicArrayStreamPrivate*)ArrowMalloc(
       sizeof(struct BasicArrayStreamPrivate));
-  if (private == NULL) {
+  if (private_data == NULL) {
     return ENOMEM;
   }
 
-  ArrowSchemaMove(schema, &private->schema);
+  ArrowSchemaMove(schema, &private_data->schema);
 
-  private->n_arrays = n_arrays;
-  private->arrays = NULL;
-  private->arrays_i = 0;
+  private_data->n_arrays = n_arrays;
+  private_data->arrays = NULL;
+  private_data->arrays_i = 0;
 
   if (n_arrays > 0) {
-    private->arrays =
+    private_data->arrays =
         (struct ArrowArray*)ArrowMalloc(n_arrays * sizeof(struct ArrowArray));
-    if (private->arrays == NULL) {
+    if (private_data->arrays == NULL) {
       ArrowBasicArrayStreamRelease(array_stream);
       return ENOMEM;
     }
   }
 
-  for (int64_t i = 0; i < private->n_arrays; i++) {
-    private->arrays[i].release = NULL;
+  for (int64_t i = 0; i < private_data->n_arrays; i++) {
+    private_data->arrays[i].release = NULL;
   }
 
   array_stream->get_schema = &ArrowBasicArrayStreamGetSchema;
   array_stream->get_next = &ArrowBasicArrayStreamGetNext;
   array_stream->get_last_error = ArrowBasicArrayStreamGetLastError;
   array_stream->release = ArrowBasicArrayStreamRelease;
-  array_stream->private_data = private;
+  array_stream->private_data = private_data;
   return NANOARROW_OK;
 }
 
 void ArrowBasicArrayStreamSetArray(struct ArrowArrayStream* array_stream, int64_t i,
                                    struct ArrowArray* array) {
-  struct BasicArrayStreamPrivate* private =
+  struct BasicArrayStreamPrivate* private_data =
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
-  ArrowArrayMove(array, &private->arrays[i]);
+  ArrowArrayMove(array, &private_data->arrays[i]);
 }
 
 ArrowErrorCode ArrowBasicArrayStreamValidate(struct ArrowArrayStream* array_stream,
                                              struct ArrowError* error) {
-  struct BasicArrayStreamPrivate* private =
+  struct BasicArrayStreamPrivate* private_data =
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
 
   struct ArrowArrayView array_view;
   NANOARROW_RETURN_NOT_OK(
-      ArrowArrayViewInitFromSchema(&array_view, &private->schema, error));
+      ArrowArrayViewInitFromSchema(&array_view, &private_data->schema, error));
 
-  for (int64_t i = 0; i < private->n_arrays; i++) {
-    if (private->arrays[i].release != NULL) {
-      int result = ArrowArrayViewSetArray(&array_view, &private->arrays[i], error);
+  for (int64_t i = 0; i < private_data->n_arrays; i++) {
+    if (private_data->arrays[i].release != NULL) {
+      int result = ArrowArrayViewSetArray(&array_view, &private_data->arrays[i], error);
       if (result != NANOARROW_OK) {
         ArrowArrayViewReset(&array_view);
         return result;

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -169,7 +169,7 @@ void ArrowFree(void* ptr) { free(ptr); }
 static uint8_t* ArrowBufferAllocatorMallocReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
-  return ArrowRealloc(ptr, new_size);
+  return (uint8_t*)ArrowRealloc(ptr, new_size);
 }
 
 static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocator,


### PR DESCRIPTION
Apparently it's difficult to pass different flags to C and C++ files in a Python extension. The C library was almost valid C++ anyway and because there are quite a few static inline functions, it's probably a good idea to make sure that the project compiles under a C++ compiler as well (since the nanoarrow.h header will be compiled with C++ if included in a C++ project).