### PR TITLE
fix: Improve limit check for unsigned input

### DIFF
--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -389,22 +389,22 @@ static inline ArrowErrorCode ArrowArrayAppendUInt(struct ArrowArray* array,
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_buffer, &value, sizeof(uint64_t)));
       break;
     case NANOARROW_TYPE_UINT32:
-      _NANOARROW_CHECK_RANGE(value, 0, UINT32_MAX);
+      _NANOARROW_CHECK_UPPER_LIMIT(value, UINT32_MAX);
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt32(data_buffer, (uint32_t)value));
       break;
     case NANOARROW_TYPE_UINT16:
-      _NANOARROW_CHECK_RANGE(value, 0, UINT16_MAX);
+      _NANOARROW_CHECK_UPPER_LIMIT(value, UINT16_MAX);
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt16(data_buffer, (uint16_t)value));
       break;
     case NANOARROW_TYPE_UINT8:
-      _NANOARROW_CHECK_RANGE(value, 0, UINT8_MAX);
+      _NANOARROW_CHECK_UPPER_LIMIT(value, UINT8_MAX);
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt8(data_buffer, (uint8_t)value));
       break;
     case NANOARROW_TYPE_INT64:
     case NANOARROW_TYPE_INT32:
     case NANOARROW_TYPE_INT16:
     case NANOARROW_TYPE_INT8:
-      _NANOARROW_CHECK_RANGE(value, 0, INT64_MAX);
+      _NANOARROW_CHECK_UPPER_LIMIT(value, INT64_MAX);
       return ArrowArrayAppendInt(array, value);
     case NANOARROW_TYPE_DOUBLE:
       NANOARROW_RETURN_NOT_OK(ArrowBufferAppendDouble(data_buffer, (double)value));

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -164,6 +164,9 @@ static inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
 #define _NANOARROW_CHECK_RANGE(x_, min_, max_) \
   NANOARROW_RETURN_NOT_OK((x_ >= min_ && x_ <= max_) ? NANOARROW_OK : EINVAL)
 
+#define _NANOARROW_CHECK_UPPER_LIMIT(x_, max_) \
+  NANOARROW_RETURN_NOT_OK((x_ <= max_) ? NANOARROW_OK : EINVAL)
+
 #if defined(NANOARROW_DEBUG)
 #define _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(NAME, EXPR, ERROR_PTR_EXPR, EXPR_STR) \
   do {                                                                                 \


### PR DESCRIPTION
`value` within this function is a uint64_t, so using the CHECK_RANGE macro yields warnings/errors like:

```sh
/home/willayd/clones/arrow-adbc/c/vendor/nanoarrow/nanoarrow.h:192:31: error: comparison of unsigned expression in ‘>= 0’ is always true [-Werror=type-limits]
  192 |   NANOARROW_RETURN_NOT_OK((x_ >= min_ && x_ <= max_) ? NANOARROW_OK : EINVAL)
      |                               ^
/home/willayd/clones/arrow-adbc/c/vendor/nanoarrow/nanoarrow.h:187:23: note: in definition of macro ‘_NANOARROW_RETURN_NOT_OK_IMPL’
  187 |     const int NAME = (EXPR);                      \
      |                       ^~~~
/home/willayd/clones/arrow-adbc/c/vendor/nanoarrow/nanoarrow.h:192:3: note: in expansion of macro ‘NANOARROW_RETURN_NOT_OK’
  192 |   NANOARROW_RETURN_NOT_OK((x_ >= min_ && x_ <= max_) ? NANOARROW_OK : EINVAL)
      |   ^~~~~~~~~~~~~~~~~~~~~~~
/home/willayd/clones/arrow-adbc/c/vendor/nanoarrow/nanoarrow.h:2606:7: note: in expansion of macro ‘_NANOARROW_CHECK_RANGE’
 2606 |       _NANOARROW_CHECK_RANGE(value, 0, UINT8_MAX);
```