### PR TITLE
fix(r): Use strict prototypes in all internal C functions

### DIFF
--- a/r/src/init.c
+++ b/r/src/init.c
@@ -78,8 +78,8 @@ extern SEXP nanoarrow_c_schema_set_dictionary(SEXP schema_mut_xptr, SEXP diction
 extern SEXP nanoarrow_c_preserved_count(void);
 extern SEXP nanoarrow_c_preserved_empty(void);
 extern SEXP nanoarrow_c_preserve_and_release_on_other_thread(SEXP obj);
-extern SEXP nanoarrow_c_version();
-extern SEXP nanoarrow_c_version_runtime();
+extern SEXP nanoarrow_c_version(void);
+extern SEXP nanoarrow_c_version_runtime(void);
 
 static const R_CallMethodDef CallEntries[] = {
     {"nanoarrow_c_make_altrep_chr", (DL_FUNC)&nanoarrow_c_make_altrep_chr, 1},

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -399,7 +399,7 @@ static void finalize_buffer_xptr(SEXP buffer_xptr) {
   }
 }
 
-static SEXP buffer_owning_xptr() {
+static SEXP buffer_owning_xptr(void) {
   struct ArrowBuffer* buffer =
       (struct ArrowBuffer*)ArrowMalloc(sizeof(struct ArrowBuffer));
   if (buffer == NULL) {

--- a/r/src/version.c
+++ b/r/src/version.c
@@ -21,6 +21,6 @@
 
 #include "nanoarrow.h"
 
-SEXP nanoarrow_c_version() { return Rf_mkString(NANOARROW_VERSION); }
+SEXP nanoarrow_c_version(void) { return Rf_mkString(NANOARROW_VERSION); }
 
-SEXP nanoarrow_c_version_runtime() { return Rf_mkString(ArrowNanoarrowVersion()); }
+SEXP nanoarrow_c_version_runtime(void) { return Rf_mkString(ArrowNanoarrowVersion()); }


### PR DESCRIPTION
Closes #150.