### PR TITLE
fix(extensions/nanoarrow_ipc): Fix crash and mixleading error messages resulting from corrupted streams

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -936,10 +936,10 @@ static inline void ArrowIpcDecoderResetHeaderInfo(struct ArrowIpcDecoder* decode
 // Returns NANOARROW_OK if data is large enough to read the first 8 bytes
 // of the message header, ESPIPE if reading more data might help, or EINVAL if the content
 // is not valid. Advances the input ArrowBufferView by 8 bytes.
-static inline int ArrowIpcDecoderCheckHeader(struct ArrowIpcDecoder* decoder,
-                                             struct ArrowBufferView* data_mut,
-                                             int32_t* message_size_bytes,
-                                             struct ArrowError* error) {
+static inline int ArrowIpcDecoderReadHeaderPrefix(struct ArrowIpcDecoder* decoder,
+                                                  struct ArrowBufferView* data_mut,
+                                                  int32_t* message_size_bytes,
+                                                  struct ArrowError* error) {
   struct ArrowIpcDecoderPrivate* private_data =
       (struct ArrowIpcDecoderPrivate*)decoder->private_data;
 
@@ -981,8 +981,8 @@ ArrowErrorCode ArrowIpcDecoderPeekHeader(struct ArrowIpcDecoder* decoder,
       (struct ArrowIpcDecoderPrivate*)decoder->private_data;
 
   ArrowIpcDecoderResetHeaderInfo(decoder);
-  NANOARROW_RETURN_NOT_OK(
-      ArrowIpcDecoderCheckHeader(decoder, &data, &decoder->header_size_bytes, error));
+  NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderReadHeaderPrefix(
+      decoder, &data, &decoder->header_size_bytes, error));
   return NANOARROW_OK;
 }
 
@@ -993,8 +993,8 @@ ArrowErrorCode ArrowIpcDecoderVerifyHeader(struct ArrowIpcDecoder* decoder,
       (struct ArrowIpcDecoderPrivate*)decoder->private_data;
 
   ArrowIpcDecoderResetHeaderInfo(decoder);
-  NANOARROW_RETURN_NOT_OK(
-      ArrowIpcDecoderCheckHeader(decoder, &data, &decoder->header_size_bytes, error));
+  NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderReadHeaderPrefix(
+      decoder, &data, &decoder->header_size_bytes, error));
 
   // Check that data contains at least the entire header (return ESPIPE to signal
   // that reading more data may help).
@@ -1031,8 +1031,8 @@ ArrowErrorCode ArrowIpcDecoderDecodeHeader(struct ArrowIpcDecoder* decoder,
       (struct ArrowIpcDecoderPrivate*)decoder->private_data;
 
   ArrowIpcDecoderResetHeaderInfo(decoder);
-  NANOARROW_RETURN_NOT_OK(
-      ArrowIpcDecoderCheckHeader(decoder, &data, &decoder->header_size_bytes, error));
+  NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderReadHeaderPrefix(
+      decoder, &data, &decoder->header_size_bytes, error));
 
   // Check that data contains at least the entire header (return ESPIPE to signal
   // that reading more data may help).

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -249,13 +249,14 @@ TEST(NanoarrowIpcTest, NanoarrowIpcVerifyInvalid) {
   // a null-terminated error. After byte 265 this passes because the values being modified
   // are parts of the flatbuffer that won't cause overrun.
   for (int64_t i = 1; i < 265; i++) {
+    SCOPED_TRACE(i);
+
     memcpy(simple_schema_invalid, kSimpleSchema, i);
     memcpy(simple_schema_invalid + i, kSimpleSchema + (i + 1),
            (sizeof(simple_schema_invalid) - i));
 
     ArrowErrorInit(&error);
-    ASSERT_NE(ArrowIpcDecoderVerifyHeader(&decoder, data, &error), NANOARROW_OK)
-        << "After removing byte " << i;
+    ASSERT_NE(ArrowIpcDecoderVerifyHeader(&decoder, data, &error), NANOARROW_OK);
     ASSERT_GT(strlen(error.message), 0);
   }
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -150,8 +150,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcCheckHeader) {
   EXPECT_EQ(ArrowIpcDecoderVerifyHeader(&decoder, data, &error), ESPIPE);
 
   EXPECT_STREQ(error.message,
-               "Expected 0 <= message body size <= 0 bytes but found message body size "
-               "of 1 bytes");
+               "Expected >= 9 bytes of remaining data but found 8 bytes in buffer");
 
   eight_bad_bytes[0] = 0xFFFFFFFF;
   eight_bad_bytes[1] = 0;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -345,7 +345,7 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
                                             struct ArrowArray* out) {
   struct ArrowIpcArrayStreamReaderPrivate* private_data =
       (struct ArrowIpcArrayStreamReaderPrivate*)stream->private_data;
-  private_data->error.message[0] = '\0';
+  ArrowErrorInit(&private_data->error);
   NANOARROW_RETURN_NOT_OK(ArrowIpcArrayStreamReaderReadSchemaIfNeeded(private_data));
 
   // Read + decode the next header
@@ -356,6 +356,9 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
     // end of stream bytes were read.
     out->release = NULL;
     return NANOARROW_OK;
+  } else if (result != NANOARROW_OK) {
+    // Other error
+    return result;
   }
 
   // Make sure we have a RecordBatch message

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -226,11 +226,8 @@ static int ArrowIpcArrayStreamReaderNextHeader(
   input_view.size_bytes = private_data->header.size_bytes;
 
   // Use PeekHeader to fill in decoder.header_size_bytes
-  int result =
-      ArrowIpcDecoderPeekHeader(&private_data->decoder, input_view, &private_data->error);
-  if (result == ENODATA) {
-    return result;
-  }
+  NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderPeekHeader(&private_data->decoder, input_view,
+                                                    &private_data->error));
 
   // Read the header bytes
   int64_t expected_header_bytes = private_data->decoder.header_size_bytes - 8;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -376,10 +376,11 @@ static int ArrowIpcArrayStreamReaderGetNext(struct ArrowArrayStream* stream,
     struct ArrowIpcSharedBuffer shared;
     NANOARROW_RETURN_NOT_OK_WITH_ERROR(
         ArrowIpcSharedBufferInit(&shared, &private_data->body), &private_data->error);
-    NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeArrayFromShared(
+    result = ArrowIpcDecoderDecodeArrayFromShared(
         &private_data->decoder, &shared, private_data->field_index, &tmp,
-        NANOARROW_VALIDATION_LEVEL_FULL, &private_data->error));
+        NANOARROW_VALIDATION_LEVEL_FULL, &private_data->error);
     ArrowIpcSharedBufferReset(&shared);
+    NANOARROW_RETURN_NOT_OK(result);
   } else {
     struct ArrowBufferView body_view;
     body_view.data.data = private_data->body.data;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -307,6 +307,8 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
   // padding.
   data.size_bytes = sizeof(kSimpleSchema);
   for (int64_t i = 1; i < 273; i++) {
+    SCOPED_TRACE(i);
+
     memcpy(simple_stream_invalid, kSimpleSchema, i);
     memcpy(simple_stream_invalid + i, kSimpleSchema + (i + 1),
            (sizeof(kSimpleSchema) - i));
@@ -316,8 +318,7 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
     ASSERT_EQ(ArrowIpcInputStreamInitBuffer(&input, &input_buffer), NANOARROW_OK);
     ASSERT_EQ(ArrowIpcArrayStreamReaderInit(&stream, &input, nullptr), NANOARROW_OK);
 
-    ASSERT_NE(stream.get_schema(&stream, &schema), NANOARROW_OK)
-        << "After removing Schema message byte " << i;
+    ASSERT_NE(stream.get_schema(&stream, &schema), NANOARROW_OK);
     ASSERT_GT(strlen(stream.get_last_error(&stream)), 0);
 
     stream.release(&stream);
@@ -328,6 +329,8 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
   memcpy(simple_stream_invalid, kSimpleSchema, sizeof(kSimpleSchema));
   data.size_bytes = sizeof(simple_stream_invalid);
   for (int64_t i = 1; i < 144; i++) {
+    SCOPED_TRACE(i);
+
     memcpy(simple_stream_invalid + sizeof(kSimpleSchema), kSimpleRecordBatch, i);
     memcpy(simple_stream_invalid + sizeof(kSimpleSchema) + i,
            kSimpleRecordBatch + (i + 1), (sizeof(kSimpleRecordBatch) - i));
@@ -339,8 +342,7 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
 
     ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
     schema.release(&schema);
-    ASSERT_NE(stream.get_next(&stream, &array), NANOARROW_OK)
-        << "After removing RecordBatch message byte " << i;
+    ASSERT_NE(stream.get_next(&stream, &array), NANOARROW_OK);
     ASSERT_GT(strlen(stream.get_last_error(&stream)), 0);
 
     stream.release(&stream);


### PR DESCRIPTION
Closes #287.

The reported crash occurred because the internal `ArrowIpcDecoderVerifyHeader()` incorrectly interpreted the return value of `ArrowIpcDecoderCheckHeader()`. Because the header checker returned an error code sometimes even if it succeeded, we had been ignoring the error in `ArrowIpcDecoderVerifyHeader()` which resulted in issuing commands like `memcpy(dst, src, -8)`. I believe that's undefined behaviour, leading to the intermittent nature of the crash.

In adding tests for this kind of error, I also made some improvements to error messages along the way.

```bash
# docker run --rm -it ghcr.io/apache/arrow-nanoarrow:ubuntu
# git clone https://github.com/apache/arrow-nanoarrow.git /arrow-nanoarrow
# or
# docker run --rm -it -v$(pwd):/arrow-nanoarrow ghcr.io/apache/arrow-nanoarrow:ubuntu

cd /arrow-nanoarrow/extensions/nanoarrow_ipc
mkdir build && cd build
cmake .. -DNANOARROW_IPC_BUILD_APPS=ON

curl https://gist.githubusercontent.com/amoeba/b64fc94ba5224bafcb3734bd261181d5/raw/af4c93da7ce6affba74a80e1ba94ed9573e91be8/test_arrow_data | \
    base64 -d > test_binary

with_byte_removed() {
    BYTE_PLUS_ONE=$(($2 + 2))
    cat $1 | head -c $2
    cat $1 | tail -c "+$BYTE_PLUS_ONE"
}

cmake --build .

echo "Errors:" > out.txt
for i in {1..32951}; do
  echo "$i/32951"
  echo "$i/32951" >> out.txt
  with_byte_removed test_binary $i | ./dump_stream - 2>> out.txt
done
```