### PR TITLE
fix: Improve readability of `ArrowArrayAllocateChildren()`

### DIFF
--- a/dist/nanoarrow.c
+++ b/dist/nanoarrow.c
@@ -1961,7 +1961,9 @@ ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_ch
     return ENOMEM;
   }
 
-  memset(array->children, 0, n_children * sizeof(struct ArrowArray*));
+  for (int64_t i = 0; i < n_children; i++) {
+    array->children[i] = NULL;
+  }
 
   for (int64_t i = 0; i < n_children; i++) {
     array->children[i] = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));

--- a/dist/nanoarrow.c
+++ b/dist/nanoarrow.c
@@ -1961,9 +1961,7 @@ ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_ch
     return ENOMEM;
   }
 
-  for (int64_t i = 0; i < n_children; i++) {
-    array->children[i] = NULL;
-  }
+  memset(array->children, 0, n_children * sizeof(struct ArrowArray*));
 
   for (int64_t i = 0; i < n_children; i++) {
     array->children[i] = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -228,9 +228,7 @@ ArrowErrorCode ArrowArrayAllocateChildren(struct ArrowArray* array, int64_t n_ch
     return ENOMEM;
   }
 
-  for (int64_t i = 0; i < n_children; i++) {
-    array->children[i] = NULL;
-  }
+  memset(array->children, 0, n_children * sizeof(struct ArrowArray*));
 
   for (int64_t i = 0; i < n_children; i++) {
     array->children[i] = (struct ArrowArray*)ArrowMalloc(sizeof(struct ArrowArray));


### PR DESCRIPTION
In `ArrowArrayAllocateChildren()` two loops over all children follow each other directly.  The first assigns a NULL to each element, then second overwrites that with an allocation.  That makes the first loop effectively deadweight.  It may be there on purpose in which case you just disregard and close this PR.  But if it is an oversight this will make it ever-so-marginally faster as we can skip one loop over `n_children`.

(I noticed another microscopic style difference:  in the corresponding `ArrowSchemaAllocateChildren()` an `if (n_children != 0) {...}` wraps around the core code of function; there it is a simpler `if (n_children == 0) return ...`.  Of course they are also the same "in practice" and I don't have a style preference either -- just curious that they differ.  No need for change, but while at it you could....) 