### PR TITLE
fix: Fix declaration of an array with an ambiguously constexpr size

### DIFF
--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -293,8 +293,8 @@ void TestArrowBitmapUnpackUnsafe(const uint8_t* bitmap, std::vector<int8_t> expe
 
 TEST(BitmapTest, BitmapTestBitmapUnpack) {
   uint8_t bitmap[3];
-  int64_t n_values = sizeof(bitmap) * 8;
-  int8_t result[n_values];
+  int8_t result[sizeof(bitmap) * 8];
+  int64_t n_values = sizeof(result);
   int32_t result32[n_values];
 
   // Basic test of a validity buffer that is all true


### PR DESCRIPTION
Closes #283.