### PR TITLE
feat: Add Decimal Get/Set utilities

### DIFF
--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -530,17 +530,28 @@ static inline ArrowErrorCode ArrowArrayAppendDecimal(struct ArrowArray* array,
       if (value->n_words != 2) {
         return EINVAL;
       } else {
-        return ArrowBufferAppend(data_buffer, value->words, 2 * sizeof(uint64_t));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowBufferAppend(data_buffer, value->words, 2 * sizeof(uint64_t)));
+        break;
       }
     case NANOARROW_TYPE_DECIMAL256:
       if (value->n_words != 4) {
         return EINVAL;
       } else {
-        return ArrowBufferAppend(data_buffer, value->words, 4 * sizeof(uint64_t));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowBufferAppend(data_buffer, value->words, 4 * sizeof(uint64_t)));
+        break;
       }
     default:
       return EINVAL;
   }
+
+  if (private_data->bitmap.buffer.data != NULL) {
+    NANOARROW_RETURN_NOT_OK(ArrowBitmapAppend(ArrowArrayValidityBitmap(array), 1, 1));
+  }
+
+  array->length++;
+  return NANOARROW_OK;
 }
 
 static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array) {

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -831,13 +831,13 @@ static inline struct ArrowBufferView ArrowArrayViewGetBytesUnsafe(
 static inline void ArrowArrayViewGetDecimalUnsafe(struct ArrowArrayView* array_view,
                                                   int64_t i, struct ArrowDecimal* out) {
   i += array_view->array->offset;
-  const uint8_t* data_view = array_view->buffer_views[2].data.as_uint8;
+  const uint8_t* data_view = array_view->buffer_views[1].data.as_uint8;
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_DECIMAL128:
-      ArrowDecimalSetBytes(out, data_view + (i * 32));
+      ArrowDecimalSetBytes(out, data_view + (i * 16));
       break;
     case NANOARROW_TYPE_DECIMAL256:
-      ArrowDecimalSetBytes(out, data_view + (i * 64));
+      ArrowDecimalSetBytes(out, data_view + (i * 32));
       break;
     default:
       memset(out->words, 0, sizeof(out->words));

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -828,6 +828,23 @@ static inline struct ArrowBufferView ArrowArrayViewGetBytesUnsafe(
   return view;
 }
 
+static inline void ArrowArrayViewGetDecimalUnsafe(struct ArrowArrayView* array_view,
+                                                  int64_t i, struct ArrowDecimal* out) {
+  i += array_view->array->offset;
+  const uint8_t* data_view = array_view->buffer_views[2].data.as_uint8;
+  switch (array_view->storage_type) {
+    case NANOARROW_TYPE_DECIMAL128:
+      ArrowDecimalSetBytes(out, data_view + (i * 32));
+      break;
+    case NANOARROW_TYPE_DECIMAL256:
+      ArrowDecimalSetBytes(out, data_view + (i * 64));
+      break;
+    default:
+      memset(out->words, 0, sizeof(out->words));
+      break;
+  }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -519,6 +519,30 @@ static inline ArrowErrorCode ArrowArrayAppendString(struct ArrowArray* array,
   }
 }
 
+static inline ArrowErrorCode ArrowArrayAppendDecimal(struct ArrowArray* array,
+                                                     struct ArrowDecimal* value) {
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)array->private_data;
+  struct ArrowBuffer* data_buffer = ArrowArrayBuffer(array, 1);
+
+  switch (private_data->storage_type) {
+    case NANOARROW_TYPE_DECIMAL128:
+      if (value->n_words != 2) {
+        return EINVAL;
+      } else {
+        return ArrowBufferAppend(data_buffer, value->words, 2 * sizeof(uint64_t));
+      }
+    case NANOARROW_TYPE_DECIMAL256:
+      if (value->n_words != 4) {
+        return EINVAL;
+      } else {
+        return ArrowBufferAppend(data_buffer, value->words, 4 * sizeof(uint64_t));
+      }
+    default:
+      return EINVAL;
+  }
+}
+
 static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array) {
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -966,6 +966,14 @@ static inline struct ArrowStringView ArrowArrayViewGetStringUnsafe(
 static inline struct ArrowBufferView ArrowArrayViewGetBytesUnsafe(
     struct ArrowArrayView* array_view, int64_t i);
 
+/// \brief Get an element in an ArrowArrayView as an ArrowDecimal
+///
+/// This function does not check for null values. The out parameter must
+/// be initialized with ArrowDecimalInit() with the proper parameters for this
+/// type before calling this for the first time.
+static inline void ArrowArrayViewGetDecimalUnsafe(struct ArrowArrayView* array_view,
+                                                  int64_t i, struct ArrowDecimal* out);
+
 /// @}
 
 /// \defgroup nanoarrow-basic-array-stream Basic ArrowArrayStream implementation

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -824,11 +824,19 @@ static inline ArrowErrorCode ArrowArrayAppendBytes(struct ArrowArray* array,
                                                    struct ArrowBufferView value);
 
 /// \brief Append a string value to an array
+///
 /// Returns NANOARROW_OK if value can be exactly represented by
 /// the underlying storage type or EINVAL otherwise (e.g.,
 /// the underlying array is not a string or large string array).
 static inline ArrowErrorCode ArrowArrayAppendString(struct ArrowArray* array,
                                                     struct ArrowStringView value);
+
+/// \brief Append a decimal value to an array
+///
+/// Returns NANOARROW_OK if array is a decimal array with the appropriate
+/// bitwidth or EINVAL otherwise.
+static inline ArrowErrorCode ArrowArrayAppendDecimal(struct ArrowArray* array,
+                                                     struct ArrowDecimal* value);
 
 /// \brief Finish a nested array element
 ///

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -600,9 +600,7 @@ static inline void ArrowDecimalInit(struct ArrowDecimal* decimal, int32_t bitwid
 /// within the signed 64-bit integer range (A precision less than or equal
 /// to 18 is sufficiently small).
 static inline int64_t ArrowDecimalGetIntUnsafe(struct ArrowDecimal* decimal) {
-  int64_t value = decimal->words[decimal->low_word_index];
-  int64_t sign_word = decimal->words[decimal->high_word_index];
-  return value |= sign_word;
+  return (int64_t)decimal->words[decimal->low_word_index];
 }
 
 /// \brief Copy the bytes of this decimal into a sufficiently large buffer

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -618,9 +618,15 @@ static inline int64_t ArrowDecimalSign(struct ArrowDecimal* decimal) {
 /// \brief Sets the integer value of this decimal
 /// \ingroup nanoarrow-utils
 static inline void ArrowDecimalSetInt(struct ArrowDecimal* decimal, int64_t value) {
-  int64_t sign_word = value & ((int64_t)1) << 63;
-  value &= ~(((int64_t)1) << 63);
-  decimal->words[decimal->high_word_index] = (uint64_t)sign_word;
+  if (value < 0) {
+    decimal->words[decimal->high_word_index] = (uint64_t)-1;
+    for (int i = decimal->low_word_index + 1; i < decimal->high_word_index; i++) {
+      decimal->words[i] = ~0;
+    }
+  } else {
+    memset(decimal->words, 0, decimal->n_words * sizeof(uint64_t));
+  }
+
   decimal->words[decimal->low_word_index] = value;
 }
 

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -159,7 +159,12 @@ TEST(DecimalTest, Decimal128Test) {
   EXPECT_EQ(decimal.n_words, 2);
   EXPECT_EQ(decimal.precision, 10);
   EXPECT_EQ(decimal.scale, 3);
-  EXPECT_EQ(decimal.high_word_index - decimal.low_word_index + 1, decimal.n_words);
+
+  if (_ArrowIsLittleEndian()) {
+    EXPECT_EQ(decimal.high_word_index - decimal.low_word_index + 1, decimal.n_words);
+  } else {
+    EXPECT_EQ(decimal.low_word_index - decimal.high_word_index + 1, decimal.n_words);
+  }
 
   auto dec_pos = *Decimal128::FromString("12.345");
   uint8_t bytes_pos[16];
@@ -191,7 +196,12 @@ TEST(DecimalTest, Decimal256Test) {
   EXPECT_EQ(decimal.n_words, 4);
   EXPECT_EQ(decimal.precision, 10);
   EXPECT_EQ(decimal.scale, 3);
-  EXPECT_EQ(decimal.high_word_index - decimal.low_word_index + 1, decimal.n_words);
+
+  if (_ArrowIsLittleEndian()) {
+    EXPECT_EQ(decimal.high_word_index - decimal.low_word_index + 1, decimal.n_words);
+  } else {
+    EXPECT_EQ(decimal.low_word_index - decimal.high_word_index + 1, decimal.n_words);
+  }
 
   auto dec_pos = *Decimal256::FromString("12.345");
   uint8_t bytes_pos[32];


### PR DESCRIPTION
Closes #170.

This is not designed to be a fully-featured performant decimal math library, but is designed to help with byte shuffling and provide enough support that users can write tests for decimal arrays (e.g., by providing integer getters and setters for numbers that fit within the int64 range).

Adds a `struct ArrowDecimal` and utility functions:

```c
static inline void ArrowDecimalInit(struct ArrowDecimal* decimal, int32_t bitwidth,
                                    int32_t precision, int32_t scale);
static inline int64_t ArrowDecimalGetIntUnsafe(struct ArrowDecimal* decimal);
static inline void ArrowDecimalGetBytes(struct ArrowDecimal* decimal, uint8_t* out);
static inline int64_t ArrowDecimalSign(struct ArrowDecimal* decimal);
static inline void ArrowDecimalSetInt(struct ArrowDecimal* decimal, int64_t value);
static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
                                        const uint8_t* value);
```

...and adds a "getter" and an "appender":

```c
static inline ArrowErrorCode ArrowArrayAppendDecimal(struct ArrowArray* array,
                                                     struct ArrowDecimal* value);
static inline void ArrowArrayViewGetDecimalUnsafe(struct ArrowArrayView* array_view,
                                                  int64_t i, struct ArrowDecimal* out);
```
