### PR TITLE
feat(r): Add callback-based async option for calling `ArrowArrayStream::get_next()`

### DIFF
--- a/r/R/array-stream.R
+++ b/r/R/array-stream.R
@@ -259,3 +259,13 @@ names.nanoarrow_array_stream <- function(x, ...) {
 `$.nanoarrow_array_stream` <- function(x, i, ...) {
   x[[i]]
 }
+
+nanoarrow_array_stream_get_next_async <- function(stream, callback,
+                                                  schema = stream$get_schema()) {
+  callback_env <- new.env(parent = emptyenv())
+  callback_env$callback <- callback
+  array <- nanoarrow_allocate_array()
+  nanoarrow_array_set_schema(array, schema, validate = FALSE)
+  .Call(nanoarrow_c_array_stream_get_next_async, stream, array, callback_env)
+  invisible(NULL)
+}

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -72,6 +72,10 @@ current_stack_trace_chr <- function() {
   paste0(utils::capture.output(print(tb)), collapse = "\n")
 }
 
+run_callbacks <- function() {
+  invisible(.Call(nanoarrow_c_run_callbacks))
+}
+
 
 `%||%` <- function(rhs, lhs) {
   if (is.null(rhs)) lhs else rhs

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -141,6 +141,12 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
   return array_stream_xptr;
 }
 
+SEXP nanoarrow_c_array_stream_get_next_async(SEXP array_stream_xptr, SEXP array_xptr,
+                                             SEXP callback_env) {
+  nanoarrow_array_stream_get_next_async(array_stream_xptr, array_xptr, callback_env);
+  return R_NilValue;
+}
+
 // Implementation of an ArrowArrayStream that keeps a dependent object valid
 struct WrapperArrayStreamData {
   SEXP parent_array_stream_xptr;

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -30,6 +30,7 @@ extern SEXP nanoarrow_c_altrep_force_materialize(SEXP x_sexp, SEXP recursive_sex
 extern SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr);
 extern SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr);
 extern SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr, SEXP validate_sexp);
+extern SEXP nanoarrow_c_array_stream_get_next_async(SEXP array_stream_xptr, SEXP array_xptr, SEXP callback_env);
 extern SEXP nanoarrow_c_array_view(SEXP array_xptr, SEXP schema_xptr);
 extern SEXP nanoarrow_c_array_init(SEXP schema_xptr);
 extern SEXP nanoarrow_c_array_set_length(SEXP array_xptr, SEXP length_sexp);
@@ -81,6 +82,7 @@ extern SEXP nanoarrow_c_schema_set_dictionary(SEXP schema_mut_xptr, SEXP diction
 extern SEXP nanoarrow_c_preserved_count(void);
 extern SEXP nanoarrow_c_preserved_empty(void);
 extern SEXP nanoarrow_c_preserve_and_release_on_other_thread(SEXP obj);
+extern SEXP nanoarrow_c_run_callbacks(void);
 extern SEXP nanoarrow_c_version(void);
 extern SEXP nanoarrow_c_version_runtime(void);
 
@@ -92,6 +94,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nanoarrow_c_array_stream_get_schema", (DL_FUNC)&nanoarrow_c_array_stream_get_schema, 1},
     {"nanoarrow_c_array_stream_get_next", (DL_FUNC)&nanoarrow_c_array_stream_get_next, 1},
     {"nanoarrow_c_basic_array_stream", (DL_FUNC)&nanoarrow_c_basic_array_stream, 3},
+    {"nanoarrow_c_array_stream_get_next_async", (DL_FUNC)&nanoarrow_c_array_stream_get_next_async, 3},
     {"nanoarrow_c_array_view", (DL_FUNC)&nanoarrow_c_array_view, 2},
     {"nanoarrow_c_array_init", (DL_FUNC)&nanoarrow_c_array_init, 1},
     {"nanoarrow_c_array_set_length", (DL_FUNC)&nanoarrow_c_array_set_length, 2},
@@ -143,6 +146,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"nanoarrow_c_preserved_count", (DL_FUNC)&nanoarrow_c_preserved_count, 0},
     {"nanoarrow_c_preserved_empty", (DL_FUNC)&nanoarrow_c_preserved_empty, 0},
     {"nanoarrow_c_preserve_and_release_on_other_thread", (DL_FUNC)&nanoarrow_c_preserve_and_release_on_other_thread, 1},
+    {"nanoarrow_c_run_callbacks", (DL_FUNC)&nanoarrow_c_run_callbacks, 0},
     {"nanoarrow_c_version", (DL_FUNC)&nanoarrow_c_version, 0},
     {"nanoarrow_c_version_runtime", (DL_FUNC)&nanoarrow_c_version_runtime, 0},
     {NULL, NULL, 0}};

--- a/r/src/util.c
+++ b/r/src/util.c
@@ -65,3 +65,7 @@ SEXP nanoarrow_c_preserve_and_release_on_other_thread(SEXP obj) {
   nanoarrow_preserve_and_release_on_other_thread(obj);
   return R_NilValue;
 }
+
+SEXP nanoarrow_c_run_callbacks(void) {
+  return Rf_ScalarInteger(nanoarrow_run_callbacks());
+}

--- a/r/src/util.h
+++ b/r/src/util.h
@@ -55,4 +55,10 @@ static inline void check_trivial_alloc(const void* ptr, const char* ptr_type) {
   }
 }
 
+// Experimental async array stream
+void nanoarrow_array_stream_get_next_async(SEXP array_stream_xptr, SEXP array_xptr,
+                                           SEXP callback_env);
+
+int nanoarrow_run_callbacks(void);
+
 #endif

--- a/r/tests/testthat/test-array-stream.R
+++ b/r/tests/testthat/test-array-stream.R
@@ -212,3 +212,13 @@ test_that("Errors from user array stream finalizer are ignored", {
   expect_false(nanoarrow_pointer_is_valid(stream))
   expect_silent(stream$release())
 })
+
+test_that("Async get next", {
+  stream <- basic_array_stream(list(1:5))
+  nanoarrow_array_stream_get_next_async(stream, function(code, array) {
+    expect_identical(code, 0L)
+    expect_identical(convert_array(array), 1:5)
+  })
+  Sys.sleep(0.5)
+  expect_identical(run_callbacks(), 1L)
+})


### PR DESCRIPTION
Total proof-of-concept of one way to go about async `stream$get_next()`, as discussed briefly with @krlmlr, @lidavidm, and @nbenn in connection with ADBC in R. When the stream is wrapping a database result set, the `get_next()` call can block for a considerable amount of time...this async version would support a world where it's easier to cancel running queries since we can loop + wait in R land (possibly calling the brand-new "cancel" function coming to ADBC 1.1).

This PR currently will leak memory and doesn't communicate any error information beyond "result code".

See also https://github.com/r-dbi/adbc/discussions/6

Reprex:

``` r
library(nanoarrow)

stream <- basic_array_stream(list(1:5))

# ...more usefully, a promise or future whose value is set from the callback
result <- NULL
nanoarrow:::nanoarrow_array_stream_get_next_async(stream, function(code, array) {
  message("done!")
  result <<- array
})

Sys.sleep(0.5)
nanoarrow:::run_callbacks()
#> done!
convert_array(result)
#> [1] 1 2 3 4 5
```

<sup>Created on 2023-06-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>