### PR TITLE
chore: Update verification action to use a cached Arrow C++ build on all platforms

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -92,7 +92,7 @@ jobs:
           mkdir arrow-build && cd arrow-build
           cmake ../apache-arrow-12.0.1/cpp -DCMAKE_INSTALL_PREFIX=../arrow
           cmake --build .
-          cmake --install . --prefix=../arrow --config=Debug
+          cmake --install . --prefix=../arrow
           cd ..
 
       - name: Set CMake options (Windows)

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow -Dgtest_force_shared_crt=ON" >> $GITHUB_ENV
 
-      - name: Set CMake options (Posix)
+      - name: Set CMake options (POSIX)
         if: matrix.config.label != 'windows'
         shell: bash
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -76,39 +76,21 @@ jobs:
           needs: check
           working-directory: src/r
 
-      - name: Cache Windows Arrow C++ Build
-        if: matrix.config.label == 'windows'
+      - name: Cache Arrow C++ Build
         id: cache-arrow-build
         uses: actions/cache@v3
         with:
           path: arrow
-          key: arrow-${{ runner.os }}-3
+          key: arrow-${{ runner.os }}-4
 
-      # For Arrow C++
-      - name: Install Arrow C++ (MacOS)
-        if: matrix.config.label == 'macos'
-        run: brew install apache-arrow
-
-      - name: Install Arrow C++ (Debian)
-        if: matrix.config.label == 'ubuntu'
+      - name: Build Arrow C++
+        if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          sudo apt-get update
-          sudo apt install -y -V ca-certificates lsb-release wget cmake
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get update
-          sudo apt-get install -y -V libarrow-dev
-          rm apache-arrow-apt-*.deb
-
-      - name: Build Arrow C++ (Windows)
-        if: matrix.config.label == 'windows' && steps.cache-arrow-build.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          curl https://dlcdn.apache.org/arrow/arrow-12.0.0/apache-arrow-12.0.0.tar.gz | \
+          curl https://dlcdn.apache.org/arrow/arrow-12.0.1/apache-arrow-12.0.1.tar.gz | \
             tar -zxf -
           mkdir arrow-build && cd arrow-build
-          cmake ../apache-arrow-12.0.0/cpp -DCMAKE_INSTALL_PREFIX=../arrow
+          cmake ../apache-arrow-12.0.1/cpp -DCMAKE_INSTALL_PREFIX=../arrow
           cmake --build .
           cmake --install . --prefix=../arrow --config=Debug
           cd ..
@@ -118,6 +100,12 @@ jobs:
         shell: bash
         run: |
           echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow -Dgtest_force_shared_crt=ON" >> $GITHUB_ENV
+
+      - name: Set CMake options (Posix)
+        if: matrix.config.label != 'windows'
+        shell: bash
+        run: |
+          echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow" >> $GITHUB_ENV
 
       - name: Run dev/release/verify-release-candidate.sh
         shell: bash

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -105,7 +105,7 @@ jobs:
         if: matrix.config.label != 'windows'
         shell: bash
         run: |
-          echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow" >> $GITHUB_ENV
+          echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd)/arrow/lib/cmake/Arrow" >> $GITHUB_ENV
 
       - name: Run dev/release/verify-release-candidate.sh
         shell: bash


### PR DESCRIPTION
Previously this was installing from `apt` on Ubuntu and `brew` on MacOS; however, the Windows verification was much faster because the arrow install can be cached. Additionally, the MacOS build was failing due to something protobuf-related and the minimal build solves that problem too.