### PR TITLE
docs: Add "getting started with nanoarrow" tutorial

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,6 +32,7 @@ on:
       - 'extensions/nanoarrow_ipc/src/**'
       - 'src/**'
       - 'r/**'
+      - 'docs/source/**'
 
 jobs:
   docs:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -101,3 +101,11 @@ jobs:
           gcc -o example_vendored_ipc_app app.c libexample_vendored_ipc_library.a
 
           cat ../schema-valid.arrows | ./example_vendored_ipc_app
+
+      - name: Getting Started Tutorial Example
+        run: |
+          cd examples/linesplitter
+          mkdir build && cd build
+          cmake ..
+          cmake --build .
+          ctest .

--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -78,6 +78,9 @@ main() {
    # Use the README as the docs homepage
    pandoc ../README.md --from markdown --to rst -s -o source/README_generated.rst
 
+   # Do some Markdown -> reST conversion
+   pandoc source/getting-started.md --from markdown --to rst -s -o source/getting-started_generated.rst
+
    # Build sphinx project
    sphinx-build source _build/html
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -16,4 +16,4 @@
 # under the License.
 
 _build/
-README_generated.rst
+*_generated.rst

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -141,21 +141,61 @@ Next, we'll provide definitions for the functions we'll implement below:
 #include <string>
 #include <util>
 
-#define LINESTRING_OK 0
-
-int linesplitter_read(const char* src, struct ArrowArray* out);
+int linesplitter_read(const std::string& src, struct ArrowArray* out);
 std::pair<int, std::string> linesplitter_write(struct ArrowArray* input);
-int linesplitter_separate_longer(struct ArrowArray* input, struct ArrowArray* output);
+int linesplitter_separate_longer(struct ArrowArray* input, struct ArrowArray* out);
 ```
 
-## The basics
+## Arow C data interface basics
 
-- Error handling
-- Memory management
+Now that we've seen the functions we need to implement and the Arrow types exposed
+in the C data interface, let's unpack a few basics about using the Arrow C data
+interface and a few conventions used in the nanoarrow implementation.
 
-## The tests
+First, let's discuss the `ArrowSchema` and the `ArrowArray`. You can think of an
+`ArrowSchema` as an expression of a data type, whereas an `ArrowArray` is the
+data itself. These structures accomodate nested types: columns are encoded in
+the `children` member of each. You always need to know the data type of an
+`ArrowArray` before accessing its contents. In our case we only operate on arrays
+of one type ("string") and document that in our interface; for functions that
+operate on more than one type of array you will need to accept an `ArrowSchema`
+and inspect it (e.g., using nanoarrow's helper functions).
 
+Second, lets discuss error handling. You may have noticed in the function definitions
+above that we return `int`, which is an errno-compatible error code or `0` to
+indicate success. This is the error reporting scheme used by the C data interface and
+nanoarrow and is common in C where exceptions and C++17's `std::optional<>` are not
+possible. If your library performs becomes complex and needs to communicate detailed
+error information you will need to choose one of those idioms. In our library, the
+only thing that can go wrong is if the OS fails to allocate memory, and this is
+sufficiently communicated using the errno code `ENOMEM`.
 
+## Building the library
+
+We'll fill in the implementations below, but for now we can add enough stubs that
+the project will compile. In `linesplitter.cc`, add:
+
+```c
+#include <string>
+#include <util>
+#include <errno.h>
+
+#include "nanoarrow.h"
+
+#include "linesplitter.h"
+
+int linesplitter_read(const std::string& src, struct ArrowArray* out) {
+  return ENOTSUP;
+}
+
+std::pair<int, std::string> linesplitter_write(struct ArrowArray* input) {
+  return {ENOTSUP, ""};
+}
+
+int linesplitter_separate_longer(struct ArrowArray* input, struct ArrowArray* out) {
+    return ENOTSUP;
+}
+```
 
 ## Reading into an ArrowArray
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -473,6 +473,13 @@ the command palette. If all goes well, choose **Test: Run All Tests** from the c
 pallete to run them! You should see some output indiciating that tests ran successfully,
 or you can use VSCode's "Testing" panel to visually inspect which tests passed.
 
+```{=rst}
+.. note::
+  If you're not using VSCode, you can accomplish the equivalent task in in a terminal
+  with ``cd build && ctest .``.
+
+```
+
 ## Summary
 
 This tutorial covered the basics of writing and testing a C++ library exposing an

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -38,18 +38,19 @@ Arrow C++, Rust, and Go are all excellent choices and can compile into
 static libraries that are C-linkable from other languages; however, existing Arrow
 implementations produce relatively large static libraries and can present complex build-time
 or run-time linking requirements depending on the implementation and features used. If
-the set of libraries you're working with already provide the conveniences you need,
+the set of libraries you're working with already provide the conveniences you require,
 nanoarrow may provide all the functionality you need.
 
 Now that we've talked about why you might want to build a library with nanoarrow...let's
 build one!
 
-```
+```{=rst}
 .. note::
   This tutorial also goes over some of the basic structure of writing a C++ library.
   If you already know how to do this, feel free to scroll to the code examples provided
   below or take a look at the
-  [complete example source](https://github.com/apache/arrow-nanoarrow/tree/main/examples/linesplitter).
+  `final example project <https://github.com/apache/arrow-nanoarrow/tree/main/examples/linesplitter>`__.
+
 ```
 
 ## The library
@@ -161,13 +162,14 @@ std::pair<int, std::string> linesplitter_read(const std::string& src,
 std::pair<int, std::string> linesplitter_write(struct ArrowArray* input);
 ```
 
-```
+```{=rst}
 .. note::
   You may notice that we don't include or mention nanoarrow in any way in the header
   that is exposed to users. Because nanoarrow is designed to be vendored and is not
   distributed as a system library, it is not safe for users of your library to
-  `#include "nanoarrow.h"` because it might conflict with another library that does
+  ``#include "nanoarrow.h"`` because it might conflict with another library that does
   the same (with possibly a different version of nanoarrow).
+
 ```
 
 ## Arrow C data/nanoarrow interface basics
@@ -308,16 +310,18 @@ directory in VSCode to activate the CMake integration. From the command pallete
 (i.e., Control/Command-Shift-P), choose **CMake: Build**. If all went well, you should
 see a few lines of output indicating progress towards building and linking `linesplitter`.
 
-```
+```{=rst}
 .. note::
   Depending on your version of CMake you might also see a few warnings. This CMakeLists.txt
   is intentionally minimal and as such does not attempt to silence them.
-```
 
 ```
+
+```{=rst}
 .. note::
   If you're not using VSCode, you can accomplish the equivalent task in in a terminal
-  with `mkdir build && cd build && cmake .. && cmake --build .`.
+  with ``mkdir build && cd build && cmake .. && cmake --build .``.
+
 ```
 
 ## Building an ArrowArray

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -58,6 +58,10 @@ For the sake of argument, we'll call it `linesplitter`.
 
 ## The development environment
 
+If you're reading this tutorial there is a good chance you already have a
+workflow for building and testing C/C++ libraries. If you do, skip to the
+next section!
+
 There are many excellent IDEs that can be used to develop C and C++ libraries. For
 this tutorial, we will use [VSCode](https://code.visualstudio.com/) and
 [CMake](https://cmake.org/). You'll need both installed to follow along:
@@ -163,17 +167,18 @@ and inspect it (e.g., using nanoarrow's helper functions).
 
 Second, lets discuss error handling. You may have noticed in the function definitions
 above that we return `int`, which is an errno-compatible error code or `0` to
-indicate success. This is the error reporting scheme used by the C data interface and
+indicate success. This is the error reporting scheme used by the C stream interface and
 nanoarrow and is common in C where exceptions and C++17's `std::optional<>` are not
-possible. If your library performs becomes complex and needs to communicate detailed
+possible. If your library becomes complex and needs to communicate detailed
 error information you will need to choose one of those idioms. In our library, the
 only thing that can go wrong is if the OS fails to allocate memory, and this is
 sufficiently communicated using the errno code `ENOMEM`.
 
 ## Building the library
 
-We'll fill in the implementations below, but for now we can add enough stubs that
-the project will compile. In `linesplitter.cc`, add:
+Our library implementation will live in `linesplitter.cc`. Before writing the
+actual implementations, let's add just enough to our project that we can
+build it using VSCode's C/C++/CMake integration:
 
 ```c
 #include <string>
@@ -196,6 +201,32 @@ int linesplitter_separate_longer(struct ArrowArray* input, struct ArrowArray* ou
     return ENOTSUP;
 }
 ```
+
+We also need a `CMakeLists.txt` file that tells CMake and VSCode what to build.
+CMake has a lot of options and scale to coordinate very large projects; however
+we only need a few lines to leverage VSCode's integration.
+
+```cmake
+include(FetchContent)
+
+project(linesplitter)
+
+FetchContent_Declare(
+  nanoarrow
+  URL https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.1.0/apache-arrow-nanoarrow-0.1.0.tar.gz
+  URL_HASH SHA512=dc62480b986ee76aaad8e38c6fbc602f8cef2cc35a5f5ede7da2a93b4db2b63839bdca3eefe8a44ae1cb6895a2fd3f090e3f6ea1020cf93cfe86437304dfee17)
+
+FetchContent_MakeAvailable(nanoarrow_example_cmake_minimal)
+
+add_library(linesplitter linesplitter.cc)
+```
+
+After saving `CMakeLists.txt`, you may have to close and re-open the `linesplitter`
+directory in VSCode to activate the CMake integration. From the command pallete
+(i.e., Control/Command-Shift-P), choose **CMake: Build**. If all went well, you should
+see a few lines of output indicating progress towards building and linking `linesplitter`.
+
+If you're not using VSCode, the equivalent in a terminal would be `mkdir build && cd build && cmake .. && cmake --build .`.
 
 ## Reading into an ArrowArray
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -79,8 +79,9 @@ you will need to install
 [Visual Studio](https://visualstudio.microsoft.com/downloads/) and
 CMake from the official download pages.
 
-After installing the required dependencies, create a folder called `linesplitter`
-and open it.
+Once you have VSCode installed, ensure you have the **CMake Tools** and **C/C++**
+extensions installed. Once your environment is set up, create a folder called
+`linesplitter` and open it using **File -> Open Folder**.
 
 ## The interface
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -1,0 +1,71 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Getting started with nanoarrow
+
+This tutorial provides a short example of writing a C++ library that exposes
+an Arrow-based API and uses nanoarrow to implement a simple text file reader/writer.
+In general, nanoarrow can help you write a library or application that:
+
+- exposes an Arrow-based API to read from a data source or format,
+- exposes an Arrow-based API to write to a data source or format,
+- exposes one or more compute functions that operates on and produces data
+  in the form of Arrow arrays, and/or
+- exposes an extension type implementation.
+
+Becauase Arrow has bindings in many languages, it means that you or others can easily
+bind or use your tool in higher-level runtimes like R, Java, C++, Python, Rust, Julia,
+Go, or Ruby, among others.
+
+The nanoarrow library is not the only way that an Arrow-based API can be implemented: Arrow C++, Rust, and Go are all excellent choices and can compile into
+static libraries that are C-linkable from other languages; however, existing Arrow
+implementations produce relatively large static libraries and can present complex build-time
+or run-time linking requirements depending on the implementation and features used. If
+the set of libraries you're working with already provide the conveniences you need,
+nanoarrow may provide all the functionality you need.
+
+Now that we've talked about why you might want to build a library with nanoarrow...let's
+build one!
+
+## The interface
+
+- C data
+
+## Basic nanoarrow
+
+- Error handling
+- Memory management
+
+## Reading into an ArrowArray
+
+read lines into a string array
+
+## Writing from an ArrowArray
+
+assemble lines from a string array
+
+## Exposing a computation
+
+Count lines
+
+## Exposing bindings in R
+
+## Exposing bindings in Python
+
+

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -33,7 +33,8 @@ Becauase Arrow has bindings in many languages, it means that you or others can e
 bind or use your tool in higher-level runtimes like R, Java, C++, Python, Rust, Julia,
 Go, or Ruby, among others.
 
-The nanoarrow library is not the only way that an Arrow-based API can be implemented: Arrow C++, Rust, and Go are all excellent choices and can compile into
+The nanoarrow library is not the only way that an Arrow-based API can be implemented:
+Arrow C++, Rust, and Go are all excellent choices and can compile into
 static libraries that are C-linkable from other languages; however, existing Arrow
 implementations produce relatively large static libraries and can present complex build-time
 or run-time linking requirements depending on the implementation and features used. If
@@ -68,7 +69,8 @@ this tutorial, we will use [VSCode](https://code.visualstudio.com/) and
 VSCode can be downloaded from the official site for most platforms;
 CMake is typically installed via your favourite package manager
 (e.g., `brew install cmake`, `apt-get install cmake` `dnf install cmake`,
-etc.). You will also need a C and C++ compiler: on MacOS these can be installed using `xcode-select --install`; on Linux you will need the packages that provice
+etc.). You will also need a C and C++ compiler: on MacOS these can be installed
+using `xcode-select --install`; on Linux you will need the packages that provice
 `gcc`, `g++`, and `make`; on Windows you will need to install
 [Visual Studio](https://visualstudio.microsoft.com/downloads/) and
 CMake from the official download pages.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -277,11 +277,11 @@ build it using VSCode's C/C++/CMake integration:
 
 std::pair<int, std::string> linesplitter_read(const std::string& src,
                                               struct ArrowArray* out) {
-  return ENOTSUP;
+  return {ENOTSUP, ""};
 }
 
 std::pair<int, std::string> linesplitter_write(struct ArrowArray* input) {
-  return ENOTSUP;
+  return {ENOTSUP, ""};
 }
 ```
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -15,15 +15,4 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-.. include:: README_generated.rst
-
-Contents
---------
-
-.. toctree::
-   :maxdepth: 2
-
-   Getting Started <getting-started>
-   C API Reference <c>
-   C++ API Reference <cpp>
-   IPC Extension Reference <ipc>
+.. include:: getting-started_generated.rst

--- a/examples/linesplitter/CMakeLists.txt
+++ b/examples/linesplitter/CMakeLists.txt
@@ -42,7 +42,7 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 add_executable(linesplitter_test linesplitter_test.cc)
-target_link_libraries(linesplitter_test linesplitter GTest::gtest_main)
+target_link_libraries(linesplitter_test linesplitter nanoarrow GTest::gtest_main)
 
 include(GoogleTest)
 gtest_discover_tests(linesplitter_test)

--- a/examples/linesplitter/CMakeLists.txt
+++ b/examples/linesplitter/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 project(linesplitter)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -6,9 +23,26 @@ include(FetchContent)
 
 FetchContent_Declare(
   nanoarrow
-  URL https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.1.0/apache-arrow-nanoarrow-0.1.0.tar.gz
-  URL_HASH SHA512=dc62480b986ee76aaad8e38c6fbc602f8cef2cc35a5f5ede7da2a93b4db2b63839bdca3eefe8a44ae1cb6895a2fd3f090e3f6ea1020cf93cfe86437304dfee17)
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
+  # We use SOURCE_DIR to simplify testing this example on CI; however,
+  # you should use a released version of nanoarrow like so:
+  # URL https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.1.0/apache-arrow-nanoarrow-0.1.0.tar.gz
+  # URL_HASH SHA512=dc62480b986ee76aaad8e38c6fbc602f8cef2cc35a5f5ede7da2a93b4db2b63839bdca3eefe8a44ae1cb6895a2fd3f090e3f6ea1020cf93cfe86437304dfee17)
+)
 FetchContent_MakeAvailable(nanoarrow)
 
 add_library(linesplitter linesplitter.cc)
 target_link_libraries(linesplitter PRIVATE nanoarrow)
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+add_executable(linesplitter_test linesplitter_test.cc)
+target_link_libraries(linesplitter_test linesplitter GTest::gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(linesplitter_test)

--- a/examples/linesplitter/CMakeLists.txt
+++ b/examples/linesplitter/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(linesplitter)
+
+set(CMAKE_CXX_STANDARD 11)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  nanoarrow
+  URL https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.1.0/apache-arrow-nanoarrow-0.1.0.tar.gz
+  URL_HASH SHA512=dc62480b986ee76aaad8e38c6fbc602f8cef2cc35a5f5ede7da2a93b4db2b63839bdca3eefe8a44ae1cb6895a2fd3f090e3f6ea1020cf93cfe86437304dfee17)
+FetchContent_MakeAvailable(nanoarrow)
+
+add_library(linesplitter linesplitter.cc)
+target_link_libraries(linesplitter PRIVATE nanoarrow)

--- a/examples/linesplitter/linesplitter.cc
+++ b/examples/linesplitter/linesplitter.cc
@@ -1,0 +1,80 @@
+
+#include <string>
+#include <sstream>
+#include <utility>
+#include <cerrno>
+#include <cstdint>
+
+#include "nanoarrow/nanoarrow.hpp"
+
+#include "linesplitter.h"
+
+static int64_t find_newline(const ArrowStringView& src) {
+  for (int64_t i = 0; i < src.size_bytes; i++) {
+    if (src.data[i] == '\n') {
+      return i;
+    }
+  }
+
+  return src.size_bytes - 1;
+}
+
+static int linesplitter_read_internal(const std::string& src, ArrowArray* out, ArrowError* error) {
+  nanoarrow::UniqueArray tmp;
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_STRING));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(tmp.get()));
+
+  ArrowStringView src_view = {src.data(), static_cast<int64_t>(src.size())};
+  ArrowStringView line_view;
+  int64_t next_newline = -1;
+  while ((next_newline = find_newline(src_view)) >= 0) {
+    line_view = {src_view.data, next_newline};
+    NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(tmp.get(), line_view));
+    src_view.data += next_newline + 1;
+    src_view.size_bytes -= next_newline + 1;
+  }
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuilding(tmp.get(), error));
+
+  ArrowArrayMove(tmp.get(), out);
+  return NANOARROW_OK;
+}
+
+std::pair<int, std::string> linesplitter_read(const std::string& src, ArrowArray* out) {
+  ArrowError error;
+  int code = linesplitter_read_internal(src, out, &error);
+  if (code != NANOARROW_OK) {
+    return {code, std::string(ArrowErrorMessage(&error))};
+  } else {
+    return {NANOARROW_OK, ""};
+  }
+}
+
+static int linesplitter_write_internal(ArrowArray* input, std::stringstream& out, ArrowError* error) {
+  nanoarrow::UniqueArrayView input_view;
+  ArrowArrayViewInitFromType(input_view.get(), NANOARROW_TYPE_STRING);
+  NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(input_view.get(), input, error));
+
+  ArrowStringView item;
+  for (int64_t i = 0; i < input->length; i++) {
+    if (ArrowArrayViewIsNull(input_view.get(), i)) {
+      out << "\n";
+    } else {
+      item = ArrowArrayViewGetStringUnsafe(input_view.get(), i);
+      out << std::string(item.data, item.size_bytes) << "\n";
+    }
+  }
+
+  return NANOARROW_OK;
+}
+
+std::pair<int, std::string> linesplitter_write(ArrowArray* input) {
+  std::stringstream out;
+  ArrowError error;
+  int code = linesplitter_write_internal(input, out, &error);
+  if (code != NANOARROW_OK) {
+    return {code, std::string(ArrowErrorMessage(&error))};
+  } else {
+    return {NANOARROW_OK, out.str()};
+  }
+}

--- a/examples/linesplitter/linesplitter.cc
+++ b/examples/linesplitter/linesplitter.cc
@@ -32,7 +32,7 @@ static int64_t find_newline(const ArrowStringView& src) {
     }
   }
 
-  return src.size_bytes - 1;
+  return src.size_bytes;
 }
 
 static int linesplitter_read_internal(const std::string& src, ArrowArray* out,

--- a/examples/linesplitter/linesplitter.cc
+++ b/examples/linesplitter/linesplitter.cc
@@ -1,9 +1,9 @@
 
-#include <string>
-#include <sstream>
-#include <utility>
 #include <cerrno>
 #include <cstdint>
+#include <sstream>
+#include <string>
+#include <utility>
 
 #include "nanoarrow/nanoarrow.hpp"
 
@@ -19,7 +19,8 @@ static int64_t find_newline(const ArrowStringView& src) {
   return src.size_bytes - 1;
 }
 
-static int linesplitter_read_internal(const std::string& src, ArrowArray* out, ArrowError* error) {
+static int linesplitter_read_internal(const std::string& src, ArrowArray* out,
+                                      ArrowError* error) {
   nanoarrow::UniqueArray tmp;
   NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(tmp.get(), NANOARROW_TYPE_STRING));
   NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(tmp.get()));
@@ -50,7 +51,8 @@ std::pair<int, std::string> linesplitter_read(const std::string& src, ArrowArray
   }
 }
 
-static int linesplitter_write_internal(ArrowArray* input, std::stringstream& out, ArrowError* error) {
+static int linesplitter_write_internal(ArrowArray* input, std::stringstream& out,
+                                       ArrowError* error) {
   nanoarrow::UniqueArrayView input_view;
   ArrowArrayViewInitFromType(input_view.get(), NANOARROW_TYPE_STRING);
   NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(input_view.get(), input, error));

--- a/examples/linesplitter/linesplitter.cc
+++ b/examples/linesplitter/linesplitter.cc
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #include <cerrno>
 #include <cstdint>
@@ -35,7 +51,7 @@ static int linesplitter_read_internal(const std::string& src, ArrowArray* out,
     src_view.size_bytes -= next_newline + 1;
   }
 
-  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuilding(tmp.get(), error));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuildingDefault(tmp.get(), error));
 
   ArrowArrayMove(tmp.get(), out);
   return NANOARROW_OK;

--- a/examples/linesplitter/linesplitter.h
+++ b/examples/linesplitter/linesplitter.h
@@ -1,3 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 #pragma once
 
@@ -47,6 +63,15 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
+// Builds an ArrowArray of type string that will contain one element for each line
+// in src and places it into out.
+//
+// On success, returns {0, ""}; on error, returns {<errno code>, <error message>}
 std::pair<int, std::string> linesplitter_read(const std::string& src,
                                               struct ArrowArray* out);
+
+// Concatenates all elements of a string ArrowArray inserting a newline between
+// elements.
+//
+// On success, returns {0, <result>}; on error, returns {<errno code>, <error message>}
 std::pair<int, std::string> linesplitter_write(struct ArrowArray* input);

--- a/examples/linesplitter/linesplitter.h
+++ b/examples/linesplitter/linesplitter.h
@@ -47,5 +47,6 @@ struct ArrowArray {
 
 #endif  // ARROW_C_DATA_INTERFACE
 
-std::pair<int, std::string> linesplitter_read(const std::string& src, struct ArrowArray* out);
+std::pair<int, std::string> linesplitter_read(const std::string& src,
+                                              struct ArrowArray* out);
 std::pair<int, std::string> linesplitter_write(struct ArrowArray* input);

--- a/examples/linesplitter/linesplitter.h
+++ b/examples/linesplitter/linesplitter.h
@@ -1,0 +1,51 @@
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <utility>
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+std::pair<int, std::string> linesplitter_read(const std::string& src, struct ArrowArray* out);
+std::pair<int, std::string> linesplitter_write(struct ArrowArray* input);

--- a/examples/linesplitter/linesplitter_test.cc
+++ b/examples/linesplitter/linesplitter_test.cc
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "linesplitter.h"
+
+TEST(Linesplitter, LinesplitterBasic) {
+  EXPECT_EQ(4, 4);
+}


### PR DESCRIPTION
This PR adds a "getting started" tutorial. The basic premise is that it demonstrates building a library in C++ that exposes an Arrow-based API...in the future, one could add tutorials for wrapping it in R and Python as well.

Open to any and all feedback (including a different premise!)