### PR TITLE
Fix incorrect function name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ int make_simple_array(struct ArrowArray* array_out, struct ArrowSchema* schema_o
   NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array_out, 3));
   NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuildingDefault(array_out, &error));
 
-  NANOARROW_RETURN_NOT_OK(ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32));
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema_out, NANOARROW_TYPE_INT32));
 
   return NANOARROW_OK;
 }


### PR DESCRIPTION
While integrating into another C project, I pulled example code from the readme that called,

```c
ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32))
```

and got this error:

```
src/main.c:41:57: error: too many arguments to function call, expected single argument 'schema', have 2 arguments
    NANOARROW_RETURN_NOT_OK(ArrowSchemaInit(schema_out, NANOARROW_TYPE_INT32));
```