### PR TITLE
feat: Add `ArrowBitsUnpackInt32()`

### DIFF
--- a/r/src/materialize_int.h
+++ b/r/src/materialize_int.h
@@ -56,6 +56,19 @@ static inline int nanoarrow_materialize_int(struct ArrayViewSlice* src,
       }
       break;
     case NANOARROW_TYPE_BOOL:
+      ArrowBitmapUnpackInt32Unsafe(
+          src->array_view->buffer_views[1].data.as_uint8 + raw_src_offset, raw_src_offset,
+          dst->length, result + dst->offset);
+
+      // Set any nulls to NA_LOGICAL
+      if (is_valid != NULL && src->array_view->array->null_count != 0) {
+        for (R_xlen_t i = 0; i < dst->length; i++) {
+          if (!ArrowBitGet(is_valid, raw_src_offset + i)) {
+            result[dst->offset + i] = NA_LOGICAL;
+          }
+        }
+      }
+      break;
     case NANOARROW_TYPE_INT8:
     case NANOARROW_TYPE_UINT8:
     case NANOARROW_TYPE_INT16:

--- a/r/src/materialize_int.h
+++ b/r/src/materialize_int.h
@@ -56,7 +56,7 @@ static inline int nanoarrow_materialize_int(struct ArrayViewSlice* src,
       }
       break;
     case NANOARROW_TYPE_BOOL:
-      ArrowBitmapUnpackInt32Unsafe(
+      ArrowBitsUnpackInt32(
           src->array_view->buffer_views[1].data.as_uint8 + raw_src_offset, raw_src_offset,
           dst->length, result + dst->offset);
 

--- a/r/src/materialize_lgl.h
+++ b/r/src/materialize_lgl.h
@@ -40,8 +40,8 @@ static int nanoarrow_materialize_lgl(struct ArrayViewSlice* src, struct VectorSl
       }
       break;
     case NANOARROW_TYPE_BOOL:
-      ArrowBitmapUnpackInt32Unsafe(data_buffer, raw_src_offset, dst->length,
-                                   result + dst->offset);
+      ArrowBitsUnpackInt32(data_buffer, raw_src_offset, dst->length,
+                           result + dst->offset);
 
       // Set any nulls to NA_LOGICAL
       if (is_valid != NULL && src->array_view->array->null_count != 0) {

--- a/r/src/materialize_lgl.h
+++ b/r/src/materialize_lgl.h
@@ -40,9 +40,8 @@ static int nanoarrow_materialize_lgl(struct ArrayViewSlice* src, struct VectorSl
       }
       break;
     case NANOARROW_TYPE_BOOL:
-      for (R_xlen_t i = 0; i < dst->length; i++) {
-        result[dst->offset + i] = ArrowBitGet(data_buffer, src->offset + i);
-      }
+      ArrowBitmapUnpackInt32Unsafe(data_buffer, raw_src_offset, dst->length,
+                                   result + dst->offset);
 
       // Set any nulls to NA_LOGICAL
       if (is_valid != NULL && src->array_view->array->null_count != 0) {

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -222,7 +222,7 @@ static inline int64_t _ArrowBytesForBits(int64_t bits) {
   return (bits >> 3) + ((bits & 7) != 0);
 }
 
-static inline void _ArrowBitmapUnpackInt8(const uint8_t word, int8_t* out) {
+static inline void _ArrowBitsUnpackInt8(const uint8_t word, int8_t* out) {
   out[0] = (word >> 0) & 1;
   out[1] = (word >> 1) & 1;
   out[2] = (word >> 2) & 1;
@@ -233,7 +233,7 @@ static inline void _ArrowBitmapUnpackInt8(const uint8_t word, int8_t* out) {
   out[7] = (word >> 7) & 1;
 }
 
-static inline void _ArrowBitmapUnpackInt32(const uint8_t word, int32_t* out) {
+static inline void _ArrowBitsUnpackInt32(const uint8_t word, int32_t* out) {
   out[0] = (word >> 0) & 1;
   out[1] = (word >> 1) & 1;
   out[2] = (word >> 2) & 1;
@@ -258,8 +258,8 @@ static inline int8_t ArrowBitGet(const uint8_t* bits, int64_t i) {
   return (bits[i >> 3] >> (i & 0x07)) & 1;
 }
 
-static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t start_offset,
-                                               int64_t length, int8_t* out) {
+static inline void ArrowBitsUnpackInt8(const uint8_t* bits, int64_t start_offset,
+                                       int64_t length, int8_t* out) {
   if (length == 0) {
     return;
   }
@@ -286,7 +286,7 @@ static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t star
 
   // middle bytes
   for (int64_t i = bytes_begin + 1; i < bytes_last_valid; i++) {
-    _ArrowBitmapUnpackInt8(bits[i], out);
+    _ArrowBitsUnpackInt8(bits[i], out);
     out += 8;
   }
 
@@ -297,8 +297,8 @@ static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t star
   }
 }
 
-static inline void ArrowBitmapUnpackInt32Unsafe(const uint8_t* bits, int64_t start_offset,
-                                                int64_t length, int32_t* out) {
+static inline void ArrowBitsUnpackInt32(const uint8_t* bits, int64_t start_offset,
+                                        int64_t length, int32_t* out) {
   if (length == 0) {
     return;
   }
@@ -325,7 +325,7 @@ static inline void ArrowBitmapUnpackInt32Unsafe(const uint8_t* bits, int64_t sta
 
   // middle bytes
   for (int64_t i = bytes_begin + 1; i < bytes_last_valid; i++) {
-    _ArrowBitmapUnpackInt32(bits[i], out);
+    _ArrowBitsUnpackInt32(bits[i], out);
     out += 8;
   }
 

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -233,6 +233,17 @@ static inline void _ArrowBitmapUnpackInt8(const uint8_t word, int8_t* out) {
   out[7] = (word >> 7) & 1;
 }
 
+static inline void _ArrowBitmapUnpackInt32(const uint8_t word, int32_t* out) {
+  out[0] = (word >> 0) & 1;
+  out[1] = (word >> 1) & 1;
+  out[2] = (word >> 2) & 1;
+  out[3] = (word >> 3) & 1;
+  out[4] = (word >> 4) & 1;
+  out[5] = (word >> 5) & 1;
+  out[6] = (word >> 6) & 1;
+  out[7] = (word >> 7) & 1;
+}
+
 static inline void _ArrowBitmapPackInt8(const int8_t* values, uint8_t* out) {
   *out = (values[0] | values[1] << 1 | values[2] << 2 | values[3] << 3 | values[4] << 4 |
           values[5] << 5 | values[6] << 6 | values[7] << 7);
@@ -261,7 +272,6 @@ static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t star
   const int64_t bytes_last_valid = i_last_valid / 8;
 
   if (bytes_begin == bytes_last_valid) {
-    // count bits within a single byte
     for (int i = 0; i < length; i++) {
       out[i] = ArrowBitGet(&bits[bytes_begin], i + i_begin % 8);
     }
@@ -277,6 +287,45 @@ static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t star
   // middle bytes
   for (int64_t i = bytes_begin + 1; i < bytes_last_valid; i++) {
     _ArrowBitmapUnpackInt8(bits[i], out);
+    out += 8;
+  }
+
+  // last byte
+  const int bits_remaining = i_end % 8 == 0 ? 8 : i_end % 8;
+  for (int i = 0; i < bits_remaining; i++) {
+    *out++ = ArrowBitGet(&bits[bytes_last_valid], i);
+  }
+}
+
+static inline void ArrowBitmapUnpackInt32Unsafe(const uint8_t* bits, int64_t start_offset,
+                                                int64_t length, int32_t* out) {
+  if (length == 0) {
+    return;
+  }
+
+  const int64_t i_begin = start_offset;
+  const int64_t i_end = start_offset + length;
+  const int64_t i_last_valid = i_end - 1;
+
+  const int64_t bytes_begin = i_begin / 8;
+  const int64_t bytes_last_valid = i_last_valid / 8;
+
+  if (bytes_begin == bytes_last_valid) {
+    for (int i = 0; i < length; i++) {
+      out[i] = ArrowBitGet(&bits[bytes_begin], i + i_begin % 8);
+    }
+
+    return;
+  }
+
+  // first byte
+  for (int i = 0; i < 8 - (i_begin % 8); i++) {
+    *out++ = ArrowBitGet(&bits[bytes_begin], i + i_begin % 8);
+  }
+
+  // middle bytes
+  for (int64_t i = bytes_begin + 1; i < bytes_last_valid; i++) {
+    _ArrowBitmapUnpackInt32(bits[i], out);
     out += 8;
   }
 

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -280,12 +280,12 @@ void TestArrowBitmapUnpackUnsafe(const uint8_t* bitmap, std::vector<int8_t> expe
 
   ASSERT_EQ(length, expected.size());
 
-  ArrowBitmapUnpackInt8Unsafe(bitmap, offset, length, out);
+  ArrowBitsUnpackInt8(bitmap, offset, length, out);
   for (int i = 0; i < length; i++) {
     EXPECT_EQ(out[i], expected[i]);
   }
 
-  ArrowBitmapUnpackInt32Unsafe(bitmap, offset, length, out32);
+  ArrowBitsUnpackInt32(bitmap, offset, length, out32);
   for (int i = 0; i < length; i++) {
     EXPECT_EQ(out32[i], expected[i]);
   }
@@ -302,12 +302,12 @@ TEST(BitmapTest, BitmapTestBitmapUnpack) {
   memset(result, 0, sizeof(result));
   memset(result32, 0, sizeof(result32));
 
-  ArrowBitmapUnpackInt8Unsafe(bitmap, 0, sizeof(result), result);
+  ArrowBitsUnpackInt8(bitmap, 0, sizeof(result), result);
   for (int i = 0; i < n_values; i++) {
     EXPECT_EQ(result[i], 1);
   }
 
-  ArrowBitmapUnpackInt32Unsafe(bitmap, 0, sizeof(result), result32);
+  ArrowBitsUnpackInt32(bitmap, 0, sizeof(result), result32);
   for (int i = 0; i < n_values; i++) {
     EXPECT_EQ(result32[i], 1);
   }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -680,6 +680,14 @@ static inline void ArrowBitsSetTo(uint8_t* bits, int64_t start_offset, int64_t l
 /// \brief Count true values in a bitmap
 static inline int64_t ArrowBitCountSet(const uint8_t* bits, int64_t i_from, int64_t i_to);
 
+/// \brief Extract int8 boolean values from a range in a bitmap
+static inline void ArrowBitsUnpackInt8(const uint8_t* bits, int64_t start_offset,
+                                       int64_t length, int8_t* out);
+
+/// \brief Extract int32 boolean values from a range in a bitmap
+static inline void ArrowBitsUnpackInt32(const uint8_t* bits, int64_t start_offset,
+                                        int64_t length, int32_t* out);
+
 /// \brief Initialize an ArrowBitmap
 ///
 /// Initialize the builder's buffer, empty its cache, and reset the size to zero
@@ -715,14 +723,6 @@ static inline ArrowErrorCode ArrowBitmapAppend(struct ArrowBitmap* bitmap,
 /// \brief Append zero or more of the same boolean value to a bitmap
 static inline void ArrowBitmapAppendUnsafe(struct ArrowBitmap* bitmap,
                                            uint8_t bits_are_set, int64_t length);
-
-/// \brief Extract int8 boolean values from a range in a bitmap
-static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t start_offset,
-                                               int64_t length, int8_t* out);
-
-/// \brief Extract int32 boolean values from a range in a bitmap
-static inline void ArrowBitmapUnpackInt32Unsafe(const uint8_t* bits, int64_t start_offset,
-                                                int64_t length, int32_t* out);
 
 /// \brief Append boolean values encoded as int8_t to a bitmap
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -716,9 +716,13 @@ static inline ArrowErrorCode ArrowBitmapAppend(struct ArrowBitmap* bitmap,
 static inline void ArrowBitmapAppendUnsafe(struct ArrowBitmap* bitmap,
                                            uint8_t bits_are_set, int64_t length);
 
-/// \brief Extract boolean values from a range in a bitmap
+/// \brief Extract int8 boolean values from a range in a bitmap
 static inline void ArrowBitmapUnpackInt8Unsafe(const uint8_t* bits, int64_t start_offset,
                                                int64_t length, int8_t* out);
+
+/// \brief Extract int32 boolean values from a range in a bitmap
+static inline void ArrowBitmapUnpackInt32Unsafe(const uint8_t* bits, int64_t start_offset,
+                                                int64_t length, int32_t* out);
 
 /// \brief Append boolean values encoded as int8_t to a bitmap
 ///


### PR DESCRIPTION
As a follow-up to #276. The `int32` version is useful because R uses 32-bit integers to represent boolean (i.e., logical) arrays. This results in a significant speedup in boolean conversion!

@WillAyd: I updated a few things that you *just* added (Sorry! 😬 ):

- I changed `Bitmap` -> `Bits` and removed `Unsafe` to make it more consistent with the other functions that accept `const uint8_t* bits`
- I updated the test function so that it tests both the int32 and int8 types at once

Before this PR:

``` r
library(nanoarrow)

lgls <- nanoarrow:::vec_gen(logical(), 1e6)
bool_array <- as_nanoarrow_array(lgls)
bool_array_arrow <- arrow::as_arrow_array(bool_array)

bench::mark(
  convert_array(bool_array, logical()),
  as.vector(bool_array_arrow),
  as.logical(lgls)
)
#> # A tibble: 3 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 convert_array(bool_array, logical()) 556µs  749µs    1.33e3    3.82MB     156.
#> 2 as.vector(bool_array_arrow)          558µs  780µs    1.30e3    3.82MB     144.
#> 3 as.logical(lgls)                         0    1ns    2.28e8        0B       0

bench::mark(
  convert_array(bool_array, integer()),
  as.integer(lgls)
)
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 convert_array(bool_array, integer()) 733µs  912µs     1093.    3.81MB     167.
#> 2 as.integer(lgls)                     615µs  788µs     1273.    3.81MB     182.
```

After this PR:

``` r
library(nanoarrow)

lgls <- nanoarrow:::vec_gen(logical(), 1e6)
bool_array <- as_nanoarrow_array(lgls)
bool_array_arrow <- arrow::as_arrow_array(bool_array)

bench::mark(
  convert_array(bool_array, logical()),
  as.vector(bool_array_arrow),
  as.logical(lgls)
)
#> # A tibble: 3 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 convert_array(bool_array, logical()) 105µs  308µs    3.21e3    3.83MB     367.
#> 2 as.vector(bool_array_arrow)          559µs  772µs    1.30e3    3.82MB     143.
#> 3 as.logical(lgls)                         0      0    5.87e8        0B       0

bench::mark(
  convert_array(bool_array, integer()),
  as.integer(lgls)
)
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                           <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 convert_array(bool_array, integer()) 104µs  310µs     3181.    3.81MB     423.
#> 2 as.integer(lgls)                     615µs  784µs     1278.    3.81MB     142.
```

<sup>Created on 2023-08-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>