### PR TITLE
feat(extensions/nanoarrow_ipc): Allow shared buffers for zero-copy buffer decode

### DIFF
--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -204,6 +204,7 @@ if (NANOARROW_IPC_BUILD_TESTS)
 
   include(GoogleTest)
   gtest_discover_tests(nanoarrow_ipc_decoder_test)
+  gtest_discover_tests(nanoarrow_ipc_reader_test)
 endif()
 
 if (NANOARROW_IPC_BUILD_APPS)

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -23,6 +23,8 @@
 #ifdef NANOARROW_NAMESPACE
 
 #define ArrowIpcCheckRuntime NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcCheckRuntime)
+#define ArrowIpcSharedBufferIsThreadSafe \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcSharedBufferIsThreadSafe)
 #define ArrowIpcDecoderInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderInit)
 #define ArrowIpcDecoderReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderReset)
 #define ArrowIpcDecoderPeekHeader \
@@ -89,6 +91,8 @@ enum ArrowIpcCompressionType {
 #define NANOARROW_IPC_FEATURE_COMPRESSED_BODY 2
 
 ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error);
+
+int ArrowIpcSharedBufferIsThreadSafe(void);
 
 /// \brief Decoder for Arrow IPC messages
 ///

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -35,6 +35,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeSchema)
 #define ArrowIpcDecoderDecodeArray \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
+#define ArrowIpcDecoderDecodeArrayFromOwned \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromOwned)
 #define ArrowIpcDecoderSetSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderSetSchema)
 #define ArrowIpcDecoderSetEndianness \

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -281,10 +281,18 @@ ArrowErrorCode ArrowIpcInputStreamInitFile(struct ArrowIpcInputStream* stream,
 
 /// \brief Options for ArrowIpcArrayStreamReaderInit()
 struct ArrowIpcArrayStreamReaderOptions {
-  /// \brief The field index to extract. Defaults to -1 (i.e., read all fields).
+  /// \brief The field index to extract.
+  ///
+  /// Defaults to -1 (i.e., read all fields). Note that this field index refers to
+  /// the flattened tree of children and not necessarily the column index.
   int64_t field_index;
 
   /// \brief Set to a non-zero value to share the message body buffer among decoded arrays
+  ///
+  /// Defaults to true. Sharing buffers is a good default when (1) using memory-mapped IO
+  /// (since unreferenced portions of the file are often not loaded into memory) or
+  /// (2) if all data from all columns are about to be referenced anyway. When loading
+  /// a single field there is probably no advantage to using shared buffers.
   int use_shared_buffers;
 };
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -25,6 +25,10 @@
 #define ArrowIpcCheckRuntime NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcCheckRuntime)
 #define ArrowIpcSharedBufferIsThreadSafe \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcSharedBufferIsThreadSafe)
+#define ArrowIpcSharedBufferInit \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcSharedBufferInit)
+#define ArrowIpcSharedBufferReset \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcSharedBufferReset)
 #define ArrowIpcDecoderInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderInit)
 #define ArrowIpcDecoderReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderReset)
 #define ArrowIpcDecoderPeekHeader \
@@ -37,8 +41,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeSchema)
 #define ArrowIpcDecoderDecodeArray \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
-#define ArrowIpcDecoderDecodeArrayFromOwned \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromOwned)
+#define ArrowIpcDecoderDecodeArrayFromShared \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromShared)
 #define ArrowIpcDecoderSetSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderSetSchema)
 #define ArrowIpcDecoderSetEndianness \

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -227,6 +227,19 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
                                           struct ArrowArray* out,
                                           struct ArrowError* error);
 
+/// \brief Decode an ArrowArray from an owned buffer
+///
+/// This implementation takes advantage of the fact that it can take ownership of
+/// body to avoid copying individual buffers. On success, the ArrowArray pointed
+/// to by out takes ownership of the original body and a copy of the reference-counted
+/// shared buffer is injected in its place (e.g., such that it can be used for
+/// subsequent calls to this function). In all cases the caller must ArrowBufferReset()
+/// body.
+ArrowErrorCode ArrowIpcDecoderDecodeArrayFromOwned(struct ArrowIpcDecoder* decoder,
+                                                   struct ArrowBuffer* body, int64_t i,
+                                                   struct ArrowArray* out,
+                                                   struct ArrowError* error);
+
 /// \brief An user-extensible input data source
 struct ArrowIpcInputStream {
   /// \brief Read up to buf_size_bytes from stream into buf

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -283,6 +283,9 @@ ArrowErrorCode ArrowIpcInputStreamInitFile(struct ArrowIpcInputStream* stream,
 struct ArrowIpcArrayStreamReaderOptions {
   /// \brief The field index to extract. Defaults to -1 (i.e., read all fields).
   int64_t field_index;
+
+  /// \brief Set to a non-zero value to share the message body buffer among decoded arrays
+  int use_shared_buffers;
 };
 
 /// \brief Initialize an ArrowArrayStream from an input stream of bytes

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -92,6 +92,15 @@ enum ArrowIpcCompressionType {
 
 ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error);
 
+struct ArrowIpcSharedBuffer {
+  struct ArrowBuffer private_src;
+};
+
+ArrowErrorCode ArrowIpcSharedBufferInit(struct ArrowIpcSharedBuffer* shared,
+                                        struct ArrowBuffer* src);
+
+void ArrowIpcSharedBufferReset(struct ArrowIpcSharedBuffer* shared);
+
 int ArrowIpcSharedBufferIsThreadSafe(void);
 
 /// \brief Decoder for Arrow IPC messages
@@ -242,10 +251,10 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
 /// subsequent calls to this function). In all cases the caller must ArrowBufferReset()
 /// body. If ArrowIpcSharedBufferIsThreadSafe() returns 0, out must not be released
 /// by another thread.
-ArrowErrorCode ArrowIpcDecoderDecodeArrayFromOwned(struct ArrowIpcDecoder* decoder,
-                                                   struct ArrowBuffer* body, int64_t i,
-                                                   struct ArrowArray* out,
-                                                   struct ArrowError* error);
+ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(struct ArrowIpcDecoder* decoder,
+                                                    struct ArrowIpcSharedBuffer* shared,
+                                                    int64_t i, struct ArrowArray* out,
+                                                    struct ArrowError* error);
 
 /// \brief An user-extensible input data source
 struct ArrowIpcInputStream {

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -90,17 +90,34 @@ enum ArrowIpcCompressionType {
 #define NANOARROW_IPC_FEATURE_DICTIONARY_REPLACEMENT 1
 #define NANOARROW_IPC_FEATURE_COMPRESSED_BODY 2
 
+/// \brief Checks the nanoarrow runtime to make sure the run/build versions match
 ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error);
 
+/// \brief A structure representing a reference-counted buffer that may be passed to
+/// ArrowIpcDecoderDecodeArrayFromShared().
 struct ArrowIpcSharedBuffer {
   struct ArrowBuffer private_src;
 };
 
+/// \brief Initialize the contents of a ArrowIpcSharedBuffer struct
+///
+/// If NANOARROW_OK is returned, the ArrowIpcSharedBuffer takes ownership of
+/// src.
 ArrowErrorCode ArrowIpcSharedBufferInit(struct ArrowIpcSharedBuffer* shared,
                                         struct ArrowBuffer* src);
 
+/// \brief Release the caller's copy of the shared buffer
+///
+/// When finished, the caller must relinquish its own copy of the shared data
+/// using this function. The original buffer will continue to exist until all
+/// ArrowArray objects that refer to it have also been released.
 void ArrowIpcSharedBufferReset(struct ArrowIpcSharedBuffer* shared);
 
+/// \brief Check for shared buffer thread safety
+///
+/// Thread-safe shared buffers require C11 and the stdatomic.h header.
+/// If either are unavailable, shared buffers are still possible but
+/// the resulting arrays must not be passed to other threads to be released.
 int ArrowIpcSharedBufferIsThreadSafe(void);
 
 /// \brief Decoder for Arrow IPC messages

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -240,7 +240,8 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
 /// to by out takes ownership of the original body and a copy of the reference-counted
 /// shared buffer is injected in its place (e.g., such that it can be used for
 /// subsequent calls to this function). In all cases the caller must ArrowBufferReset()
-/// body.
+/// body. If ArrowIpcSharedBufferIsThreadSafe() returns 0, out must not be released
+/// by another thread.
 ArrowErrorCode ArrowIpcDecoderDecodeArrayFromOwned(struct ArrowIpcDecoder* decoder,
                                                    struct ArrowBuffer* body, int64_t i,
                                                    struct ArrowArray* out,
@@ -293,10 +294,11 @@ struct ArrowIpcArrayStreamReaderOptions {
 
   /// \brief Set to a non-zero value to share the message body buffer among decoded arrays
   ///
-  /// Defaults to true. Sharing buffers is a good default when (1) using memory-mapped IO
+  /// Sharing buffers is a good choice when (1) using memory-mapped IO
   /// (since unreferenced portions of the file are often not loaded into memory) or
   /// (2) if all data from all columns are about to be referenced anyway. When loading
   /// a single field there is probably no advantage to using shared buffers.
+  /// Defaults to the value of ArrowIpcSharedBufferIsThreadSafe().
   int use_shared_buffers;
 };
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -261,13 +261,11 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
 
 /// \brief Decode an ArrowArray from an owned buffer
 ///
-/// This implementation takes advantage of the fact that it can take ownership of
-/// body to avoid copying individual buffers. On success, the ArrowArray pointed
-/// to by out takes ownership of the original body and a copy of the reference-counted
-/// shared buffer is injected in its place (e.g., such that it can be used for
-/// subsequent calls to this function). In all cases the caller must ArrowBufferReset()
-/// body. If ArrowIpcSharedBufferIsThreadSafe() returns 0, out must not be released
-/// by another thread.
+/// This implementation takes advantage of the fact that it can avoid copying individual
+/// buffers. In all cases the caller must ArrowIpcSharedBufferReset() body after one or
+/// more calls to ArrowIpcDecoderDecodeArrayFromShared(). If
+/// ArrowIpcSharedBufferIsThreadSafe() returns 0, out must not be released by another
+/// thread.
 ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(struct ArrowIpcDecoder* decoder,
                                                     struct ArrowIpcSharedBuffer* shared,
                                                     int64_t i, struct ArrowArray* out,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1260,3 +1260,14 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
   ArrowArrayMove(&temp, out);
   return NANOARROW_OK;
 }
+
+ArrowErrorCode ArrowIpcDecoderDecodeArrayFromOwned(struct ArrowIpcDecoder* decoder,
+                                                   struct ArrowBuffer* body, int64_t i,
+                                                   struct ArrowArray* out,
+                                                   struct ArrowError* error) {
+  struct ArrowBufferView body_view;
+  body_view.data.data = body->data;
+  body_view.size_bytes = body->size_bytes;
+
+  return ArrowIpcDecoderDecodeArray(decoder, body_view, i, out, error);
+}

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -490,8 +490,8 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchOwned) {
   EXPECT_EQ(memcmp(array.buffers[1], one_two_three_le, sizeof(one_two_three_le)), 0);
 
   array.release(&array);
-
   schema.release(&schema);
+  ArrowBufferReset(&body);
   ArrowIpcDecoderReset(&decoder);
 }
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -335,8 +335,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   // Field extract should fail if body is too small
   body.size_bytes = 0;
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message,
-               "Buffer 1 requires body offsets [0..12) but body has size 0");
+  EXPECT_STREQ(error.message, "Buffer requires body offsets [0..12) but body has size 0");
 
   // Should error if the number of buffers or field nodes doesn't match
   // (different numbers because we count the root struct and the message does not)

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -333,7 +333,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_UNINITIALIZED);
 
   // Field extract should fail if body is too small
-  body.size_bytes = 0;
+  decoder.body_size_bytes = 0;
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array, &error), EINVAL);
   EXPECT_STREQ(error.message, "Buffer requires body offsets [0..12) but body has size 0");
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -372,10 +372,12 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
   NANOARROW_RETURN_NOT_OK(ArrowIpcArrayStreamReaderNextBody(private_data));
 
   if (private_data->use_shared_buffers) {
-    NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArrayFromOwned(
-        &private_data->decoder, &private_data->body, private_data->field_index, out,
+    struct ArrowIpcSharedBuffer shared;
+    NANOARROW_RETURN_NOT_OK(ArrowIpcSharedBufferInit(&shared, &private_data->body));
+    NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArrayFromShared(
+        &private_data->decoder, &shared, private_data->field_index, out,
         &private_data->error));
-    ArrowBufferReset(&private_data->body);
+    ArrowIpcSharedBufferReset(&shared);
   } else {
     struct ArrowBufferView body_view;
     body_view.data.data = private_data->body.data;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -422,7 +422,7 @@ ArrowErrorCode ArrowIpcArrayStreamReaderInit(
     private_data->use_shared_buffers = options->use_shared_buffers;
   } else {
     private_data->field_index = -1;
-    private_data->use_shared_buffers = 1;
+    private_data->use_shared_buffers = ArrowIpcSharedBufferIsThreadSafe();
   }
 
   out->private_data = private_data;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -59,6 +59,14 @@ static uint8_t kSimpleRecordBatch[] = {
 
 static uint8_t kEndOfStream[] = {0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00};
 
+// If we have an explicit compile with or without atomics, test the return value of
+// ArrowIpcSharedBufferIsThreadSafe()
+#if defined(NANOARROW_IPC_USE_STDATOMIC)
+TEST(NanoarrowIpcReader, ArrowIpcSharedBufferIsThreadSafe) {
+  EXPECT_EQ(ArrowIpcSharedBufferIsThreadSafe(), NANOARROW_IPC_USE_STDATOMIC != 0);
+}
+#endif
+
 TEST(NanoarrowIpcReader, InputStreamBuffer) {
   uint8_t input_data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
   struct ArrowBuffer input;


### PR DESCRIPTION
This PR makes buffer construction more flexible, with the initial target being zero-copy shared references to a single `struct ArrowBuffer` containing the read-in message body. Where supported (i.e., C11 and up), these shared buffer references are thread safe.

I implemented this by abstracting out a `struct ArrowIpcBufferFactory`. This could be exposed to the user, too (but maybe in another PR where I also implement endian swapping).

Using the decoder API, you can request this using a new function:

```c
ArrowErrorCode ArrowIpcDecoderDecodeArrayFromOwned(struct ArrowIpcDecoder* decoder,
                                                   struct ArrowBuffer* body, int64_t i,
                                                   struct ArrowArray* out,
                                                   struct ArrowError* error);
```

Using the `ArrowArrayStream` interface this is the default *if* shared buffers are thread safe (this can be overridden).