### PR TITLE
fix(python): Ensure generator does not raise `StopIteration`

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -894,8 +894,11 @@ cdef class ArrayStream:
             return array
 
     def __iter__(self):
-        while True:
-            yield self.get_next()
+        try:
+            while True:
+                yield self.get_next()
+        except StopIteration:
+            return
 
     @staticmethod
     def allocate():


### PR DESCRIPTION
As noted in #258, the Python tests are failing! I'm not sure the details of why this started now, but `StopIteration` was being raised in a generator which should just return instead.