### PR TITLE
feat(r): Union array support

### DIFF
--- a/r/R/as-array.R
+++ b/r/R/as-array.R
@@ -210,6 +210,7 @@ as_nanoarrow_array.vctrs_unspecified <- function(x, ..., schema = NULL) {
   )
 }
 
+# Called from C to create a union array when requested
 union_array_from_data_frame <- function(x, schema) {
   if (length(x) == 0) {
     stop("Can't convert zero-column data frame to Union")
@@ -237,6 +238,7 @@ union_array_from_data_frame <- function(x, schema) {
       })
 
       children <- Map("[", x, is_child, drop = FALSE)
+      names(children) <- names(schema$children)
       array <- nanoarrow_array_init(schema)
       nanoarrow_array_modify(
         array,

--- a/r/R/as-array.R
+++ b/r/R/as-array.R
@@ -210,6 +210,33 @@ as_nanoarrow_array.vctrs_unspecified <- function(x, ..., schema = NULL) {
   )
 }
 
+union_array_from_data_frame <- function(x, schema) {
+  x_is_na <- lapply(x, is.na)
+  child_index <- rep_len(0L, nrow(x))
+  seq_x <- seq_along(x)
+  for (i in seq_along(child_index)) {
+    for (j in seq_x) {
+      if (!x_is_na[[j]][i]) {
+        child_index[i] <- j - 1L
+        break;
+      }
+    }
+  }
+
+  switch(
+    nanoarrow_schema_parse(schema)$storage_type,
+    "dense_union" = {
+      stop("todo")
+    },
+    "sparse_union" = {
+      struct_schema <- na_struct(schema$children)
+      struct_array <- as_nanoarrow_array(x, schema = struct_schema)
+      stop("todo")
+    },
+    stop("Attempt to create union from non-union array type")
+  )
+}
+
 # This is defined because it's verbose to pass named arguments from C.
 # When converting data frame columns, we try the internal C conversions
 # first to save R evaluation overhead. When the internal conversions fail,

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -77,14 +77,19 @@ SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr) {
 SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
                                     SEXP validate_sexp) {
   int validate = LOGICAL(validate_sexp)[0];
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+
+  // Schema needs a copy here because ArrowBasicArrayStreamInit() takes ownership
+  SEXP schema_copy_xptr = PROTECT(schema_owning_xptr());
+  struct ArrowSchema* schema_copy =
+      (struct ArrowSchema*)R_ExternalPtrAddr(schema_copy_xptr);
+  schema_export(schema_xptr, schema_copy);
 
   SEXP array_stream_xptr = PROTECT(array_stream_owning_xptr());
   struct ArrowArrayStream* array_stream =
       (struct ArrowArrayStream*)R_ExternalPtrAddr(array_stream_xptr);
 
   int64_t n_arrays = Rf_xlength(batches_sexp);
-  if (ArrowBasicArrayStreamInit(array_stream, schema, n_arrays) != NANOARROW_OK) {
+  if (ArrowBasicArrayStreamInit(array_stream, schema_copy, n_arrays) != NANOARROW_OK) {
     Rf_error("Failed to initialize array stream");
   }
 
@@ -101,6 +106,6 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
     }
   }
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return array_stream_xptr;
 }

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -57,7 +57,7 @@ static void as_array_int(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
 
   // Only consider the default create for now
   if (schema_view.type != NANOARROW_TYPE_INT32) {
-    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
     return;
   }
 
@@ -132,7 +132,7 @@ static void as_array_lgl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
 
   // Only consider bool for now
   if (schema_view.type != NANOARROW_TYPE_BOOL) {
-    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
     return;
   }
 
@@ -210,7 +210,7 @@ static void as_array_dbl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
     case NANOARROW_TYPE_INT32:
       break;
     default:
-      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
       return;
   }
 
@@ -329,7 +329,7 @@ static void as_array_chr(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
 
   // Only consider the default create for now
   if (schema_view.type != NANOARROW_TYPE_STRING) {
-    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
     return;
   }
 
@@ -423,7 +423,7 @@ static void as_array_data_frame(SEXP x_sexp, struct ArrowArray* array, SEXP sche
     case NANOARROW_TYPE_STRUCT:
       break;
     default:
-      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
       return;
   }
 
@@ -466,7 +466,7 @@ static void as_array_list(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xpt
   // Arbitrary nested list support is complicated without some concept of a
   // "builder", which we don't use.
   if (schema_view.type != NANOARROW_TYPE_BINARY) {
-    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+    call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
     return;
   }
 
@@ -549,7 +549,7 @@ static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_
       as_array_data_frame(x_sexp, array, schema_xptr, error);
       return;
     } else {
-      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
       return;
     }
   }
@@ -571,7 +571,7 @@ static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_
       as_array_list(x_sexp, array, schema_xptr, error);
       return;
     default:
-      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array");
+      call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");
       return;
   }
 }

--- a/r/src/infer_ptype.c
+++ b/r/src/infer_ptype.c
@@ -58,6 +58,8 @@ enum VectorType nanoarrow_infer_vector_type(enum ArrowType type) {
     case NANOARROW_TYPE_LARGE_STRING:
       return VECTOR_TYPE_CHR;
 
+    case NANOARROW_TYPE_DENSE_UNION:
+    case NANOARROW_TYPE_SPARSE_UNION:
     case NANOARROW_TYPE_STRUCT:
       return VECTOR_TYPE_DATA_FRAME;
 

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -214,7 +214,7 @@ static int nanoarrow_materialize_data_frame(struct RConverter* converter,
                                                               converter->src.offset + i);
         converter->children[child_index]->src.offset = child_offset;
         converter->children[child_index]->src.length = 1;
-        converter->children[child_index]->dst.offset = i;
+        converter->children[child_index]->dst.offset = converter->dst.offset + i;
         converter->children[child_index]->dst.length = 1;
         SEXP child_converter_xptr = VECTOR_ELT(child_converter_xptrs, child_index);
         NANOARROW_RETURN_NOT_OK(nanoarrow_materialize(converter->children[child_index],

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -137,22 +137,91 @@ SEXP nanoarrow_materialize_realloc(SEXP ptype, R_xlen_t len) {
   return result;
 }
 
+// Used in union building to pre-set all values to null
+static void fill_vec_with_nulls(SEXP x, R_xlen_t offset, R_xlen_t len) {
+  if (nanoarrow_ptype_is_data_frame(x)) {
+    for (R_xlen_t i = 0; i < Rf_xlength(x); i++) {
+      fill_vec_with_nulls(VECTOR_ELT(x, i), offset, len);
+    }
+
+    return;
+  }
+
+  switch (TYPEOF(x)) {
+    case LGLSXP:
+    case INTSXP: {
+      int* values = INTEGER(x);
+      for (R_xlen_t i = 0; i < len; i++) {
+        values[offset + i] = NA_INTEGER;
+      }
+      return;
+    }
+    case REALSXP: {
+      double* values = REAL(x);
+      for (R_xlen_t i = 0; i < len; i++) {
+        values[offset + i] = NA_REAL;
+      }
+      return;
+    }
+    case STRSXP:
+      for (R_xlen_t i = 0; i < len; i++) {
+        SET_STRING_ELT(x, offset + i, NA_STRING);
+      }
+      return;
+    case VECSXP:
+      for (R_xlen_t i = 0; i < len; i++) {
+        SET_VECTOR_ELT(x, offset + i, R_NilValue);
+      }
+      return;
+    default:
+      Rf_error("Attempt to fill vector with nulls with unsupported type");
+  }
+}
+
 static int nanoarrow_materialize_data_frame(struct RConverter* converter,
                                             SEXP converter_xptr) {
   if (converter->ptype_view.vector_type != VECTOR_TYPE_DATA_FRAME) {
     return EINVAL;
   }
 
-  for (R_xlen_t i = 0; i < converter->n_children; i++) {
-    converter->children[i]->src.offset = converter->src.offset;
-    converter->children[i]->src.length = converter->src.length;
-    converter->children[i]->dst.offset = converter->dst.offset;
-    converter->children[i]->dst.length = converter->dst.length;
-    NANOARROW_RETURN_NOT_OK(
-        nanoarrow_materialize(converter->children[i], converter_xptr));
-  }
+  SEXP converter_shelter = R_ExternalPtrProtected(converter_xptr);
+  SEXP child_converter_xptrs = VECTOR_ELT(converter_shelter, 3);
 
-  return NANOARROW_OK;
+  switch (converter->array_view.storage_type) {
+    case NANOARROW_TYPE_STRUCT:
+      for (R_xlen_t i = 0; i < converter->n_children; i++) {
+        converter->children[i]->src.offset = converter->src.offset;
+        converter->children[i]->src.length = converter->src.length;
+        converter->children[i]->dst.offset = converter->dst.offset;
+        converter->children[i]->dst.length = converter->dst.length;
+        SEXP child_converter_xptr = VECTOR_ELT(child_converter_xptrs, i);
+        NANOARROW_RETURN_NOT_OK(
+            nanoarrow_materialize(converter->children[i], child_converter_xptr));
+      }
+      return NANOARROW_OK;
+
+    case NANOARROW_TYPE_DENSE_UNION:
+    case NANOARROW_TYPE_SPARSE_UNION:
+      // Pre-fill everything with nulls
+      fill_vec_with_nulls(converter->dst.vec_sexp, converter->dst.offset, converter->dst.length);
+
+      // Fill in the possibly non-null values one at a time
+      for (R_xlen_t i = 0; i < converter->dst.length; i++) {
+        int64_t child_index = ArrowArrayViewUnionChildIndex(&converter->array_view,
+                                                            converter->src.offset + i);
+        int64_t child_offset = ArrowArrayViewUnionChildOffset(&converter->array_view,
+                                                              converter->src.offset + i);
+        converter->children[child_index]->src.offset = child_offset;
+        converter->children[child_index]->src.length = 1;
+        converter->children[child_index]->dst.offset = i;
+        converter->children[child_index]->dst.length = 1;
+        SEXP child_converter_xptr = VECTOR_ELT(child_converter_xptrs, child_index);
+        NANOARROW_RETURN_NOT_OK(nanoarrow_materialize(converter->children[child_index],
+                                                      child_converter_xptr));
+      }
+    default:
+      return ENOTSUP;
+  }
 }
 
 static int materialize_list_element(struct RConverter* converter, SEXP converter_xptr,

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -203,7 +203,8 @@ static int nanoarrow_materialize_data_frame(struct RConverter* converter,
     case NANOARROW_TYPE_DENSE_UNION:
     case NANOARROW_TYPE_SPARSE_UNION:
       // Pre-fill everything with nulls
-      fill_vec_with_nulls(converter->dst.vec_sexp, converter->dst.offset, converter->dst.length);
+      fill_vec_with_nulls(converter->dst.vec_sexp, converter->dst.offset,
+                          converter->dst.length);
 
       // Fill in the possibly non-null values one at a time
       for (R_xlen_t i = 0; i < converter->dst.length; i++) {
@@ -219,6 +220,8 @@ static int nanoarrow_materialize_data_frame(struct RConverter* converter,
         NANOARROW_RETURN_NOT_OK(nanoarrow_materialize(converter->children[child_index],
                                                       child_converter_xptr));
       }
+      return NANOARROW_OK;
+
     default:
       return ENOTSUP;
   }

--- a/r/src/schema.h
+++ b/r/src/schema.h
@@ -79,4 +79,11 @@ static inline SEXP schema_owning_xptr(void) {
   return schema_xptr;
 }
 
+static inline void schema_export(SEXP schema_xptr, struct ArrowSchema* schema_copy) {
+  int result = ArrowSchemaDeepCopy(schema_from_xptr(schema_xptr), schema_copy);
+  if (result != NANOARROW_OK) {
+    Rf_error("ArrowSchemaDeepCopy() failed");
+  }
+}
+
 #endif

--- a/r/tests/testthat/test-as-array.R
+++ b/r/tests/testthat/test-as-array.R
@@ -503,7 +503,8 @@ test_that("as_nanoarrow_array() can convert data.frame() to sparse_union()", {
     lgl = c(TRUE, NA, NA, NA, NA, FALSE),
     int = c(NA, 123L, NA, NA, NA, NA),
     dbl = c(NA, NA, 456, NA, NA, NA),
-    chr = c(NA, NA, NA, "789", NA, NA)
+    chr = c(NA, NA, NA, "789", NA, NA),
+    stringsAsFactors = FALSE
   )
 
   array <- as_nanoarrow_array(
@@ -531,7 +532,8 @@ test_that("as_nanoarrow_array() can convert data.frame() to sparse_union()", {
     lgl = c(TRUE, NA, NA, NA, NA, FALSE),
     int = c(NA, 123L, NA, NA, NA, NA),
     dbl = c(NA, NA, 456, NA, NA, NA),
-    chr = c(NA, NA, NA, "789", NA, NA)
+    chr = c(NA, NA, NA, "789", NA, NA),
+    stringsAsFactors = FALSE
   )
 
   array <- as_nanoarrow_array(


### PR DESCRIPTION
Needed to support all the types that ADBC might return (see https://github.com/r-dbi/adbc/discussions/4 ). This currently returns unions as `data.frame()` with NA values (basically a sparse union equivalent for R). There are certainly other ways to represent that in R (maybe just a `list()`). R/nanoarrow models conversions in both directions as many <-> many, so a future PR could implement `as_nanoarrow_array(list(), schema = na_sparse|dense_union()` and/or `convert_array(union_array, list())`.

``` r
library(nanoarrow)

dense_union <- as_nanoarrow_array(
  data.frame(dbl = c(NA, 2), chr = c("one", NA)),
  schema = na_dense_union(list(dbl = na_double(), chr = na_string()))
)

sparse_union <- as_nanoarrow_array(
  data.frame(dbl = c(NA, 2), chr = c("one", NA)),
  schema = na_sparse_union(list(dbl = na_double(), chr = na_string()))
)

dense_union
#> <nanoarrow_array dense_union([0,1])[2]>
#>  $ length    : int 2
#>  $ null_count: int 0
#>  $ offset    : int 0
#>  $ buffers   :List of 2
#>   ..$ :<nanoarrow_buffer_type_id[2 b] at 0x116b8b310>
#>   ..$ :<nanoarrow_buffer_union_offset[8 b] at 0x1270ca660>
#>  $ children  :List of 2
#>   ..$ dbl:<nanoarrow_array double[1]>
#>   .. ..$ length    : int 1
#>   .. ..$ null_count: int 0
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 2
#>   .. .. ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
#>   .. .. ..$ :<nanoarrow_buffer_data_double[8 b] at 0x11693e528>
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>   ..$ chr:<nanoarrow_array string[1]>
#>   .. ..$ length    : int 1
#>   .. ..$ null_count: int 0
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 3
#>   .. .. ..$ :<nanoarrow_buffer_validity[0 b] at 0x0>
#>   .. .. ..$ :<nanoarrow_buffer_data_offset32[8 b] at 0x13700ceb0>
#>   .. .. ..$ :<nanoarrow_buffer_data_utf8[3 b] at 0x1370eff30>
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>  $ dictionary: NULL
convert_array(dense_union)
#>   dbl  chr
#> 1  NA  one
#> 2   2 <NA>

sparse_union
#> <nanoarrow_array sparse_union([0,1])[2]>
#>  $ length    : int 2
#>  $ null_count: int 0
#>  $ offset    : int 0
#>  $ buffers   :List of 1
#>   ..$ :<nanoarrow_buffer_type_id[2 b] at 0x11731f630>
#>  $ children  :List of 2
#>   ..$ dbl:<nanoarrow_array double[2]>
#>   .. ..$ length    : int 2
#>   .. ..$ null_count: int 1
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 2
#>   .. .. ..$ :<nanoarrow_buffer_validity[1 b] at 0x1370e6070>
#>   .. .. ..$ :<nanoarrow_buffer_data_double[16 b] at 0x1200305f8>
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>   ..$ chr:<nanoarrow_array string[2]>
#>   .. ..$ length    : int 2
#>   .. ..$ null_count: int 1
#>   .. ..$ offset    : int 0
#>   .. ..$ buffers   :List of 3
#>   .. .. ..$ :<nanoarrow_buffer_validity[1 b] at 0x1370fd540>
#>   .. .. ..$ :<nanoarrow_buffer_data_offset32[12 b] at 0x1370f1e00>
#>   .. .. ..$ :<nanoarrow_buffer_data_utf8[3 b] at 0x1370f1e10>
#>   .. ..$ dictionary: NULL
#>   .. ..$ children  : list()
#>  $ dictionary: NULL
convert_array(sparse_union)
#>   dbl  chr
#> 1  NA  one
#> 2   2 <NA>
```

<sup>Created on 2023-05-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>