### PR TITLE
feat: Implement `ArrowArrayViewValidateFull()`

### DIFF
--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -677,7 +677,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int32[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >=0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }
@@ -692,7 +692,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int64[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >=0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }
@@ -728,7 +728,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int32[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }
@@ -757,7 +757,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int64[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }
@@ -814,9 +814,8 @@ static int ArrowAssertIncreasingInt32(struct ArrowBufferView view,
   for (int64_t i = 1; i < view.size_bytes / (int64_t)sizeof(int32_t); i++) {
     int32_t diff = view.data.as_int32[i] - view.data.as_int32[i - 1];
     if (diff < 0) {
-      ArrowErrorSet(error,
-                    "Expected element size >0 but found element size %ld at position %ld",
-                    (long)diff, (long)i);
+      ArrowErrorSet(error, "[%ld] Expected element size >= 0 but found element size %ld",
+                    (long)i, (long)diff);
       return EINVAL;
     }
   }
@@ -833,9 +832,8 @@ static int ArrowAssertIncreasingInt64(struct ArrowBufferView view,
   for (int64_t i = 1; i < view.size_bytes / (int64_t)sizeof(int64_t); i++) {
     int64_t diff = view.data.as_int64[i] - view.data.as_int64[i - 1];
     if (diff < 0) {
-      ArrowErrorSet(error,
-                    "Expected element size >0 but found element size %ld at position %ld",
-                    (long)diff, (long)i);
+      ArrowErrorSet(error, "[%ld] Expected element size >= 0 but found element size %ld",
+                    (long)i, (long)diff);
       return EINVAL;
     }
   }
@@ -847,10 +845,9 @@ static int ArrowAssertRangeInt8(struct ArrowBufferView view, int8_t min_value,
                                 int8_t max_value, struct ArrowError* error) {
   for (int64_t i = 0; i < view.size_bytes; i++) {
     if (view.data.as_int8[i] < min_value || view.data.as_int8[i] > max_value) {
-      ArrowErrorSet(
-          error,
-          "Expected buffer value between %d and %d but found value %d at position %ld",
-          (int)min_value, (int)max_value, (int)view.data.as_int8[i], (long)i);
+      ArrowErrorSet(error,
+                    "[%ld] Expected buffer value between %d and %d but found value %d",
+                    (long)i, (int)min_value, (int)max_value, (int)view.data.as_int8[i]);
       return EINVAL;
     }
   }
@@ -870,8 +867,8 @@ static int ArrowAssertInt8In(struct ArrowBufferView view, const int8_t* values,
     }
 
     if (!item_found) {
-      ArrowErrorSet(error, "Unexpected buffer value %d at position %ld",
-                    (int)view.data.as_int8[i], (long)i);
+      ArrowErrorSet(error, "[%ld] Unexpected buffer value %d", (long)i,
+                    (int)view.data.as_int8[i]);
       return EINVAL;
     }
   }
@@ -924,10 +921,11 @@ ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
       int64_t offset = ArrowArrayViewUnionChildOffset(array_view, i);
       int64_t child_length = array_view->array->children[child_id]->length;
       if (offset < 0 || offset > child_length) {
-        ArrowErrorSet(error,
-                      "Expected union offset for child id %d to be between 0 and %ld but "
-                      "found offset value %ld at position %ld",
-                      (int)child_id, (long)child_length, offset, (long)i);
+        ArrowErrorSet(
+            error,
+            "[%ld] Expected union offset for child id %d to be between 0 and %ld but "
+            "found offset value %ld",
+            (long)i, (int)child_id, (long)child_length, offset);
         return EINVAL;
       }
     }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -663,15 +663,25 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
   }
 
   if (array_view->n_children != array->n_children) {
+    ArrowErrorSet(error, "Expected %ld children but found %ld children",
+                  (long)array_view->n_children, (long)array->n_children);
     return EINVAL;
   }
 
   // Check child sizes and calculate sizes that depend on data in the array buffers
+  int64_t first_offset;
   int64_t last_offset;
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_BINARY:
       if (array_view->buffer_views[1].size_bytes != 0) {
+        first_offset = array_view->buffer_views[1].data.as_int32[0];
+        if (first_offset < 0) {
+          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+                        (long)first_offset);
+          return EINVAL;
+        }
+
         last_offset =
             array_view->buffer_views[1].data.as_int32[array->offset + array->length];
         array_view->buffer_views[2].size_bytes = last_offset;
@@ -680,6 +690,13 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_LARGE_STRING:
     case NANOARROW_TYPE_LARGE_BINARY:
       if (array_view->buffer_views[1].size_bytes != 0) {
+        first_offset = array_view->buffer_views[1].data.as_int64[0];
+        if (first_offset < 0) {
+          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+                        (long)first_offset);
+          return EINVAL;
+        }
+
         last_offset =
             array_view->buffer_views[1].data.as_int64[array->offset + array->length];
         array_view->buffer_views[2].size_bytes = last_offset;
@@ -709,6 +726,13 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       }
 
       if (array_view->buffer_views[1].size_bytes != 0) {
+        first_offset = array_view->buffer_views[1].data.as_int32[0];
+        if (first_offset < 0) {
+          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+                        (long)first_offset);
+          return EINVAL;
+        }
+
         last_offset =
             array_view->buffer_views[1].data.as_int32[array->offset + array->length];
         if (array->children[0]->length < last_offset) {
@@ -731,6 +755,13 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       }
 
       if (array_view->buffer_views[1].size_bytes != 0) {
+        first_offset = array_view->buffer_views[1].data.as_int64[0];
+        if (first_offset < 0) {
+          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+                        (long)first_offset);
+          return EINVAL;
+        }
+
         last_offset =
             array_view->buffer_views[1].data.as_int64[array->offset + array->length];
         if (array->children[0]->length < last_offset) {

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -904,7 +904,10 @@ ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
   if (array_view->storage_type == NANOARROW_TYPE_DENSE_UNION ||
       array_view->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
     // Slightly easier to check the default 0...n union type id
-    if (array_view->union_type_id_map == NULL) {
+    if (array_view->union_type_id_map == NULL ||
+        _ArrowParsedUnionTypeIdsWillEqualChildIndices(array_view->union_type_id_map,
+                                                      array_view->n_children,
+                                                      array_view->n_children)) {
       NANOARROW_RETURN_NOT_OK(ArrowAssertRangeInt8(array_view->buffer_views[0], 0,
                                                    array_view->n_children - 1, error));
     } else {

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -630,7 +630,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
     return EINVAL;
   }
 
-  if (array->offset < 0) {
+  if (array->length < 0) {
     ArrowErrorSet(error, "Expected array length >= 0 but found array length of %ld",
                   (long)array->length);
     return EINVAL;
@@ -880,9 +880,8 @@ static int ArrowAssertInt8In(struct ArrowBufferView view, const int8_t* values,
 }
 
 ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
-                                          struct ArrowArray* array,
                                           struct ArrowError* error) {
-  for (int i = 0; i < array->n_buffers; i++) {
+  for (int i = 0; i < 3; i++) {
     switch (array_view->layout.buffer_type[i]) {
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
         NANOARROW_RETURN_NOT_OK(
@@ -913,6 +912,10 @@ ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
                                                 array_view->union_type_id_map + 128,
                                                 array_view->n_children, error));
     }
+  }
+
+  for (int64_t i = 0; i < array_view->n_children; i++) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayViewValidateFull(array_view->children[i], error));
   }
 
   return NANOARROW_OK;

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -677,7 +677,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int32[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >=0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }
@@ -692,7 +692,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int64[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >0 but found %ld",
+          ArrowErrorSet(error, "Expected first offset >=0 but found %ld",
                         (long)first_offset);
           return EINVAL;
         }

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -94,10 +94,9 @@ static inline int8_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) 
   return -1;
 }
 
-static inline int8_t _ArrowUnionTypeIdsWillEqualChildIndices(const char* type_id_str,
-                                                             int64_t n_children) {
-  int8_t type_ids[128];
-  int8_t n_type_ids = _ArrowParseUnionTypeIds(type_id_str, type_ids);
+static inline int8_t _ArrowParsedUnionTypeIdsWillEqualChildIndices(const int8_t* type_ids,
+                                                                   int64_t n_type_ids,
+                                                                   int64_t n_children) {
   if (n_type_ids != n_children) {
     return 0;
   }
@@ -109,6 +108,13 @@ static inline int8_t _ArrowUnionTypeIdsWillEqualChildIndices(const char* type_id
   }
 
   return 1;
+}
+
+static inline int8_t _ArrowUnionTypeIdsWillEqualChildIndices(const char* type_id_str,
+                                                             int64_t n_children) {
+  int8_t type_ids[128];
+  int8_t n_type_ids = _ArrowParseUnionTypeIds(type_id_str, type_ids);
+  return _ArrowParsedUnionTypeIdsWillEqualChildIndices(type_ids, n_type_ids, n_children);
 }
 
 static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array) {

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1376,14 +1376,13 @@ TEST(ArrayTest, ArrayViewTestString) {
 
   offsets[0] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Expected first offset >0 but found -1");
+  EXPECT_STREQ(error.message, "Expected first offset >= 0 but found -1");
   offsets[0] = 0;
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
-  EXPECT_STREQ(error.message,
-               "Expected element size >0 but found element size -1 at position 1");
+  EXPECT_STREQ(error.message, "[1] Expected element size >= 0 but found element size -1");
 
   array.release(&array);
   ArrowArrayViewReset(&array_view);
@@ -1445,14 +1444,13 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
 
   offsets[0] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Expected first offset >0 but found -1");
+  EXPECT_STREQ(error.message, "Expected first offset >= 0 but found -1");
   offsets[0] = 0;
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
-  EXPECT_STREQ(error.message,
-               "Expected element size >0 but found element size -1 at position 1");
+  EXPECT_STREQ(error.message, "[1] Expected element size >= 0 but found element size -1");
 
   array.release(&array);
   ArrowArrayViewReset(&array_view);
@@ -1530,14 +1528,13 @@ TEST(ArrayTest, ArrayViewTestList) {
 
   offsets[0] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Expected first offset >0 but found -1");
+  EXPECT_STREQ(error.message, "Expected first offset >= 0 but found -1");
   offsets[0] = 0;
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
-  EXPECT_STREQ(error.message,
-               "Expected element size >0 but found element size -1 at position 1");
+  EXPECT_STREQ(error.message, "[1] Expected element size >= 0 but found element size -1");
 
   array.release(&array);
   ArrowArrayViewReset(&array_view);
@@ -1584,14 +1581,13 @@ TEST(ArrayTest, ArrayViewTestLargeList) {
 
   offsets[0] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Expected first offset >0 but found -1");
+  EXPECT_STREQ(error.message, "Expected first offset >= 0 but found -1");
   offsets[0] = 0;
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
-  EXPECT_STREQ(error.message,
-               "Expected element size >0 but found element size -1 at position 1");
+  EXPECT_STREQ(error.message, "[1] Expected element size >= 0 but found element size -1");
 
   array.release(&array);
   ArrowArrayViewReset(&array_view);
@@ -1761,14 +1757,14 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   type_ids[0] = -1;
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
-               "Expected buffer value between 0 and 1 but found value -1 at position 0");
+               "[0] Expected buffer value between 0 and 1 but found value -1");
   type_ids[0] = 0;
 
   offsets[0] = -1;
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
-               "Expected union offset for child id 0 to be between 0 and 1 but found "
-               "offset value -1 at position 0");
+               "[0] Expected union offset for child id 0 to be between 0 and 1 but found "
+               "offset value -1");
   offsets[0] = 0;
 
   ArrowArrayViewReset(&array_view);
@@ -1788,7 +1784,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   // Check that bad type ids are caught by validate full
   type_ids[0] = -1;
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Unexpected buffer value -1 at position 0");
+  EXPECT_STREQ(error.message, "[0] Unexpected buffer value -1");
   type_ids[0] = 0;
 
   ArrowArrayViewReset(&array_view);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1752,15 +1752,24 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 1), 1);
 
-  // Check that bad type ids are caught by validate full
+  // Check that bad type ids/offset are caught by validate full
   struct ArrowError error;
   int8_t* type_ids =
       const_cast<int8_t*>(reinterpret_cast<const int8_t*>(array.buffers[0]));
+  int32_t* offsets =
+      const_cast<int32_t*>(reinterpret_cast<const int32_t*>(array.buffers[1]));
   type_ids[0] = -1;
   EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
                "Expected buffer value between 0 and 1 but found value -1 at position 0");
   type_ids[0] = 0;
+
+  offsets[0] = -1;
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
+  EXPECT_STREQ(error.message,
+               "Expected union offset for child id 0 to be between 0 and 1 but found "
+               "offset value -1 at position 0");
+  offsets[0] = 0;
 
   ArrowArrayViewReset(&array_view);
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1282,6 +1282,17 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 1);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 3 * sizeof(int32_t));
 
+  // Expect error for bad offset + length
+  array.length = -1;
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
+  EXPECT_STREQ(error.message, "Expected array length >= 0 but found array length of -1");
+  array.length = 3;
+
+  array.offset = -1;
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
+  EXPECT_STREQ(error.message, "Expected array offset >= 0 but found array offset of -1");
+  array.offset = 0;
+
   // Expect error for the wrong number of buffers
   ArrowArrayViewReset(&array_view);
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_STRING);
@@ -1366,7 +1377,7 @@ TEST(ArrayTest, ArrayViewTestString) {
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &array, &error), EINVAL);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
                "Expected element size >0 but found element size -1 at position 1");
 
@@ -1433,7 +1444,7 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &array, &error), EINVAL);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
                "Expected element size >0 but found element size -1 at position 1");
 
@@ -1496,7 +1507,8 @@ TEST(ArrayTest, ArrayViewTestList) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_LIST), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAllocateChildren(&array, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayInitFromType(array.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromType(array.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 1234), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(&array), NANOARROW_OK);
@@ -1516,7 +1528,7 @@ TEST(ArrayTest, ArrayViewTestList) {
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &array, &error), EINVAL);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
                "Expected element size >0 but found element size -1 at position 1");
 
@@ -1548,7 +1560,8 @@ TEST(ArrayTest, ArrayViewTestLargeList) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_LARGE_LIST), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAllocateChildren(&array, 1), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayInitFromType(array.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromType(array.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 1234), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(&array), NANOARROW_OK);
@@ -1568,7 +1581,7 @@ TEST(ArrayTest, ArrayViewTestLargeList) {
 
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &array, &error), EINVAL);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
                "Expected element size >0 but found element size -1 at position 1");
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1267,6 +1267,7 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 3 * sizeof(int32_t));
   EXPECT_EQ(array_view.buffer_views[1].data.as_int32[0], 11);
@@ -1279,6 +1280,7 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 1);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 3 * sizeof(int32_t));
 
@@ -1349,6 +1351,7 @@ TEST(ArrayTest, ArrayViewTestString) {
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   array.null_count = 0;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[2].size_bytes, 0);
@@ -1362,6 +1365,7 @@ TEST(ArrayTest, ArrayViewTestString) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, (1 + 1) * sizeof(int32_t));
   EXPECT_EQ(array_view.buffer_views[2].size_bytes, 4);
@@ -1416,6 +1420,7 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   array.null_count = 0;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[2].size_bytes, 0);
@@ -1429,6 +1434,7 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, (1 + 1) * sizeof(int64_t));
   EXPECT_EQ(array_view.buffer_views[2].size_bytes, 4);
@@ -1515,6 +1521,7 @@ TEST(ArrayTest, ArrayViewTestList) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   // Expect error for offsets that will cause bad access
   struct ArrowError error;
@@ -1568,6 +1575,7 @@ TEST(ArrayTest, ArrayViewTestLargeList) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   // Expect error for offsets that will cause bad access
   struct ArrowError error;
@@ -1645,6 +1653,7 @@ TEST(ArrayTest, ArrayViewTestStructArray) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.children[0]->buffer_views[1].size_bytes, sizeof(int32_t));
   EXPECT_EQ(array_view.children[0]->buffer_views[1].data.as_int32[0], 123);
 
@@ -1687,6 +1696,7 @@ TEST(ArrayTest, ArrayViewTestFixedSizeListArray) {
   ASSERT_EQ(ArrowArrayFinishBuilding(&array, &error), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
   EXPECT_EQ(array_view.children[0]->buffer_views[1].size_bytes, 3 * sizeof(int32_t));
   EXPECT_EQ(array_view.children[0]->buffer_views[1].data.as_int32[0], 123);
 
@@ -1723,6 +1733,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ArrowArrayViewInitFromType(array_view.children[0], NANOARROW_TYPE_INT32);
   ArrowArrayViewInitFromType(array_view.children[1], NANOARROW_TYPE_STRING);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
@@ -1747,6 +1758,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+ud:1,0"), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
@@ -1793,6 +1805,7 @@ TEST(ArrayTest, ArrayViewTestDenseUnionGet) {
   // Initialize the array view
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   // Check the values that will be used to index into children
   EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 0);
@@ -1837,6 +1850,7 @@ TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
   // Initialize the array view
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, nullptr), NANOARROW_OK);
 
   // Check the values that will be used to index into children
   EXPECT_EQ(ArrowArrayViewUnionChildIndex(&array_view, 0), 0);
@@ -1877,6 +1891,7 @@ void TestGetFromNumericArrayView() {
   ARROW_EXPECT_OK(ExportArray(*arrow_array, &array, &schema));
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 2), 1);
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 3), 0);
@@ -1907,6 +1922,7 @@ void TestGetFromNumericArrayView() {
   ARROW_EXPECT_OK(ExportArray(*arrow_array, &array, &schema));
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
 
   // We're trying to test behavior with no validity buffer, so make sure that's true
   ASSERT_EQ(array_view.buffer_views[0].data.data, nullptr);
@@ -1953,6 +1969,7 @@ void TestGetFromBinary(BuilderClass& builder) {
   ARROW_EXPECT_OK(ExportArray(*arrow_array, &array, &schema));
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidateFull(&array_view, &error), NANOARROW_OK);
 
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 2), 1);
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 3), 0);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -112,6 +112,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewSetLength)
 #define ArrowArrayViewSetArray \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewSetArray)
+#define ArrowArrayViewValidateFull \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewValidateFull)
 #define ArrowArrayViewReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewReset)
 #define ArrowBasicArrayStreamInit \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowBasicArrayStreamInit)

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -893,6 +893,10 @@ void ArrowArrayViewSetLength(struct ArrowArrayView* array_view, int64_t length);
 ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
                                       struct ArrowArray* array, struct ArrowError* error);
 
+/// \brief Performs extra checks on the array that was set via ArrowArrayViewSetArray()
+ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
+                                          struct ArrowArray* array, struct ArrowError* error);
+
 /// \brief Reset the contents of an ArrowArrayView and frees resources
 void ArrowArrayViewReset(struct ArrowArrayView* array_view);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -897,7 +897,7 @@ ArrowErrorCode ArrowArrayViewSetArray(struct ArrowArrayView* array_view,
 
 /// \brief Performs extra checks on the array that was set via ArrowArrayViewSetArray()
 ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
-                                          struct ArrowArray* array, struct ArrowError* error);
+                                          struct ArrowError* error);
 
 /// \brief Reset the contents of an ArrowArrayView and frees resources
 void ArrowArrayViewReset(struct ArrowArrayView* array_view);

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -503,7 +503,8 @@ struct ArrowArrayView {
   ///
   /// If storage_type is a union type, a 256-byte ArrowMalloc()ed buffer
   /// such that child_index == union_type_id_map[type_id] and
-  /// type_id == union_type_id_map[128 + child_index]
+  /// type_id == union_type_id_map[128 + child_index]. This value may be
+  /// NULL in the case where child_id == type_id.
   int8_t* union_type_id_map;
 };
 


### PR DESCRIPTION
This is required for IPC reading because corrupted offset and/or union type ID buffers could result in consumers accessing out-of-bounds elements. `ArrowArrayViewSetArray()` already checked the *last* element of offset buffers against lengths but didn't check the first element and didn't check for negative sequential offsets.