### PR TITLE
docs(r): fix source links from pkgdown site

### DIFF
--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -19,3 +19,10 @@ url: ~
 template:
   bootstrap: 5
 destination: ../docs/_build/html/r
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-nanoarrow/
+    source: https://github.com/apache/arrow-nanoarrow/blob/main/r/
+    issue: https://github.com/apache/arrow-nanoarrow/issues/
+    user: https://github.com/


### PR DESCRIPTION
Since the R package is in a subdirectory, I believe this setting is necessary to ensure that the links to the source files are generated correctly.