### PR TITLE
fix: Fix cmake build + test and verification script on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,18 +135,25 @@ else()
 endif()
 
 if(NANOARROW_BUILD_TESTS)
-    # For testing we use GTest + Arrow C++ (both need C++11)
+    # For testing we use GTest + Arrow C++
     include(FetchContent)
 
     set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --suppressions=${CMAKE_CURRENT_LIST_DIR}/valgrind.supp --error-exitcode=1")
     include(CTest)
 
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
     find_package(Arrow REQUIRED)
     message(STATUS "Arrow version: ${ARROW_VERSION}")
     message(STATUS "Arrow SO version: ${ARROW_FULL_SO_VERSION}")
+
+    # Arrow >= 10.0.0 requires C++17; GTest requires C++11.
+    # Leave the option open to use an older version of Arrow
+    # to make it easier to test on old Linux (e.g., Centos7)
+    if (${ARROW_VERSION} VERSION_GREATER_EQUAL "10.0.0")
+        set(CMAKE_CXX_STANDARD 17)
+    else()
+        set(CMAKE_CXX_STANDARD 11)
+    endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     FetchContent_Declare(
         googletest
@@ -169,10 +176,18 @@ if(NANOARROW_BUILD_TESTS)
         target_link_libraries(nanoarrow_hpp_test coverage_config)
     endif()
 
-    target_link_libraries(utils_test nanoarrow GTest::gtest_main arrow_shared)
+    # On Windows, dynamically linking Arrow is difficult to get right,
+    # so use static linking by default.
+    if (MSVC)
+        set(NANOARROW_ARROW_TARGET arrow_static)
+    else()
+        set(NANOARROW_ARROW_TARGET arrow_shared)
+    endif()
+
+    target_link_libraries(utils_test nanoarrow GTest::gtest_main ${NANOARROW_ARROW_TARGET})
     target_link_libraries(buffer_test nanoarrow GTest::gtest_main)
-    target_link_libraries(array_test nanoarrow GTest::gtest_main arrow_shared)
-    target_link_libraries(schema_test nanoarrow GTest::gtest_main arrow_shared)
+    target_link_libraries(array_test nanoarrow GTest::gtest_main ${NANOARROW_ARROW_TARGET})
+    target_link_libraries(schema_test nanoarrow GTest::gtest_main ${NANOARROW_ARROW_TARGET})
     target_link_libraries(array_stream_test nanoarrow GTest::gtest_main)
     target_link_libraries(nanoarrow_hpp_test nanoarrow GTest::gtest_main)
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -222,7 +222,7 @@ test_r() {
   show_header "Build and test R package"
 
   if [ ! -z "${R_HOME}" ]; then
-    R_BIN=${R_HOME}/bin/R
+    R_BIN="${R_HOME}/bin/R"
   else
     R_BIN=R
   fi
@@ -232,7 +232,7 @@ test_r() {
   # (but the arrow integration tests will run if the arrow package is installed anyway).
   # Using a manual approach because installing pak takes a while on some systems and
   # beacuse the package versions don't matter much.
-  $R_BIN -e 'for (pkg in c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr")) if (!requireNamespace(pkg, quietly = TRUE)) install.packages(pkg, repos = "https://cloud.r-project.org/")'
+  "$R_BIN" -e 'for (pkg in c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr")) if (!requireNamespace(pkg, quietly = TRUE)) install.packages(pkg, repos = "https://cloud.r-project.org/")'
 
   show_info "Build the R package source tarball"
 
@@ -240,16 +240,16 @@ test_r() {
   # method to ensure the proper version of nanoarrow is vendored into the R package.
   # Do this in a temporary library so not to overwrite the a user's existing package.
   mkdir "$NANOARROW_TMPDIR/tmplib"
-  $R_BIN CMD INSTALL r --preclean --library="$NANOARROW_TMPDIR/tmplib"
+  "$R_BIN" CMD INSTALL r --preclean --library="$NANOARROW_TMPDIR/tmplib"
 
   # Builds the R source tarball
   pushd $NANOARROW_TMPDIR
-  $R_BIN CMD build "$NANOARROW_SOURCE_DIR/r"
+  "$R_BIN" CMD build "$NANOARROW_SOURCE_DIR/r"
   R_PACKAGE_TARBALL_NAME=`ls nanoarrow_*.tar.gz`
 
   show_info "Run R CMD check"
   # Runs R CMD check on the tarball
-  _R_CHECK_FORCE_SUGGESTS_=false $R_BIN CMD check "$R_PACKAGE_TARBALL_NAME" --no-manual
+  _R_CHECK_FORCE_SUGGESTS_=false "$R_BIN" CMD check "$R_PACKAGE_TARBALL_NAME" --no-manual
 
   popd
 }


### PR DESCRIPTION
Before this PR, any invocation of cmake build + test and/or running the verification script fails on Windows because (1) the most common R executable path has a space (`C:/Program Files/R/...`) and because dynamically linking Arrow is hard.