### PR TITLE
fix(r): Fix `convert_array_stream()` for non-record batch stream with zero batches

### DIFF
--- a/r/R/convert-array-stream.R
+++ b/r/R/convert-array-stream.R
@@ -71,8 +71,6 @@ convert_array_stream <- function(array_stream, to = NULL, size = NULL, n = Inf) 
   }
 
   if (n_batches == 0L && is.data.frame(to)) {
-    to[integer(0), , drop = FALSE]
-  } else if (n_batches == 0L && is.data.frame(to)) {
     to[integer(0)]
   } else if (n_batches == 1L) {
     batches[[1]]

--- a/r/R/convert-array-stream.R
+++ b/r/R/convert-array-stream.R
@@ -70,8 +70,13 @@ convert_array_stream <- function(array_stream, to = NULL, size = NULL, n = Inf) 
     batches[[n_batches]] <- .Call(nanoarrow_c_convert_array, array, to)
   }
 
-  if (n_batches == 0L && is.data.frame(to)) {
-    to[integer(0)]
+  if (n_batches == 0L) {
+    # vec_slice(to, 0)
+    if (is.data.frame(to)) {
+      to[integer(0), , drop = FALSE]
+    } else {
+      to[integer(0)]
+    }
   } else if (n_batches == 1L) {
     batches[[1]]
   } else if (inherits(to, "data.frame")) {

--- a/r/tests/testthat/test-convert-array-stream.R
+++ b/r/tests/testthat/test-convert-array-stream.R
@@ -29,6 +29,9 @@ test_that("convert array stream works", {
     )
   )
   expect_identical(convert_array_stream(stream2), data.frame(x = 1:10))
+
+  stream3 <- basic_array_stream(list(), schema = na_int32())
+  expect_identical(convert_array_stream(stream3), integer())
 })
 
 test_that("convert array stream with explicit size works", {


### PR DESCRIPTION
Looks like a copy-pastie.