### PR TITLE
chore: Add IPC extension and ARM64 to verification script

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -179,4 +179,5 @@ jobs:
 
         run: |
           cd src
+          echo "::group::Docker Pull"
           docker compose run -e GITHUB_ACTIONS ${{ matrix.config.compose_args }} verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -170,4 +170,5 @@ jobs:
 
         run: |
           cd src
-          docker compose ${{ matrix.config.compose_args }} run verify
+          # Set GITHUB_WORKSPACE to set more log-friendly headers
+          docker compose -e GITHUB_WORKSPACE=1 ${{ matrix.config.compose_args }} run verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -145,7 +145,8 @@ jobs:
           - {platform: "fedora", arch: "amd64"}
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
-          - {platform: "ubuntu", arch: "amd64", extra_label: "-memcheck", extra_env: "TEST_WITH_MEMCHECK=1"}
+          - {platform: "ubuntu", arch: "amd64",
+             extra_label: "-memcheck", extra_env: "TEST_WITH_MEMCHECK=1 TEST_C_BUNDLED=0"}
           - {platform: "ubuntu", arch: "arm64"}
           - {platform: "alpine", arch: "s390x"}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -142,10 +142,11 @@ jobs:
       matrix:
         config:
           - {platform: "ubuntu", arch: "amd64"}
-          - {platform: "ubuntu", arch: "arm64"}
           - {platform: "fedora", arch: "amd64"}
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
+          - {platform: "ubuntu", arch: "amd64", extra_env: "TEST_WITH_MEMCHECK=1"}
+          - {platform: "ubuntu", arch: "arm64"}
           - {platform: "alpine", arch: "s390x"}
 
     steps:
@@ -167,4 +168,4 @@ jobs:
 
         run: |
           cd src
-          docker compose run verify
+          ${{ matrix.config.extra_env }} docker compose run verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -145,9 +145,12 @@ jobs:
           - {platform: "fedora", arch: "amd64"}
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
-          - {platform: "ubuntu", arch: "amd64",
-             extra_label: "-memcheck",
-             compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"}
+          - {
+              platform: "ubuntu",
+              arch: "amd64",
+              extra_label: "-memcheck",
+              compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"
+            }
           - {platform: "ubuntu", arch: "arm64"}
           - {platform: "alpine", arch: "s390x"}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -151,8 +151,8 @@ jobs:
               extra_label: "-memcheck",
               compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"
             }
-          - {platform: "ubuntu", arch: "arm64"}
-          - {platform: "alpine", arch: "s390x"}
+          - {platform: "ubuntu", arch: "arm64", compose_args: "-e TEST_C_BUNDLED=0"}
+          - {platform: "alpine", arch: "s390x", compose_args: "-e TEST_C_BUNDLED=0"}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -155,7 +155,7 @@ jobs:
               platform: "ubuntu",
               arch: "amd64",
               extra_label: "-c99",
-              compose_args: "-e NANOARROW_CMAKE_OPTIONS=CMAKE_C_STANDARD=99"
+              compose_args: "-e NANOARROW_CMAKE_OPTIONS=-DCMAKE_C_STANDARD=99"
             }
           - {platform: "ubuntu", arch: "arm64", compose_args: "-e TEST_C_BUNDLED=0"}
           - {platform: "alpine", arch: "s390x", compose_args: "-e TEST_C_BUNDLED=0"}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -142,6 +142,7 @@ jobs:
       matrix:
         config:
           - {platform: "ubuntu", arch: "amd64"}
+          - {platform: "ubuntu", arch: "arm64"}
           - {platform: "fedora", arch: "amd64"}
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
@@ -166,5 +167,4 @@ jobs:
 
         run: |
           cd src
-          # docker compose pull verify
           docker compose run verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -171,4 +171,4 @@ jobs:
         run: |
           cd src
           # Set GITHUB_WORKSPACE to set more log-friendly headers
-          docker compose -e GITHUB_WORKSPACE=1 ${{ matrix.config.compose_args }} run verify
+          docker compose run -e GITHUB_WORKSPACE=1 ${{ matrix.config.compose_args }} verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -173,5 +173,4 @@ jobs:
 
         run: |
           cd src
-          # Set GITHUB_WORKSPACE to set more log-friendly headers
-          docker compose run -e GITHUB_WORKSPACE=1 ${{ matrix.config.compose_args }} verify
+          docker compose run -e GITHUB_ACTIONS ${{ matrix.config.compose_args }} verify

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -135,7 +135,7 @@ jobs:
           name: nanoarrow-verify-tmp
 
   verify-docker:
-    name: "docker-${{ matrix.config.platform }}-${{ matrix.config.arch }}"
+    name: "docker-${{ matrix.config.platform }}-${{ matrix.config.arch }}${{ matrix.config.extra_label}}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -145,7 +145,7 @@ jobs:
           - {platform: "fedora", arch: "amd64"}
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
-          - {platform: "ubuntu", arch: "amd64", extra_env: "TEST_WITH_MEMCHECK=1"}
+          - {platform: "ubuntu", arch: "amd64", extra_label: "-memcheck", extra_env: "TEST_WITH_MEMCHECK=1"}
           - {platform: "ubuntu", arch: "arm64"}
           - {platform: "alpine", arch: "s390x"}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -151,6 +151,12 @@ jobs:
               extra_label: "-memcheck",
               compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"
             }
+          - {
+              platform: "ubuntu",
+              arch: "amd64",
+              extra_label: "-c99",
+              compose_args: "-e NANOARROW_CMAKE_OPTIONS=CMAKE_C_STANDARD=99"
+            }
           - {platform: "ubuntu", arch: "arm64", compose_args: "-e TEST_C_BUNDLED=0"}
           - {platform: "alpine", arch: "s390x", compose_args: "-e TEST_C_BUNDLED=0"}
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -146,7 +146,8 @@ jobs:
           - {platform: "archlinux", arch: "amd64"}
           - {platform: "alpine", arch: "amd64"}
           - {platform: "ubuntu", arch: "amd64",
-             extra_label: "-memcheck", extra_env: "TEST_WITH_MEMCHECK=1 TEST_C_BUNDLED=0"}
+             extra_label: "-memcheck",
+             compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"}
           - {platform: "ubuntu", arch: "arm64"}
           - {platform: "alpine", arch: "s390x"}
 
@@ -169,4 +170,4 @@ jobs:
 
         run: |
           cd src
-          ${{ matrix.config.extra_env }} docker compose run verify
+          docker compose ${{ matrix.config.compose_args }} run verify

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,11 +171,13 @@ if(NANOARROW_BUILD_TESTS)
         FetchContent_Declare(
             googletest
             URL https://github.com/google/googletest/archive/release-1.11.0.zip
+            URL_HASH SHA256=353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
         )
     else()
         FetchContent_Declare(
             googletest
             URL https://github.com/google/googletest/archive/release-1.10.0.zip
+            URL_HASH SHA256=94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
         )
     endif()
 

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -10,3 +10,7 @@ r/nanoarrow.Rproj
 *.Rd
 r/tests/testthat/_snaps/*.md
 r/cran-comments.md
+dist/flatcc/*
+dist/flatcc.c
+extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_flatcc_generated.h
+extensions/nanoarrow_ipc/thirdparty/*

--- a/dev/release/source_build.sh
+++ b/dev/release/source_build.sh
@@ -47,12 +47,7 @@ main() {
     rm -rf "${base_name}.tmp/"
 
     # Remove components that are not yet ready for packaging
-    rm -rf "${base_name}/extensions"
     rm -rf "${base_name}/python"
-    rm -rf "${base_name}/dist/flatcc"
-    rm -f "${base_name}/dist/flatcc.c"
-    rm -f "${base_name}/dist/nanoarrow_ipc.c"
-    rm -f "${base_name}/dist/nanoarrow_ipc.h"
 
     # Create new tarball
     tar czf "${tar_ball}" "${base_name}/"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -28,12 +28,12 @@
 # - NANOARROW_CMAKE_OPTIONS (e.g., to help cmake find Arrow C++)
 # - R_HOME: Path to the desired R installation. Defaults to `R` on PATH.
 # - TEST_SOURCE: Set to 0 to selectively run component verification.
-# - TEST_C: Builds the C library and tests using the default CMake
+# - TEST_C: Builds C libraries and tests using the default CMake
 #   configuration. Defaults to the value of TEST_SOURCE.
-# - TEST_C_BUNDLED: Bundles and builds the nanoarrow.h/nanorrow.c distribution
-#   and runs tests. Defaults to the value of TEST_SOURCE.
 # - TEST_R: Builds the R package source tarball and runs R CMD check.
 #   Defaults to the value of TEST_SOURCE.
+# - TEST_WITH_MEMCHECK: Set to a nonzero value to additionally run tests
+#   with memcheck. This requires valgrind on PATH.
 
 set -e
 set -o pipefail
@@ -176,9 +176,8 @@ setup_tempdir() {
   echo "Working in sandbox ${NANOARROW_TMPDIR}"
 }
 
-test_c() {
-  show_header "Build and test C library"
-
+# Usage: test_cmake_project build-dir src-dir extra-config-arg1 extra-config-arg...
+test_cmake_project() {
   if [ -z "${CMAKE_BIN}" ]; then
     CMAKE_BIN=cmake
   fi
@@ -187,50 +186,42 @@ test_c() {
     CTEST_BIN=ctest
   fi
 
-  mkdir -p $NANOARROW_TMPDIR/build
-  pushd $NANOARROW_TMPDIR/build
+  mkdir -p "${NANOARROW_TMPDIR}/${1}"
+  pushd "${NANOARROW_TMPDIR}/${1}"
 
   show_info "Configure CMake Project"
-  "$CMAKE_BIN" ${NANOARROW_SOURCE_DIR} \
-    -DNANOARROW_BUILD_TESTS=ON \
+  ${CMAKE_BIN} "${NANOARROW_SOURCE_DIR}/${2}" \
+    "${@:3}" \
     ${NANOARROW_CMAKE_OPTIONS:-}
 
   show_info "Build CMake Project"
-  "$CMAKE_BIN" --build .
+  ${CMAKE_BIN} --build .
 
   show_info "Run Tests"
-  "$CTEST_BIN" --output-on-failure
+  ${CTEST_BIN} --output-on-failure
+
+  if [ ${TEST_WITH_MEMCHECK} -gt 0 ]; then
+    show_info "Run Tests with memcheck"
+    ${CTEST_BIN} -T memcheck .
+  fi
 
   popd
 }
 
-test_c_bundled() {
-  show_header "Build test C library"
+test_c() {
+  show_header "Build and test C library"
+  test_cmake_project build . -DNANOARROW_BUILD_TESTS=ON
 
-  if [ -z "${CMAKE_BIN}" ]; then
-    CMAKE_BIN=cmake
-  fi
+  show_header "Build test bundled C library"
+  test_cmake_project build-bundled . -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_BUNDLE=ON
 
-  if [ -z "${CTEST_BIN}" ]; then
-    CTEST_BIN=ctest
-  fi
+  show_header "Build and test C IPC extension"
+  test_cmake_project build-ipc extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_TESTS=ON
 
-  mkdir -p $NANOARROW_TMPDIR/build_bundled
-  pushd $NANOARROW_TMPDIR/build_bundled
-
-  show_info "Configure CMake Project"
-  "$CMAKE_BIN" ${NANOARROW_SOURCE_DIR} \
-    -DNANOARROW_BUILD_TESTS=ON \
-    -DNANOARROW_BUNDLE=ON \
-    ${NANOARROW_CMAKE_OPTIONS:-}
-
-  show_info "Build CMake Project"
-  "$CMAKE_BIN" --build .
-
-  show_info "Run Tests"
-  "$CTEST_BIN" --output-on-failure
-
-  popd
+  show_header "Build and test bundled C IPC extension"
+  test_cmake_project build-ipc extensions/nanoarrow_ipc \
+    -DNANOARROW_IPC_BUILD_TESTS=ON \
+    -DNANOARROW_IPC_BUNDLE=ON
 }
 
 test_r() {
@@ -325,10 +316,10 @@ test_source_distribution() {
 # To deactivate one test, deactivate the test and all of its dependents
 # To explicitly select one test, set TEST_DEFAULT=0 TEST_X=1
 : ${TEST_DEFAULT:=1}
+: ${TEST_WITH_MEMCHECK:=0}
 
 : ${TEST_SOURCE:=${TEST_DEFAULT}}
 : ${TEST_C:=${TEST_SOURCE}}
-: ${TEST_C_BUNDLED:=${TEST_SOURCE}}
 : ${TEST_R:=${TEST_SOURCE}}
 
 TEST_SUCCESS=no

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -30,6 +30,7 @@
 # - TEST_SOURCE: Set to 0 to selectively run component verification.
 # - TEST_C: Builds C libraries and tests using the default CMake
 #   configuration. Defaults to the value of TEST_SOURCE.
+# - TEST_C_BUNDLED: Tests the bundled version of the C libraries.
 # - TEST_R: Builds the R package source tarball and runs R CMD check.
 #   Defaults to the value of TEST_SOURCE.
 # - TEST_WITH_MEMCHECK: Set to a nonzero value to additionally run tests
@@ -212,11 +213,13 @@ test_c() {
   show_header "Build and test C library"
   test_cmake_project build . -DNANOARROW_BUILD_TESTS=ON
 
-  show_header "Build test bundled C library"
-  test_cmake_project build-bundled . -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_BUNDLE=ON
-
   show_header "Build and test C IPC extension"
   test_cmake_project build-ipc extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_TESTS=ON
+}
+
+test_c_bundled() {
+  show_header "Build test bundled C library"
+  test_cmake_project build-bundled . -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_BUNDLE=ON
 
   show_header "Build and test bundled C IPC extension"
   test_cmake_project build-ipc extensions/nanoarrow_ipc \
@@ -320,6 +323,7 @@ test_source_distribution() {
 
 : ${TEST_SOURCE:=${TEST_DEFAULT}}
 : ${TEST_C:=${TEST_SOURCE}}
+: ${TEST_C_BUNDLED:=${TEST_C}}
 : ${TEST_R:=${TEST_SOURCE}}
 
 TEST_SUCCESS=no

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -76,7 +76,7 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 NANOARROW_DIR="$(cd "${SOURCE_DIR}/../.." && pwd)"
 
 show_header() {
-  if [ -z "$GITHUB_WORKSPACE" ]; then
+  if [ -z "$GITHUB_ACTIONS" ]; then
     echo ""
     printf '=%.0s' $(seq ${#1}); printf '\n'
     echo "${1}"

--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -16,8 +16,12 @@
 # under the License.
 
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.14)
 include(FetchContent)
+
+if(NOT DEFINED CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
 
 project(nanoarrow_ipc)
 
@@ -181,11 +185,24 @@ if (NANOARROW_IPC_BUILD_TESTS)
   message(STATUS "Arrow SO version: ${ARROW_FULL_SO_VERSION}")
 
   # Warning about timestamps of downloaded files
-  cmake_policy(SET CMP0135 NEW)
-  FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/release-1.11.0.zip
-  )
+  if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.23")
+      cmake_policy(SET CMP0135 NEW)
+  endif()
+
+  # Use an old version of googletest if we have to to support gcc 4.8
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "5.0.0")
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/release-1.11.0.zip
+    )
+  else()
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/release-1.10.0.zip
+    )
+  endif()
+
   FetchContent_MakeAvailable(googletest)
 
   enable_testing()
@@ -199,8 +216,20 @@ if (NANOARROW_IPC_BUILD_TESTS)
     target_link_libraries(nanoarrow_ipc PRIVATE ipc_coverage_config)
   endif()
 
-  target_link_libraries(nanoarrow_ipc_decoder_test nanoarrow_ipc nanoarrow arrow_shared gtest_main)
-  target_link_libraries(nanoarrow_ipc_reader_test nanoarrow_ipc nanoarrow gtest_main)
+  # On Windows, dynamically linking Arrow is difficult to get right,
+  # so use static linking by default.
+  if (MSVC)
+      set(NANOARROW_IPC_ARROW_TARGET arrow_static)
+  else()
+      set(NANOARROW_IPC_ARROW_TARGET arrow_shared)
+  endif()
+
+  target_link_libraries(
+    nanoarrow_ipc_decoder_test
+    nanoarrow_ipc nanoarrow ${NANOARROW_IPC_ARROW_TARGET} gtest_main)
+  target_link_libraries(
+    nanoarrow_ipc_reader_test
+    nanoarrow_ipc nanoarrow gtest_main)
 
   include(GoogleTest)
   gtest_discover_tests(nanoarrow_ipc_decoder_test)

--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -195,11 +195,13 @@ if (NANOARROW_IPC_BUILD_TESTS)
     FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/release-1.11.0.zip
+        URL_HASH SHA256=353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
     )
   else()
     FetchContent_Declare(
         googletest
         URL https://github.com/google/googletest/archive/release-1.10.0.zip
+        URL_HASH SHA256=94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
     )
   endif()
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -21,6 +21,8 @@
 
 #include "nanoarrow_ipc.h"
 
+#include "flatcc/portable/pendian_detect.h"
+
 static uint8_t kSimpleSchema[] = {
     0xff, 0xff, 0xff, 0xff, 0x10, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x0a, 0x00, 0x0e, 0x00, 0x06, 0x00, 0x05, 0x00, 0x08, 0x00, 0x0a, 0x00, 0x00, 0x00,
@@ -155,14 +157,20 @@ TEST(NanoarrowIpcReader, StreamReaderBasic) {
   ASSERT_EQ(ArrowIpcArrayStreamReaderInit(&stream, &input, nullptr), NANOARROW_OK);
 
   struct ArrowSchema schema;
+
   ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
   schema.release(&schema);
 
   struct ArrowArray array;
+  // TODO: Support endian swapping (GH-171)
+#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
+#else
+  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
+#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -197,9 +205,14 @@ TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
   schema.release(&schema);
 
   struct ArrowArray array;
+  // TODO: Support endian swapping (GH-171)
+#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
+#else
+  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
+#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -233,9 +246,14 @@ TEST(NanoarrowIpcReader, StreamReaderBasicWithEndOfStream) {
   schema.release(&schema);
 
   struct ArrowArray array;
+  // TODO: Support endian swapping (GH-171)
+#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
+#else
+  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
+#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);


### PR DESCRIPTION
This PR:

- Adds the IPC extension to the release verification
- Adds a memcheck option to release verification (off by default)
- Adds the IPC extension to the source tarball now that it's being verified
- Adds arm64, memcheck, and centos7 to the CI configuration that runs the verification script (with bundling checks turned off for anything that runs on qemu)