### PR TITLE
fix(r): Release streams when calling `as.vector()` or `as.data.frame()`

### DIFF
--- a/r/R/array-stream.R
+++ b/r/R/array-stream.R
@@ -161,6 +161,11 @@ infer_nanoarrow_schema.nanoarrow_array_stream <- function(x, ...) {
 
 #' @export
 as.data.frame.nanoarrow_array_stream <- function(x, ...) {
+  # Always release the input: we are always consuming the entire stream.
+  # For more fine-grained behaviour on error, one can use
+  # convert_array_stream()
+  on.exit(x$release())
+
   to <- infer_nanoarrow_ptype(x$get_schema())
   if (!inherits(to, "data.frame")) {
     stop("Can't convert non-struct array stream to data.frame")
@@ -171,6 +176,7 @@ as.data.frame.nanoarrow_array_stream <- function(x, ...) {
 
 #' @export
 as.vector.nanoarrow_array_stream <- function(x, mode) {
+  on.exit(x$release())
   convert_array_stream(x)
 }
 

--- a/r/tests/testthat/test-array-stream.R
+++ b/r/tests/testthat/test-array-stream.R
@@ -110,6 +110,7 @@ test_that("as.data.frame() is implemented for streams", {
     as.data.frame(stream),
     data.frame(x = 1:5)
   )
+  expect_false(nanoarrow_pointer_is_valid(stream))
 })
 
 test_that("as.vector() is implemented for streams", {
@@ -118,6 +119,7 @@ test_that("as.vector() is implemented for streams", {
     as.vector(stream),
     data.frame(x = 1:5)
   )
+  expect_false(nanoarrow_pointer_is_valid(stream))
 })
 
 test_that("nanoarrow_array_stream list interface works", {


### PR DESCRIPTION
In https://github.com/apache/arrow-adbc/pull/706 , the added `read_adbc()` releases a stream whose statement (and possibly connection) will be released when the stream itself is released. When the user is definitely consuming the entire stream, it is helpful to release it at a guaranteed time so that subsequent operations (e.g., closing a connection, deleting a file on Windows) don't confusingly fail.