### PR TITLE
refactor(extensions/nanoarrow_ipc): Reconfigure assembling arrays for better validation

### DIFF
--- a/dist/nanoarrow.c
+++ b/dist/nanoarrow.c
@@ -1898,9 +1898,9 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
   return NANOARROW_OK;
 }
 
-static ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
-                                                  struct ArrowArrayView* array_view,
-                                                  struct ArrowError* error) {
+ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
+                                           struct ArrowArrayView* array_view,
+                                           struct ArrowError* error) {
   ArrowArrayInitFromType(array, array_view->storage_type);
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
@@ -2670,8 +2670,8 @@ ArrowErrorCode ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
     } else if (_ArrowParsedUnionTypeIdsWillEqualChildIndices(
                    array_view->union_type_id_map, array_view->n_children,
                    array_view->n_children)) {
-      NANOARROW_RETURN_NOT_OK(ArrowAssertRangeInt8(array_view->buffer_views[0], 0,
-                                                   (int8_t)(array_view->n_children - 1), error));
+      NANOARROW_RETURN_NOT_OK(ArrowAssertRangeInt8(
+          array_view->buffer_views[0], 0, (int8_t)(array_view->n_children - 1), error));
     } else {
       NANOARROW_RETURN_NOT_OK(ArrowAssertInt8In(array_view->buffer_views[0],
                                                 array_view->union_type_id_map + 128,
@@ -2793,8 +2793,9 @@ static void ArrowBasicArrayStreamRelease(struct ArrowArrayStream* array_stream) 
 
 ArrowErrorCode ArrowBasicArrayStreamInit(struct ArrowArrayStream* array_stream,
                                          struct ArrowSchema* schema, int64_t n_arrays) {
-  struct BasicArrayStreamPrivate* private_data = (struct BasicArrayStreamPrivate*)ArrowMalloc(
-      sizeof(struct BasicArrayStreamPrivate));
+  struct BasicArrayStreamPrivate* private_data =
+      (struct BasicArrayStreamPrivate*)ArrowMalloc(
+          sizeof(struct BasicArrayStreamPrivate));
   if (private_data == NULL) {
     return ENOMEM;
   }

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -39,12 +39,10 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeHeader)
 #define ArrowIpcDecoderDecodeSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeSchema)
-#define ArrowIpcDecoderDecodeArray \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
 #define ArrowIpcDecoderDecodeArrayView \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayView)
-#define ArrowIpcDecoderValidateArray \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderValidateArray)
+#define ArrowIpcDecoderDecodeArrayFromShared \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromShared)
 #define ArrowIpcDecoderSetSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderSetSchema)
 #define ArrowIpcDecoderSetEndianness \

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -41,6 +41,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeSchema)
 #define ArrowIpcDecoderDecodeArrayView \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayView)
+#define ArrowIpcDecoderDecodeArray \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
 #define ArrowIpcDecoderDecodeArrayFromShared \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromShared)
 #define ArrowIpcDecoderSetSchema \

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -283,6 +283,11 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
                                           struct ArrowArray* out,
                                           struct ArrowError* error);
 
+ArrowErrorCode ArrowIpcDecoderDecodeArrayView(struct ArrowIpcDecoder* decoder,
+                                              struct ArrowBufferView body, int64_t i,
+                                              struct ArrowArrayView** out,
+                                              struct ArrowError* error);
+
 /// \brief Decode an ArrowArray from an owned buffer
 ///
 /// This implementation takes advantage of the fact that it can avoid copying individual

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -283,6 +283,17 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
                                           struct ArrowArray* out,
                                           struct ArrowError* error);
 
+/// \brief Decode an ArrowArrayView
+///
+/// After a successful call to ArrowIpcDecoderDecodeHeader(), deserialize the content
+/// of body into an internally-managed ArrowArrayView and return it. Note that field index
+/// does not equate to column index if any columns contain nested types. Use a value of -1
+/// to decode the entire array into a struct. The pointed-to ArrowArrayView is owned by
+/// the ArrowIpcDecoder and must not be released.
+///
+/// For streams that match system endianness and do not use compression, this operation
+/// will not perform any heap allocations; however, the buffers referred to by the returned
+/// ArrowArrayView are only valid as long as the buffer referred to by body stays valid.
 ArrowErrorCode ArrowIpcDecoderDecodeArrayView(struct ArrowIpcDecoder* decoder,
                                               struct ArrowBufferView body, int64_t i,
                                               struct ArrowArrayView** out,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.h
@@ -41,8 +41,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeSchema)
 #define ArrowIpcDecoderDecodeArray \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArray)
-#define ArrowIpcDecoderDecodeArrayFromShared \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayFromShared)
+#define ArrowIpcDecoderDecodeArrayView \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderDecodeArrayView)
 #define ArrowIpcDecoderValidateArray \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcDecoderValidateArray)
 #define ArrowIpcDecoderSetSchema \
@@ -267,6 +267,23 @@ ArrowErrorCode ArrowIpcDecoderSetSchema(struct ArrowIpcDecoder* decoder,
 ArrowErrorCode ArrowIpcDecoderSetEndianness(struct ArrowIpcDecoder* decoder,
                                             enum ArrowIpcEndianness endianness);
 
+/// \brief Decode an ArrowArrayView
+///
+/// After a successful call to ArrowIpcDecoderDecodeHeader(), deserialize the content
+/// of body into an internally-managed ArrowArrayView and return it. Note that field index
+/// does not equate to column index if any columns contain nested types. Use a value of -1
+/// to decode the entire array into a struct. The pointed-to ArrowArrayView is owned by
+/// the ArrowIpcDecoder and must not be released.
+///
+/// For streams that match system endianness and do not use compression, this operation
+/// will not perform any heap allocations; however, the buffers referred to by the
+/// returned ArrowArrayView are only valid as long as the buffer referred to by body stays
+/// valid.
+ArrowErrorCode ArrowIpcDecoderDecodeArrayView(struct ArrowIpcDecoder* decoder,
+                                              struct ArrowBufferView body, int64_t i,
+                                              struct ArrowArrayView** out,
+                                              struct ArrowError* error);
+
 /// \brief Decode an ArrowArray
 ///
 /// After a successful call to ArrowIpcDecoderDecodeHeader(), assemble an ArrowArray given
@@ -281,23 +298,8 @@ ArrowErrorCode ArrowIpcDecoderSetEndianness(struct ArrowIpcDecoder* decoder,
 ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
                                           struct ArrowBufferView body, int64_t i,
                                           struct ArrowArray* out,
+                                          enum ArrowValidationLevel validation_level,
                                           struct ArrowError* error);
-
-/// \brief Decode an ArrowArrayView
-///
-/// After a successful call to ArrowIpcDecoderDecodeHeader(), deserialize the content
-/// of body into an internally-managed ArrowArrayView and return it. Note that field index
-/// does not equate to column index if any columns contain nested types. Use a value of -1
-/// to decode the entire array into a struct. The pointed-to ArrowArrayView is owned by
-/// the ArrowIpcDecoder and must not be released.
-///
-/// For streams that match system endianness and do not use compression, this operation
-/// will not perform any heap allocations; however, the buffers referred to by the returned
-/// ArrowArrayView are only valid as long as the buffer referred to by body stays valid.
-ArrowErrorCode ArrowIpcDecoderDecodeArrayView(struct ArrowIpcDecoder* decoder,
-                                              struct ArrowBufferView body, int64_t i,
-                                              struct ArrowArrayView** out,
-                                              struct ArrowError* error);
 
 /// \brief Decode an ArrowArray from an owned buffer
 ///
@@ -306,19 +308,10 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayView(struct ArrowIpcDecoder* decoder,
 /// more calls to ArrowIpcDecoderDecodeArrayFromShared(). If
 /// ArrowIpcSharedBufferIsThreadSafe() returns 0, out must not be released by another
 /// thread.
-ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(struct ArrowIpcDecoder* decoder,
-                                                    struct ArrowIpcSharedBuffer* shared,
-                                                    int64_t i, struct ArrowArray* out,
-                                                    struct ArrowError* error);
-
-/// \brief Validate a decoded ArrowArray
-///
-/// Verifies buffer lengths and contents depending on validation_level. Users
-/// are reccomended to use NANOARROW_VALIDATION_LEVEL_FULL as any lesser value
-/// may result in some types of corrupted data crashing a process on read.
-ArrowErrorCode ArrowIpcDecoderValidateArray(struct ArrowArray* decoded,
-                                            enum ArrowValidationLevel validation_level,
-                                            struct ArrowError* error);
+ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(
+    struct ArrowIpcDecoder* decoder, struct ArrowIpcSharedBuffer* shared, int64_t i,
+    struct ArrowArray* out, enum ArrowValidationLevel validation_level,
+    struct ArrowError* error);
 
 /// \brief An user-extensible input data source
 struct ArrowIpcInputStream {

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1228,12 +1228,14 @@ struct ArrowIpcBufferSource {
 /// non-owned view of memory that must be copied slice-wise or (2) adding a reference
 /// to an ArrowIpcSharedBuffer and returning a slice of that memory.
 struct ArrowIpcBufferFactory {
-  /// \brief User-defined callback to create initialize the desired buffer into dst
+  /// \brief User-defined callback to populate a buffer view
   ///
   /// At the time that this callback is called, the ArrowIpcBufferSource has been checked
-  /// to ensure that it is within the body size declared by the message header. If
-  /// NANOARROW_OK is returned, the caller is responsible for dst. Otherwise, error must
-  /// contain a null-terminated message.
+  /// to ensure that it is within the body size declared by the message header. A
+  /// possibly preallocated ArrowBuffer (dst) is provided, which implementations must use
+  /// if an allocation is required (in which case the view must be populated pointing to
+  /// the contents of the ArrowBuffer) If NANOARROW_OK is not returned, error must contain
+  /// a null-terminated message.
   ArrowErrorCode (*make_buffer)(struct ArrowIpcBufferFactory* factory,
                                 struct ArrowIpcBufferSource* src,
                                 struct ArrowBufferView* dst_view, struct ArrowBuffer* dst,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -46,12 +46,17 @@
 #include "nanoarrow_ipc.h"
 #include "nanoarrow_ipc_flatcc_generated.h"
 
-// Internal representation of a parsed "Field" from flabuffers. This
+// Internal representation of a parsed "Field" from flatbuffers. This
 // represents a field in a depth-first walk of column arrays and their
 // children.
 struct ArrowIpcField {
+  // Pointer to the ArrowIpcDecoderPrivate::array_view or child for this node
   struct ArrowArrayView* array_view;
+  // Pointer to the ArrowIpcDecoderPrivate::array or child for this node. This
+  // array is scratch space for any intermediary allocations (i.e., it is never moved
+  // to the user).
   struct ArrowArray* array;
+  // The cumulative number of buffers preceeding this node.
   int64_t buffer_offset;
 };
 
@@ -62,7 +67,8 @@ struct ArrowIpcDecoderPrivate {
   // A cached system endianness value
   enum ArrowIpcEndianness system_endianness;
   // An ArrowArrayView whose length/null_count/buffers are set directly from the
-  // deserialized flatbuffer message (i.e., no underlying ArrowArray exists).
+  // deserialized flatbuffer message (i.e., no fully underlying ArrowArray exists,
+  // although some buffers may be temporarily owned by ArrowIpcDecoderPrivate::array).
   struct ArrowArrayView array_view;
   // An ArrowArray with the same structure as the ArrowArrayView whose ArrowArrayBuffer()
   // values are used to allocate or store memory when this is required. This ArrowArray

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1552,9 +1552,3 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(
   ArrowArrayMove(&temp, out);
   return NANOARROW_OK;
 }
-
-ArrowErrorCode ArrowIpcDecoderValidateArray(struct ArrowArray* decoded,
-                                            enum ArrowValidationLevel validation_level,
-                                            struct ArrowError* error) {
-  return ArrowArrayFinishBuilding(decoded, validation_level, error);
-}

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1129,6 +1129,9 @@ ArrowErrorCode ArrowIpcDecoderSetSchema(struct ArrowIpcDecoder* decoder,
   private_data->n_buffers = 0;
   private_data->n_fields = 0;
   ArrowArrayViewReset(&private_data->array_view);
+  if (private_data->array.release != NULL) {
+    private_data->array.release(&private_data->array);
+  }
   if (private_data->fields != NULL) {
     ArrowFree(private_data->fields);
   }
@@ -1137,6 +1140,8 @@ ArrowErrorCode ArrowIpcDecoderSetSchema(struct ArrowIpcDecoder* decoder,
   // this will fail if the schema is not valid.
   NANOARROW_RETURN_NOT_OK(
       ArrowArrayViewInitFromSchema(&private_data->array_view, schema, error));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromArrayView(&private_data->array,
+                                                      &private_data->array_view, error));
 
   // Root must be a struct
   if (private_data->array_view.storage_type != NANOARROW_TYPE_STRUCT) {

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1284,6 +1284,9 @@ struct ArrowIpcArraySetter {
 static int ArrowIpcDecoderMakeBuffer(struct ArrowIpcArraySetter* setter, int64_t offset,
                                      int64_t length, struct ArrowBufferView* out_view,
                                      struct ArrowBuffer* out, struct ArrowError* error) {
+  out_view->data.data = NULL;
+  out_view->size_bytes = 0;
+
   if (length == 0) {
     return NANOARROW_OK;
   }

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -42,6 +42,7 @@ struct ArrowIpcDecoderPrivate {
   enum ArrowIpcEndianness endianness;
   enum ArrowIpcEndianness system_endianness;
   struct ArrowArrayView array_view;
+  struct ArrowArray array;
   int64_t n_fields;
   struct ArrowIpcField* fields;
   int64_t n_buffers;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -35,6 +35,7 @@ using namespace arrow;
 extern "C" {
 struct ArrowIpcField {
   struct ArrowArrayView* array_view;
+  struct ArrowArray* array;
   int64_t buffer_offset;
 };
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -378,23 +378,16 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
         ArrowIpcSharedBufferInit(&shared, &private_data->body), &private_data->error);
     NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArrayFromShared(
         &private_data->decoder, &shared, private_data->field_index, &tmp,
-        &private_data->error));
+        NANOARROW_VALIDATION_LEVEL_FULL, &private_data->error));
     ArrowIpcSharedBufferReset(&shared);
   } else {
     struct ArrowBufferView body_view;
     body_view.data.data = private_data->body.data;
     body_view.size_bytes = private_data->body.size_bytes;
 
-    NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArray(&private_data->decoder, body_view,
-                                                       private_data->field_index, &tmp,
-                                                       &private_data->error));
-  }
-
-  result = ArrowIpcDecoderValidateArray(&tmp, NANOARROW_VALIDATION_LEVEL_FULL,
-                                        &private_data->error);
-  if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
-    return result;
+    NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArray(
+        &private_data->decoder, body_view, private_data->field_index, &tmp,
+        NANOARROW_VALIDATION_LEVEL_FULL, &private_data->error));
   }
 
   ArrowArrayMove(&tmp, out);

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -1009,15 +1009,16 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
 
   if (array_view->storage_type == NANOARROW_TYPE_DENSE_UNION ||
       array_view->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
-    // Check that we have valid type ids.
     if (array_view->union_type_id_map == NULL) {
-      // If the union_type_id map is NULL
-      // (e.g., when using ArrowArrayInitFromType() + ArrowArrayAllocateChildren()
-      // + ArrowArrayFinishBuilding()), we don't have enough information to validate
-      // this buffer (GH-178).
-    } else if (_ArrowParsedUnionTypeIdsWillEqualChildIndices(
-                   array_view->union_type_id_map, array_view->n_children,
-                   array_view->n_children)) {
+      // If the union_type_id map is NULL (e.g., when using ArrowArrayInitFromType() +
+      // ArrowArrayAllocateChildren() + ArrowArrayFinishBuilding()), we don't have enough
+      // information to validate this buffer.
+      ArrowErrorSet(error,
+                    "Insufficient information provided for validation of union array");
+      return EINVAL;
+    } else if (_ArrowParsedUnionTypeIdsWillEqualChildIndices(array_view->union_type_id_map,
+                                                      array_view->n_children,
+                                                      array_view->n_children)) {
       NANOARROW_RETURN_NOT_OK(ArrowAssertRangeInt8(
           array_view->buffer_views[0], 0, (int8_t)(array_view->n_children - 1), error));
     } else {

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -165,9 +165,9 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
   return NANOARROW_OK;
 }
 
-static ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
-                                                  struct ArrowArrayView* array_view,
-                                                  struct ArrowError* error) {
+ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
+                                           struct ArrowArrayView* array_view,
+                                           struct ArrowError* error) {
   ArrowArrayInitFromType(array, array_view->storage_type);
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1971,15 +1971,16 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
-  // The ArrayView for a union could in theroy be created without a schema,
-  // in which case the type_ids are assumed to equal child indices
+  // The ArrayView for a union could in theroy be created without a schema.
+  // Currently FULL validation will fail here since we can't guarantee that
+  // these are valid.
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_DENSE_UNION);
   ASSERT_EQ(ArrowArrayViewAllocateChildren(&array_view, 2), NANOARROW_OK);
   ArrowArrayViewInitFromType(array_view.children[0], NANOARROW_TYPE_INT32);
   ArrowArrayViewInitFromType(array_view.children[1], NANOARROW_TYPE_STRING);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
-            NANOARROW_OK);
+            EINVAL);
 
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewUnionTypeId(&array_view, 1), 1);
@@ -1988,7 +1989,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
 
   ArrowArrayViewReset(&array_view);
 
-  // The test schema explicitly sets the type_ids 0,1 and this should work too
+  // The test schema explicitly sets the type_ids 0,1 and this should validate properly
   ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, nullptr),

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -752,6 +752,15 @@ ArrowErrorCode ArrowArrayInitFromSchema(struct ArrowArray* array,
                                         struct ArrowSchema* schema,
                                         struct ArrowError* error);
 
+/// \brief Initialize the contents of an ArrowArray from an ArrowArrayView
+///
+/// Caller is responsible for calling the array->release callback if
+/// NANOARROW_OK is returned.
+ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
+                                           struct ArrowArrayView* array_view,
+                                           struct ArrowError* error);
+
+
 /// \brief Allocate the array->children array
 ///
 /// Includes the memory for each child struct ArrowArray,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -92,6 +92,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayInitFromType)
 #define ArrowArrayInitFromSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayInitFromSchema)
+#define ArrowArrayInitFromArrayView \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayInitFromArrayView)
 #define ArrowArrayAllocateChildren \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayAllocateChildren)
 #define ArrowArrayAllocateDictionary \
@@ -759,7 +761,6 @@ ArrowErrorCode ArrowArrayInitFromSchema(struct ArrowArray* array,
 ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
                                            struct ArrowArrayView* array_view,
                                            struct ArrowError* error);
-
 
 /// \brief Allocate the array->children array
 ///


### PR DESCRIPTION
Currently the decoder always assembles an `ArrowArray` and subsequently validates that array. That caused a problem when validating a union because the `ArrowArray` builder doesn't have a place to put custom type IDs. Also, this is every so slightly wasteful: the `ArrowArray` validation allocates an unnecessary `ArrowArrayView` and validates that. We already have an `ArrowArrayView` to help with the buffer shuffling, so this PR just swaps the direction: the first step is to create the `ArrowArrayView`; the second step is to validate the `ArrowArrayView`, then populate the `ArrowArray` (if requested).

Closes #178 by erroring if there is insufficient information to validate a union array. I don't think this will cause problems with existing code that builds a union array but if it does it could be relaxed to the previous state (silently ignoring union arrays that can't be validated).