### PR TITLE
fix(r): Warn for possibly out of range int64 -> double conversions

### DIFF
--- a/r/tests/testthat/test-convert-array.R
+++ b/r/tests/testthat/test-convert-array.R
@@ -515,6 +515,14 @@ test_that("convert to vector works for dictionary<double> -> double()", {
   )
 })
 
+test_that("convert to vector warns for possibly invalid double()", {
+  array <- as_nanoarrow_array(2^54, schema = na_int64())
+  expect_warning(
+    convert_array(array, double()),
+    "1 value\\(s\\) may have incurred loss of precision in conversion to double()"
+  )
+})
+
 test_that("convert to vector errors for bad array to double()", {
   expect_error(
     convert_array(as_nanoarrow_array(letters), double()),


### PR DESCRIPTION
It looks like I had left this as a TODO after my initial push to get most conversions implemented. The idea is to warn when converting very large int64/uint64 values to double. This an important case to warn for because double is the default conversion from int64 and values that won't (or might not) roundtrip back to int64 are important to warn about. See #293 implementing a safer conversion.

``` r
library(nanoarrow)

array <- as_nanoarrow_array(2^54, schema = na_int64())
convert_array(array, double())
#> Warning in convert_array.default(array, double()): 1 value(s) may have incurred
#> loss of precision in conversion to double()
#> [1] 1.80144e+16
```

<sup>Created on 2023-09-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>