### PR TITLE
refactor(python): Cleaner strategy for `__iter__()` on an `ArrowArrayStream`

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -894,11 +894,10 @@ cdef class ArrayStream:
             return array
 
     def __iter__(self):
-        try:
-            while True:
-                yield self.get_next()
-        except StopIteration:
-            return
+        return self
+
+    def __next__(self):
+        return self.get_next()
 
     @staticmethod
     def allocate():


### PR DESCRIPTION
After https://github.com/apache/arrow-nanoarrow/pull/262#discussion_r1269088588 .