### PR TITLE
feat(extensions/nanoarrow_ipc): Add endian swapping to IPC reader

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1529,10 +1529,6 @@ static int ArrowIpcDecoderWalkSetArrayView(struct ArrowIpcArraySetter* setter,
     setter->src.data_type = array_view->layout.buffer_data_type[i];
     setter->src.element_size_bits = array_view->layout.element_size_bits[i];
 
-    if (setter->src.data_type == NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO) {
-      printf("fish!\n");
-    }
-
     NANOARROW_RETURN_NOT_OK(
         ArrowIpcDecoderMakeBuffer(setter, buffer_offset, buffer_length,
                                   &array_view->buffer_views[i], buffer_dst, error));

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1371,7 +1371,7 @@ static int ArrowIpcDecoderSwapEndian(struct ArrowIpcBufferSource* src,
         item.months = bswap32(item.months);
         item.days = bswap32(item.days);
         item.ns = bswap64(item.ns);
-        memcpy(dst + i * item_size_bytes, &item, item_size_bytes);
+        memcpy(ptr_dst + i * item_size_bytes, &item, item_size_bytes);
       }
       break;
     }
@@ -1528,6 +1528,10 @@ static int ArrowIpcDecoderWalkSetArrayView(struct ArrowIpcArraySetter* setter,
 
     setter->src.data_type = array_view->layout.buffer_data_type[i];
     setter->src.element_size_bits = array_view->layout.element_size_bits[i];
+
+    if (setter->src.data_type == NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO) {
+      printf("fish!\n");
+    }
 
     NANOARROW_RETURN_NOT_OK(
         ArrowIpcDecoderMakeBuffer(setter, buffer_offset, buffer_length,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1393,7 +1393,6 @@ static int ArrowIpcDecoderSwapEndian(struct ArrowIpcBufferSource* src,
           (struct ArrowIpcIntervalMonthDayNano*)out_view->data.data;
       struct ArrowIpcIntervalMonthDayNano* ptr =
           (struct ArrowIpcIntervalMonthDayNano*)dst->data;
-      uint64_t words[2];
       for (int64_t i = 0; i < (dst->size_bytes / 16); i++) {
         ptr[i].months_days.months = bswap32(ptr_src[i].months_days.months);
         ptr[i].months_days.days = bswap32(ptr_src[i].months_days.days);

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1308,9 +1308,16 @@ struct ArrowIpcDecimal256 {
   uint64_t words[4];
 };
 
-struct ArrowIpcIntervalMonthDayNano {
+struct ArrowIpcMonthsDays {
   uint32_t months;
   uint32_t days;
+};
+
+struct ArrowIpcIntervalMonthDayNano {
+  union {
+    uint64_t force_align_uint64;
+    struct ArrowIpcMonthsDays months_days;
+  };
   uint64_t ns;
 };
 
@@ -1388,8 +1395,8 @@ static int ArrowIpcDecoderSwapEndian(struct ArrowIpcBufferSource* src,
           (struct ArrowIpcIntervalMonthDayNano*)dst->data;
       uint64_t words[2];
       for (int64_t i = 0; i < (dst->size_bytes / 16); i++) {
-        ptr[i].months = bswap32(ptr_src[i].months);
-        ptr[i].days = bswap32(ptr_src[i].days);
+        ptr[i].months_days.months = bswap32(ptr_src[i].months_days.months);
+        ptr[i].months_days.days = bswap32(ptr_src[i].months_days.days);
         ptr[i].ns = bswap64(ptr_src[i].ns);
       }
       break;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -512,7 +512,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchFromShared) {
 
 TEST(NanoarrowIpcTest, NanoarrowIpcSharedBufferThreadSafeDecode) {
   if (!ArrowIpcSharedBufferIsThreadSafe()) {
-    GTEST_SKIP();
+    GTEST_SKIP() << "ArrowIpcSharedBufferIsThreadSafe() returned false";
   }
 
   struct ArrowIpcDecoder decoder;
@@ -735,3 +735,124 @@ INSTANTIATE_TEST_SUITE_P(
         arrow::schema({}, arrow::KeyValueMetadata::Make({"key1"}, {"value1"})),
         // Non-nullable field
         arrow::schema({arrow::field("some_name", arrow::int32(), false)})));
+
+TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSwapEndian) {
+  enum ArrowType data_type = NANOARROW_TYPE_INT32;
+
+  // Make a data buffer long enough for 10 Decimal256s with a pattern
+  // where an endian swap isn't silently the same value (e.g., 0s)
+  uint8_t data_buffer[32 * 10];
+  for (int64_t i = 0; i < sizeof(data_buffer); i++) {
+    data_buffer[i] = i % 256;
+  }
+
+  int bit_width;
+  std::shared_ptr<arrow::DataType> arrow_data_type;
+  switch (data_type) {
+    case NANOARROW_TYPE_BOOL:
+      bit_width = 1;
+      arrow_data_type = arrow::boolean();
+      break;
+    case NANOARROW_TYPE_INT8:
+      bit_width = 8;
+      arrow_data_type = arrow::int8();
+      break;
+    case NANOARROW_TYPE_INT16:
+      bit_width = 16;
+      arrow_data_type = arrow::int16();
+      break;
+    case NANOARROW_TYPE_INT32:
+      bit_width = 32;
+      arrow_data_type = arrow::int32();
+      break;
+    case NANOARROW_TYPE_INT64:
+      bit_width = 64;
+      arrow_data_type = arrow::int64();
+      break;
+    case NANOARROW_TYPE_DECIMAL128:
+      arrow_data_type = arrow::decimal128(10, 3);
+      bit_width = 128;
+      break;
+    case NANOARROW_TYPE_DECIMAL256:
+      bit_width = 256;
+      arrow_data_type = arrow::decimal256(10, 3);
+      break;
+    default:
+      GTEST_FAIL() << "Type not supported for test";
+  }
+
+  // "Manually" swap the endians
+  uint8_t data_buffer_swapped[32 * 10];
+  if (bit_width > 8) {
+    int64_t n_elements = sizeof(data_buffer) * 8 / bit_width;
+    int byte_width = bit_width / 8;
+    for (int64_t i = 0; i < n_elements; i++) {
+      uint8_t* src = data_buffer + (i * byte_width);
+      uint8_t* dst = data_buffer_swapped + (i * byte_width);
+      for (int j = 0; j < byte_width; j++) {
+        dst[j] = src[byte_width - j - 1];
+      }
+    }
+  } else {
+    memcpy(data_buffer_swapped, data_buffer, sizeof(data_buffer));
+  }
+
+  // Make an array wrapping the swapped buffer
+  auto empty = std::make_shared<arrow::Buffer>(nullptr, 0);
+  auto buffer =
+      std::make_shared<arrow::Buffer>(data_buffer_swapped, sizeof(data_buffer_swapped));
+  arrow::BufferVector buffers = {empty, buffer};
+  auto array_data =
+      std::make_shared<arrow::ArrayData>(arrow_data_type, 10, buffers, 0, 0);
+  auto array = arrow::MakeArray(array_data);
+
+  // Make a RecordBatch
+  auto arrow_schema = arrow::schema({arrow::field("col1", arrow_data_type)});
+  auto arrow_record_batch = arrow::RecordBatch::Make(arrow_schema, 10, {array});
+
+  // Serialize it
+  auto options = arrow::ipc::IpcWriteOptions::Defaults();
+  auto maybe_serialized = arrow::ipc::SerializeRecordBatch(*arrow_record_batch, options);
+  if (!maybe_serialized.ok()) {
+    GTEST_FAIL() << maybe_serialized.status();
+  }
+  auto serialized = *maybe_serialized;
+
+  struct ArrowSchema schema;
+  if (!arrow::ExportSchema(*arrow_schema, &schema).ok()) {
+    GTEST_FAIL() << "schema export failed";
+  }
+
+  struct ArrowBufferView data;
+  data.data.as_uint8 = serialized->data();
+  data.size_bytes = serialized->size();
+
+  struct ArrowIpcDecoder decoder;
+  ArrowIpcDecoderInit(&decoder);
+  ASSERT_EQ(ArrowIpcDecoderSetSchema(&decoder, &schema, nullptr), NANOARROW_OK);
+
+#ifdef __BIG_ENDIAN__
+  ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_LITTLE),
+            NANOARROW_OK);
+#else
+  ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_BIG),
+            NANOARROW_OK);
+#endif
+
+  ASSERT_EQ(ArrowIpcDecoderDecodeHeader(&decoder, data, nullptr), NANOARROW_OK);
+  data.data.as_uint8 += decoder.header_size_bytes;
+  data.size_bytes -= decoder.header_size_bytes;
+
+  struct ArrowArrayView* array_view;
+  ASSERT_EQ(ArrowIpcDecoderDecodeArrayView(&decoder, data, 0, &array_view, nullptr),
+            NANOARROW_OK);
+  ASSERT_EQ(array_view->storage_type, data_type);
+
+  // Check buffer equality with our initial buffer
+  EXPECT_EQ(memcmp(array_view->buffer_views[1].data.data, data_buffer,
+                   array_view->buffer_views[1].size_bytes),
+            0);
+
+  schema.release(&schema);
+  ArrowIpcDecoderReset(&decoder);
+}

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -868,4 +868,6 @@ TEST_P(ArrowTypeIdParameterizedTestFixture, NanoarrowIpcDecodeSwapEndian) {
 INSTANTIATE_TEST_SUITE_P(NanoarrowIpcTest, ArrowTypeIdParameterizedTestFixture,
                          ::testing::Values(NANOARROW_TYPE_BOOL, NANOARROW_TYPE_INT8,
                                            NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32,
-                                           NANOARROW_TYPE_INT64));
+                                           NANOARROW_TYPE_INT64,
+                                           NANOARROW_TYPE_DECIMAL128,
+                                           NANOARROW_TYPE_DECIMAL256));

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -330,19 +330,6 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   EXPECT_STREQ(error.message, "The nanoarrow_ipc extension does not support compression");
   decoder.codec = NANOARROW_IPC_COMPRESSION_TYPE_NONE;
 
-  // Field extract should fail on non-system endian
-  if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_LITTLE) {
-    ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_BIG);
-  } else {
-    ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_LITTLE);
-  }
-  EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array,
-                                       NANOARROW_VALIDATION_LEVEL_FULL, &error),
-            ENOTSUP);
-  EXPECT_STREQ(error.message,
-               "The nanoarrow_ipc extension does not support non-system endianness");
-  ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_UNINITIALIZED);
-
   // Field extract should fail if body is too small
   decoder.body_size_bytes = 0;
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
@@ -152,8 +152,7 @@ class TestFile {
         io::RandomAccessFile::GetStream(buffer_reader, 0, content_copy_wrapped->size());
 #endif
 
-    auto maybe_reader =
-        ipc::RecordBatchStreamReader::Open(input_stream);
+    auto maybe_reader = ipc::RecordBatchStreamReader::Open(input_stream);
     if (!maybe_reader.ok()) {
       GTEST_FAIL() << maybe_reader.status().message();
     }
@@ -229,22 +228,22 @@ TEST_P(ArrowTestingPathParameterizedTestFixture, NanoarrowIpcTestFileNativeEndia
   param.Test(dir_builder.str());
 }
 
-// TEST_P(ArrowTestingPathParameterizedTestFixture, NanoarrowIpcTestFileSwapEndian) {
-//   const char* testing_dir = getenv("NANOARROW_ARROW_TESTING_DIR");
-//   if (testing_dir == nullptr || strlen(testing_dir) == 0) {
-//     GTEST_SKIP() << "NANOARROW_ARROW_TESTING_DIR environment variable not set";
-//   }
+TEST_P(ArrowTestingPathParameterizedTestFixture, NanoarrowIpcTestFileSwapEndian) {
+  const char* testing_dir = getenv("NANOARROW_ARROW_TESTING_DIR");
+  if (testing_dir == nullptr || strlen(testing_dir) == 0) {
+    GTEST_SKIP() << "NANOARROW_ARROW_TESTING_DIR environment variable not set";
+  }
 
-//   std::stringstream dir_builder;
+  std::stringstream dir_builder;
 
-// #if defined(__BIG_ENDIAN__)
-//   dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-littleendian";
-// #else
-//   dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-bigendian";
-// #endif
-//   TestFile param = GetParam();
-//   param.Test(dir_builder.str());
-// }
+#if defined(__BIG_ENDIAN__)
+  dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-littleendian";
+#else
+  dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-bigendian";
+#endif
+  TestFile param = GetParam();
+  param.Test(dir_builder.str());
+}
 
 INSTANTIATE_TEST_SUITE_P(
     NanoarrowIpcTest, ArrowTestingPathParameterizedTestFixture,

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
@@ -229,6 +229,23 @@ TEST_P(ArrowTestingPathParameterizedTestFixture, NanoarrowIpcTestFileNativeEndia
   param.Test(dir_builder.str());
 }
 
+// TEST_P(ArrowTestingPathParameterizedTestFixture, NanoarrowIpcTestFileSwapEndian) {
+//   const char* testing_dir = getenv("NANOARROW_ARROW_TESTING_DIR");
+//   if (testing_dir == nullptr || strlen(testing_dir) == 0) {
+//     GTEST_SKIP() << "NANOARROW_ARROW_TESTING_DIR environment variable not set";
+//   }
+
+//   std::stringstream dir_builder;
+
+// #if defined(__BIG_ENDIAN__)
+//   dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-littleendian";
+// #else
+//   dir_builder << testing_dir << "/data/arrow-ipc-stream/integration/1.0.0-bigendian";
+// #endif
+//   TestFile param = GetParam();
+//   param.Test(dir_builder.str());
+// }
+
 INSTANTIATE_TEST_SUITE_P(
     NanoarrowIpcTest, ArrowTestingPathParameterizedTestFixture,
     ::testing::Values(

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -21,8 +21,6 @@
 
 #include "nanoarrow_ipc.h"
 
-#include "flatcc/portable/pendian_detect.h"
-
 static uint8_t kSimpleSchema[] = {
     0xff, 0xff, 0xff, 0xff, 0x10, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x0a, 0x00, 0x0e, 0x00, 0x06, 0x00, 0x05, 0x00, 0x08, 0x00, 0x0a, 0x00, 0x00, 0x00,
@@ -163,14 +161,9 @@ TEST(NanoarrowIpcReader, StreamReaderBasic) {
   schema.release(&schema);
 
   struct ArrowArray array;
-  // TODO: Support endian swapping (GH-171)
-#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
-#else
-  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
-#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -205,14 +198,9 @@ TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
   schema.release(&schema);
 
   struct ArrowArray array;
-  // TODO: Support endian swapping (GH-171)
-#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
-#else
-  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
-#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -246,14 +234,9 @@ TEST(NanoarrowIpcReader, StreamReaderBasicWithEndOfStream) {
   schema.release(&schema);
 
   struct ArrowArray array;
-  // TODO: Support endian swapping (GH-171)
-#if !defined(__BIG_ENDIAN__)
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
   array.release(&array);
-#else
-  ASSERT_EQ(stream.get_next(&stream, &array), ENOTSUP);
-#endif
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);


### PR DESCRIPTION
Ensures IPC reader compatibility reading little endian streams from big endian (99% for the purposes of not scaring away potential dependencies that run tests on big endian). It's also not that hard to do since flatcc did the hard work of defining `bswap16()`, `bswap32()`, and `bswap64()` based on compiler defines.