### PR TITLE
chore(ci): Add documentation build tools to the Ubuntu docker image

### DIFF
--- a/ci/docker/ubuntu.dockerfile
+++ b/ci/docker/ubuntu.dockerfile
@@ -19,7 +19,7 @@ ARG NANOARROW_ARCH
 
 FROM --platform=linux/${NANOARROW_ARCH} ubuntu:latest
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales git cmake r-base gnupg curl valgrind
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales git cmake r-base gnupg curl valgrind python3-pip doxygen pandoc
 RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 
 # For Arrow C++
@@ -29,9 +29,12 @@ RUN apt-get install -y -V ca-certificates lsb-release wget && \
     apt-get update && \
     apt-get install -y -V libarrow-dev
 
+# For documentation build
+RUN pip3 install pip3 install pydata-sphinx-theme sphinx breathe
+
 # For R. Note that we install arrow here so that the integration tests for R run
 # in at least one test image.
-RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr"), repos = "https://cloud.r-project.org")'
+RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "pkgdown"), repos = "https://cloud.r-project.org")'
 
 # Required for this to work on MacOS/arm64
 RUN mkdir ~/.R && echo "CXX17FLAGS += -fPIC" > ~/.R/Makevars


### PR DESCRIPTION
The Ubuntu image is unofficially the "maximal" image (it also contains the arrow R package). Adding this in a separate PR from the actual build script so that I can manually trigger the image push once this is merged (and then it will be available for pulling by CI in the relevant PR).