### PR TITLE
ci(python): avoid reinstalling for testing docstrings

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -61,10 +61,8 @@ jobs:
       - name: Run doctests
         if: success() && matrix.python-version == '3.10'
         run: |
-          # Needs editable install to run --doctest-cython
           pip install pytest-cython
-          pip install -e python
-          pytest python --doctest-cython
+          pytest python/src/nanoarrow --doctest-cython
 
       - name: Coverage
         if: success() && matrix.python-version == '3.10'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,7 +62,7 @@ jobs:
         if: success() && matrix.python-version == '3.10'
         run: |
           pip install pytest-cython
-          pytest python/src/nanoarrow --doctest-cython
+          pytest --pyargs nanoarrow --doctest-cython
 
       - name: Coverage
         if: success() && matrix.python-version == '3.10'


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow-nanoarrow/pull/117/files#r1231696846