### PR TITLE
fix: Improve reliability of R tests on non-standard systems

### DIFF
--- a/r/tests/testthat/test-pkg-arrow.R
+++ b/r/tests/testthat/test-pkg-arrow.R
@@ -51,6 +51,8 @@ test_that("infer_nanoarrow_schema() works for arrow objects", {
   )
   expect_true(arrow::as_schema(tbl_schema)$Equals(tbl_schema_expected))
 
+  skip_if_not(isTRUE(arrow::arrow_info()$capabilities["dataset"]))
+
   tbl_schema <- infer_nanoarrow_schema(
     arrow::InMemoryDataset$create(arrow::record_batch(x = 1L))
   )

--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -55,11 +55,15 @@ test_that("infer_nanoarrow_schema() methods work for built-in types", {
   time <- as.POSIXct("2000-01-01", tz = "UTC")
   expect_identical(infer_nanoarrow_schema(time)$format, "tsu:UTC")
 
-  time <- as.POSIXct("2000-01-01", tz = "")
-  expect_identical(
-    infer_nanoarrow_schema(time)$format,
-    paste0("tsu:", Sys.timezone())
-  )
+  # Some systems (mostly Docker images) don't return a value for Sys.timezone()
+  # so set one explicitly to test the Sys.timezone() fallback.
+  withr::with_timezone("America/Halifax", {
+    time <- as.POSIXct("2000-01-01", tz = "")
+    expect_identical(
+      infer_nanoarrow_schema(time)$format,
+      paste0("tsu:", Sys.timezone())
+    )
+  })
 
   difftime <- as.difftime(double(), unit = "secs")
   expect_identical(infer_nanoarrow_schema(difftime)$format, "tDu")

--- a/r/tests/testthat/test-util.R
+++ b/r/tests/testthat/test-util.R
@@ -37,11 +37,14 @@ test_that("can set option/env var to pretend the arrow package is not installed"
 
 test_that("preserve/release works when release happens on another thread", {
   some_non_null_sexp <- 1L
-  count0 <- preserved_count()
+
+  preserved_empty()
+  expect_identical(preserved_empty(), 0)
   preserve_and_release_on_other_thread(some_non_null_sexp)
-  expect_identical(preserved_count(), count0 + 1)
+  # We can't test the exact value of preserved_count() because what the
+  # garbage collector releases and when is not stable.
+  expect_true(preserved_count() > 0)
   expect_identical(preserved_empty(), 1)
-  expect_identical(preserved_count(), count0)
   expect_identical(preserved_empty(), 0)
 })
 


### PR DESCRIPTION
...mostly Docker images that are slow or are missing components usually present on systems people are actually using.

- Closes #121 
- Closes #123