### PR TITLE
chore: Fix archlinux dev docker container build

### DIFF
--- a/ci/docker/archlinux.dockerfile
+++ b/ci/docker/archlinux.dockerfile
@@ -17,9 +17,8 @@
 
 FROM archlinux:latest
 
-RUN pacman -Syu --noconfirm git gcc make cmake r-base gnupg curl arrow python-pip
-
-RUN pip3 install build Cython numpy pytest pyarrow
+RUN pacman -Syu --noconfirm git gcc make cmake r-base gnupg curl arrow \
+    python-pip python-build cython python-numpy python-pytest python-pyarrow
 
 # For R
 RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars


### PR DESCRIPTION
I'd added some Python dependencies to all the dev docker images in preparation for actually verifying the Python builds; however the archlinux dev container build was failing because `pip` is not allowed on that platforms. This PR replaces the `pip` command with Archlinux-supplied Python dependencies.