### PR TITLE
fix(extensions/nanoarrow_ipc): Don't produce arrays with NULL data buffers

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1542,10 +1542,9 @@ static int ArrowIpcDecoderWalkSetArrayView(struct ArrowIpcArraySetter* setter,
   return NANOARROW_OK;
 }
 
-static ArrowErrorCode ArrowIpcDecoderDecodeArrayInternal(struct ArrowIpcDecoder* decoder,
-                                                         int64_t field_i,
-                                                         struct ArrowArray* out,
-                                                         struct ArrowError* error) {
+static ArrowErrorCode ArrowIpcDecoderDecodeArrayInternal(
+    struct ArrowIpcDecoder* decoder, int64_t field_i, struct ArrowArray* out,
+    enum ArrowValidationLevel validation_level, struct ArrowError* error) {
   struct ArrowIpcDecoderPrivate* private_data =
       (struct ArrowIpcDecoderPrivate*)decoder->private_data;
 
@@ -1569,8 +1568,17 @@ static ArrowErrorCode ArrowIpcDecoderDecodeArrayInternal(struct ArrowIpcDecoder*
         ArrowIpcDecoderWalkGetArray(root->array_view, root->array, out, error));
   }
 
-  // If validation is going to happen it has already occurred
-  ArrowArrayFinishBuilding(out, NANOARROW_VALIDATION_LEVEL_NONE, error);
+  // If validation is going to happen it has already occurred; however, the part of
+  // ArrowArrayFinishBuilding() that allocates a data buffer if the data buffer is
+  // NULL (required for compatability with Arrow <= 9.0.0) assumes CPU data access
+  // and thus needs a validation level >= default.
+  if (validation_level >= NANOARROW_VALIDATION_LEVEL_DEFAULT) {
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayFinishBuilding(out, NANOARROW_VALIDATION_LEVEL_DEFAULT, error));
+  } else {
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayFinishBuilding(out, NANOARROW_VALIDATION_LEVEL_NONE, error));
+  }
 
   return NANOARROW_OK;
 }
@@ -1644,7 +1652,8 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
 
   struct ArrowArray temp;
   temp.release = NULL;
-  int result = ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, error);
+  int result =
+      ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, validation_level, error);
   if (result != NANOARROW_OK && temp.release != NULL) {
     temp.release(&temp);
   } else if (result != NANOARROW_OK) {
@@ -1667,7 +1676,8 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(
 
   struct ArrowArray temp;
   temp.release = NULL;
-  int result = ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, error);
+  int result =
+      ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, validation_level, error);
   if (result != NANOARROW_OK && temp.release != NULL) {
     temp.release(&temp);
   } else if (result != NANOARROW_OK) {


### PR DESCRIPTION
This only affects Arrow C++ <= 9.0.0 consumers (i.e., the last Arrow C++ that builds with default Centos 7 compilers and the version that exists on archlinux when you install from the system package manager). Technically it adds a redundant check when producing an Array; however, that check is cheap and the way to maximize performance would be to completely avoid the Array in the first place.

Fixes verification failure on Centos 7 and Archlinux: https://github.com/apache/arrow-nanoarrow/actions/runs/5232667457/jobs/9447554040 , https://github.com/apache/arrow-nanoarrow/actions/runs/5232667457/jobs/9447553922 , as tested by `export NANOARROW_PLATFORM=centos7 && docker compose run --rm verify`.