### PR TITLE
feat(extensions/nanoarrow_ipc): Add option to validate arrays at `NANOARROW_VALIDATION_LEVEL_FULL`

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -275,6 +275,15 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(struct ArrowIpcDecoder* deco
                                                     int64_t i, struct ArrowArray* out,
                                                     struct ArrowError* error);
 
+/// \brief Validate a decoded ArrowArray
+///
+/// Verifies buffer lengths and contents depending on validation_level. Users
+/// are reccomended to use NANOARROW_VALIDATION_LEVEL_FULL as any lesser value
+/// may result in some types of corrupted data crashing a process on read.
+ArrowErrorCode ArrowIpcDecoderValidateArray(struct ArrowArray* decoded,
+                                            enum ArrowValidationLevel validation_level,
+                                            struct ArrowError* error);
+
 /// \brief An user-extensible input data source
 struct ArrowIpcInputStream {
   /// \brief Read up to buf_size_bytes from stream into buf

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1378,10 +1378,9 @@ static ArrowErrorCode ArrowIpcDecoderDecodeArrayInternal(
     }
   }
 
-  // TODO: this performs some validation but doesn't do everything we need it to do
-  // notably it doesn't loop over offset buffers to look for values that will cause
-  // out-of-bounds buffer access on the data buffer or child arrays.
-  result = ArrowArrayFinishBuildingDefault(&temp, error);
+  // Finish building to flush internal pointers but defer validation to
+  // ArrowIpcDecoderValidateArray()
+  result = ArrowArrayFinishBuilding(&temp, NANOARROW_VALIDATION_LEVEL_NONE, error);
   if (result != NANOARROW_OK) {
     temp.release(&temp);
     return result;
@@ -1405,4 +1404,10 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(struct ArrowIpcDecoder* deco
                                                     struct ArrowError* error) {
   return ArrowIpcDecoderDecodeArrayInternal(
       decoder, ArrowIpcBufferFactoryFromShared(body), i, out, error);
+}
+
+ArrowErrorCode ArrowIpcDecoderValidateArray(struct ArrowArray* decoded,
+                                            enum ArrowValidationLevel validation_level,
+                                            struct ArrowError* error) {
+  return ArrowArrayFinishBuilding(decoded, validation_level, error);
 }

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -295,6 +295,9 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   // Check full struct extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, -1, &array, nullptr),
             NANOARROW_OK);
+  EXPECT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   EXPECT_EQ(array.null_count, 0);
   ASSERT_EQ(array.n_children, 1);
@@ -309,6 +312,9 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
 
   // Check field extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array, nullptr), NANOARROW_OK);
+  EXPECT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
   ASSERT_EQ(array.n_buffers, 2);
   ASSERT_EQ(array.length, 3);
   EXPECT_EQ(array.null_count, 0);
@@ -478,6 +484,9 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchFromShared) {
   // Check full struct extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArrayFromShared(&decoder, &shared, -1, &array, nullptr),
             NANOARROW_OK);
+  EXPECT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
 
   EXPECT_EQ(array.length, 3);
   EXPECT_EQ(array.null_count, 0);
@@ -494,6 +503,10 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchFromShared) {
   // Check field extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArrayFromShared(&decoder, &shared, 0, &array, nullptr),
             NANOARROW_OK);
+  EXPECT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
+
   // Release the original shared (forthcoming array buffers should still be valid)
   ArrowIpcSharedBufferReset(&shared);
 
@@ -543,8 +556,12 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSharedBufferThreadSafeDecode) {
 
   struct ArrowArray arrays[10];
   for (int i = 0; i < 10; i++) {
-    ASSERT_EQ(ArrowIpcDecoderDecodeArrayFromShared(&decoder, &shared, -1, arrays + i, nullptr),
-            NANOARROW_OK);
+    ASSERT_EQ(
+        ArrowIpcDecoderDecodeArrayFromShared(&decoder, &shared, -1, arrays + i, nullptr),
+        NANOARROW_OK);
+    ASSERT_EQ(ArrowIpcDecoderValidateArray(arrays + i, NANOARROW_VALIDATION_LEVEL_FULL,
+                                           nullptr),
+              NANOARROW_OK);
   }
 
   // Clean up
@@ -556,7 +573,8 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSharedBufferThreadSafeDecode) {
   std::thread threads[10];
   for (int i = 0; i < 10; i++) {
     threads[i] = std::thread([&arrays, i, &one_two_three_le] {
-      memcmp(arrays[i].children[0]->buffers[1], one_two_three_le, sizeof(one_two_three_le));
+      memcmp(arrays[i].children[0]->buffers[1], one_two_three_le,
+             sizeof(one_two_three_le));
       arrays[i].release(arrays + i);
     });
   }
@@ -605,6 +623,10 @@ TEST_P(ArrowTypeParameterizedTestFixture, NanoarrowIpcArrowArrayRoundtrip) {
   buffer_view.size_bytes -= decoder.header_size_bytes;
   ASSERT_EQ(ArrowIpcDecoderDecodeArray(&decoder, buffer_view, -1, &array, nullptr),
             NANOARROW_OK);
+  struct ArrowError error;
+  ASSERT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
 
   auto maybe_batch = arrow::ImportRecordBatch(&array, dummy_schema);
   ASSERT_TRUE(maybe_batch.ok());
@@ -622,6 +644,9 @@ TEST_P(ArrowTypeParameterizedTestFixture, NanoarrowIpcArrowArrayRoundtrip) {
   buffer_view.size_bytes -= decoder.header_size_bytes;
   ASSERT_EQ(ArrowIpcDecoderDecodeArray(&decoder, buffer_view, -1, &array, nullptr),
             NANOARROW_OK);
+  ASSERT_EQ(
+      ArrowIpcDecoderValidateArray(&array, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
+      NANOARROW_OK);
 
   maybe_batch = arrow::ImportRecordBatch(&array, dummy_schema);
   ASSERT_TRUE(maybe_batch.ok());


### PR DESCRIPTION
...and do it by default in tests and in the reader.