### PR TITLE
chore: Publish dev docs to asf-site branch instead of gh-pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,13 +18,11 @@
 
 github:
   description: "Helpers for Arrow C Data & Arrow C Stream interfaces"
-  homepage: https://arrow.apache.org/
+  homepage: https://arrow.apache.org/nanoarrow
   enabled_merge_buttons:
     squash:  true
   features:
     issues: true
-  ghp_branch: gh-pages
-  ghp_path: ~
 
 notifications:
   commits:      commits@arrow.apache.org

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -53,17 +53,17 @@ jobs:
           name: nanarrow-docs
           path: docs/_build/html
 
-      - name: Clone gh-pages branch
+      - name: Clone asf-site branch
         if: success() && github.repository == 'apache/arrow-nanoarrow' && github.ref == 'refs/heads/main'
         uses: actions/checkout@v2
         with:
-          ref: gh-pages
+          ref: asf-site
           path: pages-clone
 
       - name: Update development documentation
         if: success() && github.repository == 'apache/arrow-nanoarrow' && github.ref == 'refs/heads/main'
         env:
-          DOC_TAG: "dev"
+          DOC_TAG: "main"
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
@@ -73,8 +73,6 @@ jobs:
           fi
           mkdir "$DOC_TAG"
           cp -R ../docs/_build/html/* "$DOC_TAG"
-          touch .nojekyll
-          git add .nojekyll
           git add *
           git commit --allow-empty -m"update documentation for tag $DOC_TAG"
           git push

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 # nanoarrow
 
 [![Codecov test coverage](https://codecov.io/gh/apache/arrow-nanoarrow/branch/main/graph/badge.svg)](https://app.codecov.io/gh/apache/arrow-nanoarrow?branch=main)
-[![Documentation](https://img.shields.io/badge/Documentation-dev-yellow)](https://apache.github.io/arrow-nanoarrow/dev)
+[![Documentation](https://img.shields.io/badge/Documentation-main-yellow)](https://arrow.apache.org/nanoarrow/main)
 [![nanoarrow on GitHub](https://img.shields.io/badge/GitHub-apache%2Farrow--nanoarrow-blue)](https://github.com/apache/arrow-nanoarrow)
 
 The nanoarrow library is a set of helper functions to interpret and generate

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -37,7 +37,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 <!-- badges: end -->
 
-The goal of nanoarrow is to provide minimal useful bindings to the [Arrow C Data](https://arrow.apache.org/docs/format/CDataInterface.html) and [Arrow C Stream](https://arrow.apache.org/docs/format/CStreamInterface.html) interfaces using the [nanoarrow C library](https://apache.github.io/arrow-nanoarrow/).
+The goal of nanoarrow is to provide minimal useful bindings to the [Arrow C Data](https://arrow.apache.org/docs/format/CDataInterface.html) and [Arrow C Stream](https://arrow.apache.org/docs/format/CStreamInterface.html) interfaces using the [nanoarrow C library](https://arrow.apache.org/nanoarrow).
 
 ## Installation
 

--- a/r/README.md
+++ b/r/README.md
@@ -29,7 +29,7 @@ The goal of nanoarrow is to provide minimal useful bindings to the
 and [Arrow C
 Stream](https://arrow.apache.org/docs/format/CStreamInterface.html)
 interfaces using the [nanoarrow C
-library](https://apache.github.io/arrow-nanoarrow/).
+library](https://arrow.apache.org/nanoarrow).
 
 ## Installation
 


### PR DESCRIPTION
Now that the documentation is hosted at https://arrow.apache.org/nanoarrow via the asf-site branch, the dev documentation should be there, too.