### PR TITLE
fix(r): Don't invoke undefined behaviour in conversions to/from Arrow

### DIFF
--- a/r/tests/testthat/test-as-array.R
+++ b/r/tests/testthat/test-as-array.R
@@ -163,10 +163,10 @@ test_that("as_nanoarrow_array() works for double() -> na_int32()", {
     as.raw(array$buffers[[1]]),
     packBits(c(rep(TRUE, 10), FALSE, rep(FALSE, 5)))
   )
-  # The last element here is (int)NaN not NA_integer_
+  # The last element here is 0 because (int)nan is undefined behaviour
   expect_identical(
-    head(as.raw(array$buffers[[2]]), 10 * 4L),
-    as.raw(as_nanoarrow_buffer(1:10))
+    as.raw(array$buffers[[2]]),
+    as.raw(as_nanoarrow_buffer(c(1:10, 0L)))
   )
 
   # With overflow

--- a/r/tests/testthat/test-convert-array.R
+++ b/r/tests/testthat/test-convert-array.R
@@ -329,13 +329,13 @@ test_that("convert to vector works for null -> logical()", {
 })
 
 test_that("convert to vector warns for invalid integer()", {
-  array <- as_nanoarrow_array(.Machine$double.xmax)
+  array <- as_nanoarrow_array(.Machine$integer.max + 1)
   expect_warning(
     expect_identical(convert_array(array, integer()), NA_integer_),
     "1 value\\(s\\) outside integer range set to NA"
   )
 
-  array <- as_nanoarrow_array(c(NA, .Machine$double.xmax))
+  array <- as_nanoarrow_array(c(NA, .Machine$integer.max + 1))
   expect_warning(
     expect_identical(convert_array(array, integer()), c(NA_integer_, NA_integer_)),
     "1 value\\(s\\) outside integer range set to NA"


### PR DESCRIPTION
Closes #159.

Checked via:

```bash
PKG_CFLAGS=-fsanitize=undefined PKG_LIBS=-fsanitize=undefined R CMD INSTALL . --preclean
```

Then:

```r
devtools::test()
```