### PR TITLE
chore(ci): Add centos7 image; add valgrind and arrow/R to ubuntu image

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -42,9 +42,11 @@ jobs:
           - { platform: "fedora", arch: "amd64" }
           - { platform: "archlinux", arch: "amd64" }
           - { platform: "alpine", arch: "amd64" }
+          - { platform: "centos7", arch: "amd64" }
 
           - { platform: "ubuntu", arch: "arm64" }
           - { platform: "alpine", arch: "arm64" }
+          - { platform: "centos7", arch: "arm64" }
 
           - { platform: "alpine", arch: "s390x" }
 

--- a/ci/docker/centos7.dockerfile
+++ b/ci/docker/centos7.dockerfile
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG NANOARROW_ARCH
+
+FROM --platform=linux/${NANOARROW_ARCH} centos:7
+
+RUN yum install -y epel-release
+RUN yum install -y git gnupg curl R gcc-c++ cmake3
+
+RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# For Arrow C++. Use 9.0.0 because this version works fine with the default gcc
+RUN curl https://dlcdn.apache.org/arrow/arrow-9.0.0/apache-arrow-9.0.0.tar.gz | tar -zxf - && \
+    mkdir /arrow-build && \
+    cd /arrow-build && \
+    cmake3 ../apache-arrow-9.0.0/cpp \
+        -DARROW_JEMALLOC=OFF \
+        -DARROW_SIMD_LEVEL=NONE \
+        -DCMAKE_INSTALL_PREFIX=../arrow && \
+    cmake3 --build . && \
+    make install
+
+# For R. Note that arrow is not installed (takes too long).
+RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr"), repos = "https://cloud.r-project.org")'
+
+ENV NANOARROW_CMAKE_OPTIONS -DArrow_DIR=/arrow/lib/cmake/Arrow
+ENV CMAKE_BIN cmake3
+ENV CTEST_BIN ctest3

--- a/ci/docker/ubuntu.dockerfile
+++ b/ci/docker/ubuntu.dockerfile
@@ -19,7 +19,7 @@ ARG NANOARROW_ARCH
 
 FROM --platform=linux/${NANOARROW_ARCH} ubuntu:latest
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales git cmake r-base gnupg curl
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales git cmake r-base gnupg curl valgrind
 RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 
 # For Arrow C++
@@ -29,5 +29,10 @@ RUN apt-get install -y -V ca-certificates lsb-release wget && \
     apt-get update && \
     apt-get install -y -V libarrow-dev
 
-# For R. Note that arrow is not installed (takes too long).
+# For R. Note that we install arrow here so that the integration tests for R run
+# in at least one test image.
 RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr"), repos = "https://cloud.r-project.org")'
+
+# Required for this to work on MacOS/arm64
+RUN mkdir ~/.R && echo "CXX17FLAGS += -fPIC" > ~/.R/Makevars
+RUN ARROW_USE_PKG_CONFIG=false ARROW_R_DEV=true R -e 'install.packages("arrow", repos = "https://cloud.r-project.org"); library(arrow)'


### PR DESCRIPTION
...so that we can run memcheck from docker compose and at least one image runs nanoarrow/R tests with arrow/R installed.