### PR TITLE
fix(extensions/nanoarrow_ipc): Ensure tests pass on big endian

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
@@ -54,7 +54,6 @@ ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error) {
 static enum ArrowIpcEndianness ArrowIpcSystemEndianness(void) {
   uint32_t check = 1;
   char first_byte;
-  enum ArrowIpcEndianness system_endianness;
   memcpy(&first_byte, &check, sizeof(char));
   if (first_byte) {
     return NANOARROW_IPC_ENDIANNESS_LITTLE;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
@@ -770,6 +770,9 @@ static inline int ArrowIpcDecoderCheckHeader(struct ArrowIpcDecoder* decoder,
                                              struct ArrowBufferView* data_mut,
                                              int32_t* message_size_bytes,
                                              struct ArrowError* error) {
+  struct ArrowIpcDecoderPrivate* private_data =
+      (struct ArrowIpcDecoderPrivate*)decoder->private_data;
+
   if (data_mut->size_bytes < 8) {
     ArrowErrorSet(error, "Expected data of at least 8 bytes but only %ld bytes remain",
                   (long)data_mut->size_bytes);
@@ -783,8 +786,8 @@ static inline int ArrowIpcDecoderCheckHeader(struct ArrowIpcDecoder* decoder,
     return EINVAL;
   }
 
-  *message_size_bytes =
-      ArrowIpcReadInt32LE(data_mut, ArrowIpcDecoderNeedsSwapEndian(decoder));
+  int swap_endian = private_data->system_endianness == NANOARROW_IPC_ENDIANNESS_BIG;
+  *message_size_bytes = ArrowIpcReadInt32LE(data_mut, swap_endian);
   if ((*message_size_bytes) < 0) {
     ArrowErrorSet(
         error, "Expected message body size > 0 but found message body size of %ld bytes",

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.c
@@ -92,10 +92,9 @@ void ArrowIpcDecoderReset(struct ArrowIpcDecoder* decoder) {
   memset(decoder, 0, sizeof(struct ArrowIpcDecoder));
 }
 
-static inline uint32_t ArrowIpcReadUint32LE(struct ArrowBufferView* data) {
+static inline uint32_t ArrowIpcReadContinuationBytes(struct ArrowBufferView* data) {
   uint32_t value;
   memcpy(&value, data->data.as_uint8, sizeof(uint32_t));
-  // TODO: bswap32() if big endian
   data->data.as_uint8 += sizeof(uint32_t);
   data->size_bytes -= sizeof(uint32_t);
   return value;
@@ -761,7 +760,7 @@ static inline int ArrowIpcDecoderCheckHeader(struct ArrowIpcDecoder* decoder,
     return ESPIPE;
   }
 
-  uint32_t continuation = ArrowIpcReadUint32LE(data_mut);
+  uint32_t continuation = ArrowIpcReadContinuationBytes(data_mut);
   if (continuation != 0xFFFFFFFF) {
     ArrowErrorSet(error, "Expected 0xFFFFFFFF at start of message but found 0x%08X",
                   (unsigned int)continuation);

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -90,14 +90,13 @@ struct ArrowIpcDecoder {
   /// \brief The last verified or decoded message type
   enum ArrowIpcMessageType message_type;
 
-  /// \brief The metadata version used by this and forthcoming messages
+  /// \brief The metadata version as indicated by the current schema message
   enum ArrowIpcMetadataVersion metadata_version;
 
-  /// \brief Endianness of forthcoming RecordBatch messages
+  /// \brief Buffer endianness as indicated by the current schema message
   enum ArrowIpcEndianness endianness;
 
-  /// \brief Features used by this and forthcoming messages as indicated by the current
-  /// Schema message
+  /// \brief Arrow IPC Features used as indicated by the current Schema message
   int32_t feature_flags;
 
   /// \brief Compression used by the current RecordBatch message
@@ -167,7 +166,7 @@ ArrowErrorCode ArrowIpcDecoderDecodeHeader(struct ArrowIpcDecoder* decoder,
                                            struct ArrowBufferView data,
                                            struct ArrowError* error);
 
-/// \brief Decode an ArrowArray
+/// \brief Decode an ArrowSchema
 ///
 /// After a successful call to ArrowIpcDecoderDecodeHeader(), retrieve an ArrowSchema.
 /// The caller is responsible for releasing the schema if NANOARROW_OK is returned.
@@ -182,11 +181,25 @@ ArrowErrorCode ArrowIpcDecoderDecodeSchema(struct ArrowIpcDecoder* decoder,
 ///
 /// Prepares the decoder for future record batch messages
 /// of this type. The decoder takes ownership of schema if NANOARROW_OK is returned.
+/// Note that you must call this explicitly after decoding a
+/// Schema message (i.e., the decoder does not assume that the last-decoded
+/// schema message applies to future record batch messages).
 ///
 /// Returns EINVAL if schema validation fails or NANOARROW_OK otherwise.
 ArrowErrorCode ArrowIpcDecoderSetSchema(struct ArrowIpcDecoder* decoder,
                                         struct ArrowSchema* schema,
                                         struct ArrowError* error);
+
+/// \brief Set the endianness used to decode future record batch messages
+///
+/// Prepares the decoder for future record batch messages with the specified
+/// endianness. Note that you must call this explicitly after decoding a
+/// Schema message (i.e., the decoder does not assume that the last-decoded
+/// schema message applies to future record batch messages).
+///
+/// Returns NANOARROW_OK on success.
+ArrowErrorCode ArrowIpcDecoderSetEndianness(struct ArrowIpcDecoder* decoder,
+                                            enum ArrowIpcEndianness endianness);
 
 /// \brief Decode an ArrowArray
 ///

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -37,6 +37,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
 #define ArrowIpcDecoderSetSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderSetSchema)
+#define ArrowIpcDecoderSetEndianness \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderSetEndianness)
 
 #endif
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_test.cc
@@ -257,6 +257,10 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   struct ArrowSchema schema;
   struct ArrowArray array;
 
+  // Data buffer content of the hard-coded record batch message
+  uint8_t one_two_three_le[] = {0x01, 0x00, 0x00, 0x00, 0x02, 0x00,
+                                0x00, 0x00, 0x03, 0x00, 0x00, 0x00};
+
   ArrowSchemaInit(&schema);
   ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
@@ -296,17 +300,9 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   ASSERT_EQ(array.children[0]->n_buffers, 2);
   ASSERT_EQ(array.children[0]->length, 3);
   EXPECT_EQ(array.children[0]->null_count, 0);
-  const int32_t* out = reinterpret_cast<const int32_t*>(array.children[0]->buffers[1]);
-
-  if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_LITTLE) {
-    EXPECT_EQ(out[0], 1);
-    EXPECT_EQ(out[1], 2);
-    EXPECT_EQ(out[2], 3);
-  } else {
-    EXPECT_EQ(out[0], bswap32(1));
-    EXPECT_EQ(out[1], bswap32(2));
-    EXPECT_EQ(out[2], bswap32(3));
-  }
+  EXPECT_EQ(
+      memcmp(array.children[0]->buffers[1], one_two_three_le, sizeof(one_two_three_le)),
+      0);
 
   array.release(&array);
 
@@ -315,17 +311,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   ASSERT_EQ(array.n_buffers, 2);
   ASSERT_EQ(array.length, 3);
   EXPECT_EQ(array.null_count, 0);
-  out = reinterpret_cast<const int32_t*>(array.buffers[1]);
-
-  if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_LITTLE) {
-    EXPECT_EQ(out[0], 1);
-    EXPECT_EQ(out[1], 2);
-    EXPECT_EQ(out[2], 3);
-  } else {
-    EXPECT_EQ(out[0], bswap32(1));
-    EXPECT_EQ(out[1], bswap32(2));
-    EXPECT_EQ(out[2], bswap32(3));
-  }
+  EXPECT_EQ(memcmp(array.buffers[1], one_two_three_le, sizeof(one_two_three_le)), 0);
 
   array.release(&array);
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_test.cc
@@ -36,6 +36,8 @@ struct ArrowIpcField {
 };
 
 struct ArrowIpcDecoderPrivate {
+  enum ArrowIpcEndianness endianness;
+  enum ArrowIpcEndianness system_endianness;
   struct ArrowArrayView array_view;
   int64_t n_fields;
   struct ArrowIpcField* fields;
@@ -298,11 +300,11 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
 
   // Field extract should fail on non-system endian
   // This test will have to get updated when we start testing on big endian
-  decoder.endianness = NANOARROW_IPC_ENDIANNESS_BIG;
+  ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_BIG);
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array, &error), ENOTSUP);
   EXPECT_STREQ(error.message,
                "The nanoarrow_ipc extension does not support non-system endianness");
-  decoder.endianness = NANOARROW_IPC_ENDIANNESS_UNINITIALIZED;
+  ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_UNINITIALIZED);
 
   // Field extract should fail if body is too small
   body.size_bytes = 0;


### PR DESCRIPTION
This PR tweaks the tests and endianness setup so that the tests pass on big endian. Buffer decoding on non-platform endian isn't supported yet...this PR is just about making sure all of the other infrastructure around the buffers works. This is also in preparation for adding the nanoarrow_ipc extension to release verification (which now runs on big endian on CI).

You can test this using the shiny new alpine-s390x image in this repo's container store!

```bash
# git clone https://github.com/paleolimbot/arrow-nanoarrow.git && cd arrow-nanoarrow && git switch ipc-improvements
# docker run --rm -it ghcr.io/apache/arrow-nanoarrow:alpine-s390x
mkdir build && cd build
cmake ..
cmake --build .
ctest
```