### PR TITLE
chore: Generalize option for static linking of Arrow C++ to link tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -99,7 +99,7 @@ jobs:
         if: matrix.config.label == 'windows'
         shell: bash
         run: |
-          echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow -Dgtest_force_shared_crt=ON" >> $GITHUB_ENV
+          echo "NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS} -DNANOARROW_ARROW_STATIC=ON -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow -Dgtest_force_shared_crt=ON" >> $GITHUB_ENV
 
       - name: Set CMake options (POSIX)
         if: matrix.config.label != 'windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ option(NANOARROW_BUILD_TESTS "Build tests" OFF)
 option(NANOARROW_BUNDLE "Create bundled nanoarrow.h and nanoarrow.c" OFF)
 option(NANOARROW_BUNDLE_AS_CPP "Bundle nanoarrow source file as nanoarrow.cc" OFF)
 option(NANOARROW_NAMESPACE "A prefix for exported symbols" OFF)
+option(NANOARROW_ARROW_STATIC
+       "Use a statically-linked Arrow C++ build when linking tests" OFF)
 
 if(NANOARROW_NAMESPACE)
   set(NANOARROW_NAMESPACE_DEFINE "#define NANOARROW_NAMESPACE ${NANOARROW_NAMESPACE}")
@@ -172,11 +174,8 @@ if(NANOARROW_BUILD_TESTS)
     cmake_policy(SET CMP0135 NEW)
   endif()
 
-  # On Windows, dynamically linking Arrow is difficult to get right,
-  # so use static linking by default. GTest needs to use shared C runtime
-  # when using MSVC.
-  if(MSVC)
-    set(gtest_force_shared_crt on)
+  # Give caller the option to link a static version of Arrow C++
+  if(NANOARROW_ARROW_STATIC)
     set(NANOARROW_ARROW_TARGET arrow_static)
   else()
     set(NANOARROW_ARROW_TARGET arrow_shared)

--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -32,6 +32,8 @@ option(NANOARROW_IPC_FLATCC_ROOT_DIR
        "Root directory for flatcc include and lib directories" OFF)
 option(NANOARROW_IPC_FLATCC_INCLUDE_DIR "Include directory for flatcc includes" OFF)
 option(NANOARROW_IPC_FLATCC_LIB_DIR "Library directory that contains libflatccrt.a" OFF)
+option(NANOARROW_ARROW_STATIC
+       "Use a statically-linked Arrow C++ build when linking tests" OFF)
 
 option(NANOARROW_IPC_CODE_COVERAGE "Enable coverage reporting" OFF)
 add_library(ipc_coverage_config INTERFACE)

--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -216,12 +216,11 @@ if(NANOARROW_IPC_BUILD_TESTS)
     target_link_libraries(nanoarrow_ipc PRIVATE ipc_coverage_config)
   endif()
 
-  # On Windows, dynamically linking Arrow is difficult to get right,
-  # so use static linking by default.
-  if(MSVC)
-    set(NANOARROW_IPC_ARROW_TARGET arrow_static)
+  # Give caller the option to link a static version of Arrow C++
+  if(NANOARROW_ARROW_STATIC)
+    set(NANOARROW_ARROW_TARGET arrow_static)
   else()
-    set(NANOARROW_IPC_ARROW_TARGET arrow_shared)
+    set(NANOARROW_ARROW_TARGET arrow_shared)
   endif()
 
   target_link_libraries(nanoarrow_ipc_decoder_test


### PR DESCRIPTION
The previous option to use static linking was just a test for `MSVC`; however, the may be other times where using a shared library fails (e.g., #254). This PR generalizes that option as a workaround.