### PR TITLE
fix(r): Don't link to arrow package R6 class pages

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -20,8 +20,8 @@
 #' In nanoarrow an 'array' refers to the `struct ArrowArray` definition
 #' in the Arrow C data interface. At the R level, we attach a
 #' [schema][as_nanoarrow_schema] such that functionally the nanoarrow_array
-#' class can be used in a similar way as an [arrow::Array]. Note that in
-#' nanoarrow an [arrow::RecordBatch] and a non-nullable [arrow::StructArray]
+#' class can be used in a similar way as an `arrow::Array`. Note that in
+#' nanoarrow an `arrow::RecordBatch` and a non-nullable `arrow::StructArray`
 #' are represented identically.
 #'
 #' @param x An object to convert to a array

--- a/r/man/as_nanoarrow_array.Rd
+++ b/r/man/as_nanoarrow_array.Rd
@@ -21,8 +21,8 @@ An object of class 'nanoarrow_array'
 In nanoarrow an 'array' refers to the \verb{struct ArrowArray} definition
 in the Arrow C data interface. At the R level, we attach a
 \link[=as_nanoarrow_schema]{schema} such that functionally the nanoarrow_array
-class can be used in a similar way as an \link[arrow:array]{arrow::Array}. Note that in
-nanoarrow an \link[arrow:RecordBatch]{arrow::RecordBatch} and a non-nullable \link[arrow:array]{arrow::StructArray}
+class can be used in a similar way as an \code{arrow::Array}. Note that in
+nanoarrow an \code{arrow::RecordBatch} and a non-nullable \code{arrow::StructArray}
 are represented identically.
 }
 \examples{


### PR DESCRIPTION
These pages were renamed as part of the 13.0.0 release and will cause submission problems for arrow's reverse dependency checks (since the page removal causes the CMD check to fail).