### PR TITLE
feat: Include dictionary member in `ArrowArrayView` struct

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -307,9 +307,10 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
       dictionary = {
         if (!is.null(value)) {
           value <- as_nanoarrow_array(value)
+          value_copy <- array_shallow_copy(value, validate = validate)
         }
 
-        .Call(nanoarrow_c_array_set_dictionary, array_copy, value)
+        .Call(nanoarrow_c_array_set_dictionary, array_copy, value_copy)
 
         if (!is.null(schema) && !is.null(value)) {
           schema <- nanoarrow_schema_modify(

--- a/r/R/array.R
+++ b/r/R/array.R
@@ -198,16 +198,6 @@ nanoarrow_array_proxy <- function(array, schema = NULL, recursive = FALSE) {
     result <- .Call(nanoarrow_c_array_proxy, array, NULL, recursive)
   }
 
-  # Recursive-ness of the dictionary is handled here because it's not
-  # part of the array view
-  if (recursive && !is.null(result$dictionary)) {
-    result$dictionary <- nanoarrow_array_proxy(
-      result$dictionary,
-      schema = schema$dictionary,
-      recursive = TRUE
-    )
-  }
-
   result
 }
 

--- a/r/R/array.R
+++ b/r/R/array.R
@@ -180,19 +180,19 @@ nanoarrow_array_proxy <- function(array, schema = NULL, recursive = FALSE) {
     array_view <- .Call(nanoarrow_c_array_view, array, schema)
     result <- .Call(nanoarrow_c_array_proxy, array, array_view, recursive)
 
-    # Pass on some information from the schema if we have it
-    if (!is.null(result$dictionary)) {
-      nanoarrow_array_set_schema(result$dictionary, schema$dictionary)
-    }
-
     names(result$children) <- names(schema$children)
 
     if (!recursive) {
+      # Pass on some information from the schema if we have it
       result$children <- Map(
         nanoarrow_array_set_schema,
         result$children,
         schema$children
       )
+
+      if (!is.null(result$dictionary)) {
+        nanoarrow_array_set_schema(result$dictionary, schema$dictionary)
+      }
     }
   } else {
     result <- .Call(nanoarrow_c_array_proxy, array, NULL, recursive)
@@ -308,6 +308,8 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
         if (!is.null(value)) {
           value <- as_nanoarrow_array(value)
           value_copy <- array_shallow_copy(value, validate = validate)
+        } else {
+          value_copy <- NULL
         }
 
         .Call(nanoarrow_c_array_set_dictionary, array_copy, value_copy)

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -215,7 +215,8 @@ SEXP nanoarrow_c_array_set_dictionary(SEXP array_xptr, SEXP dictionary_xptr) {
       }
     }
 
-    array_export(dictionary_xptr, array->dictionary);
+    struct ArrowArray* dictionary = array_from_xptr(dictionary_xptr);
+    ArrowArrayMove(dictionary, array->dictionary);
   }
 
   return R_NilValue;

--- a/r/src/array.h
+++ b/r/src/array.h
@@ -145,7 +145,7 @@ static inline void array_export(SEXP array_xptr, struct ArrowArray* array_copy) 
   result = ArrowArrayAllocateChildren(array_copy, array->n_children);
   if (result != NANOARROW_OK) {
     array_copy->release(array_copy);
-    Rf_error("ArrowArraySetBuffer() failed");
+    Rf_error("ArrowArrayAllocateChildren() failed");
   }
 
   for (int64_t i = 0; i < array->n_children; i++) {

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -321,6 +321,20 @@ static ArrowErrorCode ArrowArrayViewInitFromArray(struct ArrowArrayView* array_v
     }
   }
 
+  if (array->dictionary != NULL) {
+    result = ArrowArrayViewAllocateDictionary(array_view);
+    if (result != NANOARROW_OK) {
+      ArrowArrayViewReset(array_view);
+      return result;
+    }
+
+    result = ArrowArrayViewInitFromArray(array_view->dictionary, array->dictionary);
+    if (result != NANOARROW_OK) {
+      ArrowArrayViewReset(array_view);
+      return result;
+    }
+  }
+
   return NANOARROW_OK;
 }
 
@@ -521,10 +535,19 @@ ArrowErrorCode ArrowArrayViewInitFromSchema(struct ArrowArrayView* array_view,
     }
   }
 
-  result = ArrowArrayViewAllocateDictionary(array_view);
-  if (result != NANOARROW_OK) {
-    ArrowArrayViewReset(array_view);
-    return result;
+  if (schema->dictionary != NULL) {
+    result = ArrowArrayViewAllocateDictionary(array_view);
+    if (result != NANOARROW_OK) {
+      ArrowArrayViewReset(array_view);
+      return result;
+    }
+
+    result =
+        ArrowArrayViewInitFromSchema(array_view->dictionary, schema->dictionary, error);
+    if (result != NANOARROW_OK) {
+      ArrowArrayViewReset(array_view);
+      return result;
+    }
   }
 
   if (array_view->storage_type == NANOARROW_TYPE_SPARSE_UNION ||

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -150,9 +150,13 @@ static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array) 
     }
   }
 
-  // Start building any child arrays
+  // Start building any child arrays or dictionaries
   for (int64_t i = 0; i < array->n_children; i++) {
     NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array->children[i]));
+  }
+
+  if (array->dictionary != NULL) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array->dictionary));
   }
 
   return NANOARROW_OK;
@@ -166,6 +170,10 @@ static inline ArrowErrorCode ArrowArrayShrinkToFit(struct ArrowArray* array) {
 
   for (int64_t i = 0; i < array->n_children; i++) {
     NANOARROW_RETURN_NOT_OK(ArrowArrayShrinkToFit(array->children[i]));
+  }
+
+  if (array->dictionary != NULL) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayShrinkToFit(array->dictionary));
   }
 
   return NANOARROW_OK;

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1992,6 +1992,23 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   item = ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1);
   EXPECT_EQ(std::string(item.data, item.size_bytes), "def");
 
+  array.release(&array);
+
+  // Setting a non-dictionary array should error
+  struct ArrowError error;
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
+  EXPECT_STREQ(error.message, "Expected dictionary but found NULL");
+
+  array.release(&array);
+
+  // Setting a dictionary array to a non-dictionary array view should error
+  ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+  ArrowArrayViewReset(&array_view);
+  ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_INT32);
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
+  EXPECT_STREQ(error.message, "Expected NULL dictionary but found dictionary member");
+
   schema.release(&schema);
   array.release(&array);
   ArrowArrayViewReset(&array_view);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -939,11 +939,14 @@ ArrowErrorCode ArrowArrayViewInitFromSchema(struct ArrowArrayView* array_view,
                                             struct ArrowSchema* schema,
                                             struct ArrowError* error);
 
-/// \brief Allocate the schema_view->children array
+/// \brief Allocate the array_view->children array
 ///
 /// Includes the memory for each child struct ArrowArrayView
 ArrowErrorCode ArrowArrayViewAllocateChildren(struct ArrowArrayView* array_view,
                                               int64_t n_children);
+
+/// \brief Allocate array_view->dictionary
+ArrowErrorCode ArrowArrayViewAllocateDictionary(struct ArrowArrayView* array_view);
 
 /// \brief Set data-independent buffer sizes from length
 void ArrowArrayViewSetLength(struct ArrowArrayView* array_view, int64_t length);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -112,6 +112,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewInitFromSchema)
 #define ArrowArrayViewAllocateChildren \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewAllocateChildren)
+#define ArrowArrayViewAllocateDictionary \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewAllocateDictionary)
 #define ArrowArrayViewSetLength \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewSetLength)
 #define ArrowArrayViewSetArray \

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -608,7 +608,7 @@ struct ArrowArrayView {
   /// \brief Pointers to views of this array's children
   struct ArrowArrayView** children;
 
-  /// \brief Pointers to views of this array's dictionary
+  /// \brief Pointer to a view of this array's dictionary
   struct ArrowArrayView* dictionary;
 
   /// \brief Union type id to child index mapping

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -608,6 +608,9 @@ struct ArrowArrayView {
   /// \brief Pointers to views of this array's children
   struct ArrowArrayView** children;
 
+  /// \brief Pointers to views of this array's dictionary
+  struct ArrowArrayView* dictionary;
+
   /// \brief Union type id to child index mapping
   ///
   /// If storage_type is a union type, a 256-byte ArrowMalloc()ed buffer


### PR DESCRIPTION
This doesn't add any features really, but ensures that one can walk `ArrowSchema`, `ArrowArray`, and `ArrowArrayView` recursively using the same pattern. I'd like to include this in the 0.2 release because it is very difficult to work around this limitation: for example, if you have a deeply nested dictionary field, you currently have to walk your whole tree of arrays twice (once to validate the non-dictionary bits, once looking for dictionary bits that may or may not exist to validate). The R package worked around this in some creative but error-prone ways and I'd like to avoid anybody else attempting creative workarounds when this is a feature that will almost certainly get added soon.

Another application of this is device array support, since that PR essentially constructs an `ArrowArrayView` and recursively copies the buffer view from the array view to a standalone buffer using some device-specific logic.