### PR TITLE
fix(extensions/nanoarrow_ipc): Don't release input stream automatically on end of input

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -343,12 +343,6 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
                                             struct ArrowArray* out) {
   struct ArrowIpcArrayStreamReaderPrivate* private_data =
       (struct ArrowIpcArrayStreamReaderPrivate*)stream->private_data;
-  // Check if we are all done
-  if (private_data->input.release == NULL) {
-    out->release = NULL;
-    return NANOARROW_OK;
-  }
-
   private_data->error.message[0] = '\0';
   NANOARROW_RETURN_NOT_OK(ArrowIpcArrayStreamReaderReadSchemaIfNeeded(private_data));
 
@@ -356,8 +350,8 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
   int result = ArrowIpcArrayStreamReaderNextHeader(
       private_data, NANOARROW_IPC_MESSAGE_TYPE_RECORD_BATCH);
   if (result == ENODATA) {
-    // If the stream is finished, release the input
-    private_data->input.release(&private_data->input);
+    // Stream is finished either because there is no input or because
+    // end of stream bytes were read.
     out->release = NULL;
     return NANOARROW_OK;
   }


### PR DESCRIPTION
Before this PR, the input was released from within `get_next()` in the `ArrowArrayStream` implementation. This is unnecessary and prevented the reader from being useful in the context of streams that have non-standard layouts (e.g., if several streams are concatenated together, one could continue calling `get_next()` to "try again"). Also, there is a much better chance that `get_next()` is going to get called on another thread and it's easier to reason about lifecycles if the stream gets closed on `release()` instead.