### PR TITLE
fix(r): Ensure `ordered` is reflected in `na_dictionary()`

### DIFF
--- a/r/R/type.R
+++ b/r/R/type.R
@@ -386,6 +386,16 @@ na_map <- function(key_type, item_type, keys_sorted = FALSE, nullable = TRUE) {
 na_dictionary <- function(value_type, index_type = na_int32(), ordered = FALSE) {
   index_type <- as_nanoarrow_schema(index_type)
   index_type$dictionary <- value_type
+
+  if (ordered) {
+    index_type$flags <- bitwOr(index_type$flags, ARROW_FLAG$DICTIONARY_ORDERED)
+  } else {
+    index_type$flags <- bitwAnd(
+      index_type$flags,
+      bitwNot(ARROW_FLAG$DICTIONARY_ORDERED)
+    )
+  }
+
   index_type
 }
 
@@ -451,4 +461,10 @@ NANOARROW_TYPE <- list(
   LARGE_BINARY = 36L,
   LARGE_LIST = 37L,
   INTERVAL_MONTH_DAY_NANO = 38L
+)
+
+ARROW_FLAG <- list(
+  DICTIONARY_ORDERED = 1L,
+  NULLABLE = 2L,
+  MAP_KEYS_SORTED = 4L
 )

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -136,9 +136,16 @@ test_that("map constructor assigns the correct key and value types", {
 })
 
 test_that("dictionary types can be created", {
-  schema <- na_dictionary(na_string())
+  schema <- na_dictionary(na_string(), ordered = FALSE)
   expect_identical(schema$format, "i")
   expect_identical(schema$dictionary$format, "u")
+  expect_identical(schema$flags, ARROW_FLAG$NULLABLE)
+
+  schema <- na_dictionary(na_string(), ordered = TRUE)
+  expect_identical(
+    schema$flags,
+    bitwOr(ARROW_FLAG$NULLABLE, ARROW_FLAG$DICTIONARY_ORDERED)
+  )
 })
 
 test_that("extension types can be created", {


### PR DESCRIPTION
Closes #296.

``` r
library(nanoarrow)

arrow::as_data_type(na_dictionary(na_string(), ordered = FALSE))
#> DictionaryType
#> dictionary<values=string, indices=int32>
arrow::as_data_type(na_dictionary(na_string(), ordered = TRUE))
#> DictionaryType
#> dictionary<values=string, indices=int32>

arrow::as_data_type(
  infer_nanoarrow_schema(factor(letters[1:5], ordered = TRUE))
)
#> DictionaryType
#> dictionary<values=string, indices=int32>
arrow::as_data_type(
  infer_nanoarrow_schema(factor(letters[1:5], ordered = FALSE))
)
#> DictionaryType
#> dictionary<values=string, indices=int32>
```

<sup>Created on 2023-09-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>