### PR TITLE
fix(r): Support map conversion to R vector

### DIFF
--- a/r/R/infer-ptype.R
+++ b/r/R/infer-ptype.R
@@ -91,6 +91,7 @@ infer_ptype_other <- function(schema) {
         tzone = parsed$timezone
       )
     },
+    "map" = ,
     "large_list" = ,
     "list" = ,
     "fixed_size_list" = {


### PR DESCRIPTION
Closes #281.

``` r
library(adbcdrivermanager)
library(nanoarrow)

db <- adbc_database_init(adbcsqlite::adbcsqlite(), uri = ":memory:")
con <- adbc_connection_init(db)
stream <- adbc_connection_get_info(con, 0)

tibble::as_tibble(stream)
#> # A tibble: 1 × 2
#>   info_name info_value$string_value $bool_value $int64_value $int32_bitmask
#>       <dbl> <chr>                   <lgl>              <dbl>          <int>
#> 1         0 SQLite                  NA                    NA             NA
#> # ℹ 2 more variables: info_value$string_list <list<chr>>,
#> #   $int32_to_int32_list_map <list<df[,2]>>
```

<sup>Created on 2023-08-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>