### PR TITLE
feat: Add Type/Field/Schema JSON writer for integration testing JSON

### DIFF
--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -51,7 +51,25 @@ class TestingJSONWriter {
       return EINVAL;
     }
 
-    return ENOTSUP;
+    // Write fields
+    out << R"("fields": )";
+    if (schema->n_children == 0) {
+      out << "[]";
+    } else {
+      out << "[";
+      NANOARROW_RETURN_NOT_OK(WriteField(out, schema->children[0]));
+      for (int64_t i = 1; i < schema->n_children; i++) {
+        out << ", ";
+        NANOARROW_RETURN_NOT_OK(WriteField(out, schema->children[i]));
+      }
+      out << "]";
+    }
+
+    // Write metadata
+    out << R"(, "metadata": )";
+    NANOARROW_RETURN_NOT_OK(WriteMetadata(out, schema->metadata));
+
+    return NANOARROW_OK;
   }
 
   /// \brief Write a field to out
@@ -88,7 +106,7 @@ class TestingJSONWriter {
     } else {
       out << "[";
       NANOARROW_RETURN_NOT_OK(WriteField(out, field->children[0]));
-      for (int64_t i = 0; i < field->n_children; i++) {
+      for (int64_t i = 1; i < field->n_children; i++) {
         out << ", ";
         NANOARROW_RETURN_NOT_OK(WriteField(out, field->children[i]));
       }

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -51,6 +51,8 @@ class TestingJSONWriter {
       return EINVAL;
     }
 
+    out << "{";
+
     // Write fields
     out << R"("fields": )";
     if (schema->n_children == 0) {
@@ -69,6 +71,7 @@ class TestingJSONWriter {
     out << R"(, "metadata": )";
     NANOARROW_RETURN_NOT_OK(WriteMetadata(out, schema->metadata));
 
+    out << "}";
     return NANOARROW_OK;
   }
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -88,7 +88,8 @@ class TestingJSONWriter {
     if (field->name == nullptr) {
       out << R"("name": null)";
     } else {
-      out << R"("name": ")" << field->name << R"(")";
+      out << R"("name": )";
+      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->format)));
     }
 
     // Write nullability
@@ -170,7 +171,8 @@ class TestingJSONWriter {
     if (field->name == nullptr) {
       out << R"("name": null)";
     } else {
-      out << R"("name": ")" << field->name << R"(")";
+      out << R"("name": )";
+      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->format)));
     }
 
     // Write length

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -105,6 +105,16 @@ class TestingJSONWriter {
     return NANOARROW_OK;
   }
 
+  /// \brief Write the type portion of a field
+  ///
+  /// Creates output like `{"name": "int", ...}`
+  ArrowErrorCode WriteType(std::ostream& out, const ArrowSchema* field) {
+    ArrowSchemaView view;
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&view, (ArrowSchema*)field, nullptr));
+    NANOARROW_RETURN_NOT_OK(WriteType(out, &view));
+    return NANOARROW_OK;
+  }
+
   /// \brief Write a "batch" to out
   ///
   /// Creates output like `{"count": 123, "columns": [...]}`.
@@ -245,15 +255,15 @@ class TestingJSONWriter {
       case NANOARROW_TYPE_INT16:
       case NANOARROW_TYPE_INT32:
       case NANOARROW_TYPE_INT64:
-        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[2]
+        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[1]
             << R"(, "isSigned": true)";
         break;
       case NANOARROW_TYPE_UINT8:
       case NANOARROW_TYPE_UINT16:
       case NANOARROW_TYPE_UINT64:
       case NANOARROW_TYPE_UINT32:
-        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[2]
-            << R"(" "isSigned": false)";
+        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[1]
+            << R"(, "isSigned": false)";
         break;
       case NANOARROW_TYPE_HALF_FLOAT:
         out << R"("name": "floatingpoint", "precision": "HALF")";

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -42,6 +42,25 @@ namespace testing {
 /// \brief Writer for the Arrow integration testing JSON format
 class TestingJSONWriter {
  public:
+  /// \brief Write a schema to out
+  ///
+  /// Creates output like `{"fields": [...], "metadata": [...]}`.
+  ArrowErrorCode WriteSchema(std::ostream& out, const ArrowSchema* schema) {
+    // Make sure we have a struct
+    if (std::string(schema->format) != "+s") {
+      return EINVAL;
+    }
+
+    return ENOTSUP;
+  }
+
+  /// \brief Write a field to out
+  ///
+  /// Creates output like `{"name" : "col", "type": {...}, ...}`
+  ArrowErrorCode WriteField(std::ostream& out, const ArrowSchema* field) {
+    return ENOTSUP;
+  }
+
   /// \brief Write a "batch" to out
   ///
   /// Creates output like `{"count": 123, "columns": [...]}`.
@@ -161,6 +180,142 @@ class TestingJSONWriter {
   }
 
  private:
+  ArrowErrorCode WriteType(std::ostream& out, const ArrowSchemaView* field) {
+    ArrowType type;
+    if (field->extension_name.data != nullptr) {
+      type = field->storage_type;
+    } else {
+      type = field->type;
+    }
+
+    out << "{";
+
+    switch (field->type) {
+      case NANOARROW_TYPE_NA:
+        out << R"("name": "null")";
+        break;
+      case NANOARROW_TYPE_BOOL:
+        out << R"("name": "bool")";
+        break;
+      case NANOARROW_TYPE_INT8:
+      case NANOARROW_TYPE_INT16:
+      case NANOARROW_TYPE_INT32:
+      case NANOARROW_TYPE_INT64:
+        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[2]
+            << R"(, "isSigned": true)";
+        break;
+      case NANOARROW_TYPE_UINT8:
+      case NANOARROW_TYPE_UINT16:
+      case NANOARROW_TYPE_UINT64:
+      case NANOARROW_TYPE_UINT32:
+        out << R"("name": "int", "bitWidth": )" << field->layout.element_size_bits[2]
+            << R"(" "isSigned": false)";
+        break;
+      case NANOARROW_TYPE_HALF_FLOAT:
+        out << R"("name": "floatingpoint", "precision": "HALF")";
+        break;
+      case NANOARROW_TYPE_FLOAT:
+        out << R"("name": "floatingpoint", "precision": "SINGLE")";
+        break;
+      case NANOARROW_TYPE_DOUBLE:
+        out << R"("name": "floatingpoint", "precision": "DOUBLE")";
+        break;
+      case NANOARROW_TYPE_STRING:
+        out << R"("name": "utf8")";
+        break;
+      case NANOARROW_TYPE_LARGE_STRING:
+        out << R"("name": "largeutf8")";
+        break;
+      case NANOARROW_TYPE_BINARY:
+        out << R"("name": "binary")";
+        break;
+      case NANOARROW_TYPE_LARGE_BINARY:
+        out << R"("name": "largebinary")";
+        break;
+      case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+        out << R"("name": "fixedsizebinary", "byteWidth": )" << field->fixed_size;
+        break;
+      case NANOARROW_TYPE_DECIMAL128:
+      case NANOARROW_TYPE_DECIMAL256:
+        out << R"("name": "struct", "bitWidth": )" << field->decimal_bitwidth
+            << R"(, "precision": )" << field->decimal_precision << R"(, "scale": )"
+            << field->decimal_scale;
+        break;
+      case NANOARROW_TYPE_STRUCT:
+        out << R"("name": "struct")";
+        break;
+      case NANOARROW_TYPE_LIST:
+        out << R"("name": "list")";
+        break;
+      case NANOARROW_TYPE_MAP:
+        out << R"("name": "map", "keysSorted": )";
+        if (field->schema->flags & ARROW_FLAG_MAP_KEYS_SORTED) {
+          out << "true";
+        } else {
+          out << "false";
+        }
+        break;
+      case NANOARROW_TYPE_LARGE_LIST:
+        out << R"("name": "largelist")";
+        break;
+      case NANOARROW_TYPE_FIXED_SIZE_LIST:
+        out << R"("name": "fixedsizelist", "listSize": )"
+            << field->layout.child_size_elements;
+        break;
+      case NANOARROW_TYPE_DENSE_UNION:
+        out << R"("name": "union", "mode": "DENSE", "typeIds": [)"
+            << field->union_type_ids << "]";
+        break;
+      case NANOARROW_TYPE_SPARSE_UNION:
+        out << R"("name": "union", "mode": "SPARSE", "typeIds": [)"
+            << field->union_type_ids << "]";
+        break;
+
+      default:
+        // Not supported
+        return ENOTSUP;
+    }
+
+    out << "}";
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode WriteMetadata(std::ostream& out, const char* metadata) {
+    if (metadata == nullptr) {
+      out << "null";
+      return NANOARROW_OK;
+    }
+
+    ArrowMetadataReader reader;
+    NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderInit(&reader, metadata));
+    if (reader.remaining_keys == 0) {
+      out << "[]";
+      return NANOARROW_OK;
+    }
+
+    out << "[";
+    NANOARROW_RETURN_NOT_OK(WriteMetadataItem(out, &reader));
+    while (reader.remaining_keys > 0) {
+      out << ", ";
+      NANOARROW_RETURN_NOT_OK(WriteMetadataItem(out, &reader));
+    }
+
+    out << "]";
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode WriteMetadataItem(std::ostream& out, ArrowMetadataReader* reader) {
+    ArrowStringView key;
+    ArrowStringView value;
+    NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderRead(reader, &key, &value));
+    out << R"({"key": )";
+    NANOARROW_RETURN_NOT_OK(WriteString(out, key));
+    out << R"(, "value": )";
+    NANOARROW_RETURN_NOT_OK(WriteString(out, value));
+    out << "}";
+    return NANOARROW_OK;
+  }
+
   void WriteBitmap(std::ostream& out, const uint8_t* bits, int64_t length) {
     if (length == 0) {
       out << "[]";

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -89,7 +89,7 @@ class TestingJSONWriter {
       out << R"("name": null)";
     } else {
       out << R"("name": )";
-      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->format)));
+      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->name)));
     }
 
     // Write nullability
@@ -172,7 +172,7 @@ class TestingJSONWriter {
       out << R"("name": null)";
     } else {
       out << R"("name": )";
-      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->format)));
+      NANOARROW_RETURN_NOT_OK(WriteString(out, ArrowCharView(field->name)));
     }
 
     // Write length

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -291,7 +291,7 @@ class TestingJSONWriter {
         break;
       case NANOARROW_TYPE_DECIMAL128:
       case NANOARROW_TYPE_DECIMAL256:
-        out << R"("name": "struct", "bitWidth": )" << field->decimal_bitwidth
+        out << R"("name": "decimal", "bitWidth": )" << field->decimal_bitwidth
             << R"(, "precision": )" << field->decimal_precision << R"(, "scale": )"
             << field->decimal_scale;
         break;

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -55,11 +55,11 @@ ArrowErrorCode WriteTypeJSON(std::ostream& out, const ArrowSchema* schema,
   return writer.WriteType(out, schema);
 }
 
-void TestColumn(std::function<ArrowErrorCode(ArrowSchema*)> type_expr,
-                std::function<ArrowErrorCode(ArrowArray*)> append_expr,
-                ArrowErrorCode (*test_expr)(std::ostream&, const ArrowSchema*,
-                                            ArrowArrayView*),
-                const std::string& expected_json) {
+void TestWriteJSON(std::function<ArrowErrorCode(ArrowSchema*)> type_expr,
+                   std::function<ArrowErrorCode(ArrowArray*)> append_expr,
+                   ArrowErrorCode (*test_expr)(std::ostream&, const ArrowSchema*,
+                                               ArrowArrayView*),
+                   const std::string& expected_json) {
   std::stringstream ss;
 
   nanoarrow::UniqueSchema schema;
@@ -80,14 +80,14 @@ void TestColumn(std::function<ArrowErrorCode(ArrowSchema*)> type_expr,
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnNull) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
       R"({"name": null, "count": 0})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, "colname"));
@@ -98,7 +98,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnNull) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT32);
       },
@@ -106,7 +106,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
       R"({"name": null, "count": 0, "VALIDITY": [], "DATA": []})");
 
   // Without a null value
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT32);
       },
@@ -120,7 +120,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
       R"({"name": null, "count": 3, "VALIDITY": [1, 1, 1], "DATA": [0, 1, 0]})");
 
   // With two null values
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT32);
       },
@@ -134,7 +134,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt64) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT64);
       },
@@ -149,7 +149,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt64) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnUInt64) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_UINT64);
       },
@@ -164,7 +164,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnUInt64) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnFloat) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_FLOAT);
       },
@@ -178,7 +178,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnFloat) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
@@ -192,7 +192,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
       R"("OFFSET": [0, 3, 6], "DATA": ["abc", "def"]})");
 
   // Check a string that requires escaping of characters \ and "
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
@@ -205,7 +205,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
       R"("OFFSET": [0, 2], "DATA": ["\"\\"]})");
 
   // Check a string that requires unicode escape
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
@@ -219,7 +219,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnLargeString) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_LARGE_STRING);
       },
@@ -234,7 +234,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnLargeString) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnBinary) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_BINARY);
       },
@@ -255,7 +255,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnBinary) {
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnStruct) {
   // Empty struct
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
@@ -265,7 +265,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnStruct) {
       R"({"name": null, "count": 0, "VALIDITY": [], "children": []})");
 
   // Non-empty struct
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 2));
@@ -284,7 +284,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnStruct) {
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnDenseUnion) {
   // Empty union
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
@@ -297,7 +297,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnDenseUnion) {
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
   // Empty batch
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
@@ -308,7 +308,18 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
-  TestColumn(
+  // Zero fields
+  TestWriteJSON(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteSchemaJSON,
+      R"({"fields": [], "metadata": null})");
+
+  // More than zero fields
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 2));
@@ -326,7 +337,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         return NANOARROW_OK;
@@ -334,7 +345,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         schema->flags = 0;
@@ -343,7 +354,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
       R"({"name": null, "nullable": false, "type": {"name": "null"}, "children": [], "metadata": null})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, "colname"));
@@ -355,7 +366,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
   // Non-null but zero-size metadata
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetMetadata(schema, "\0\0\0\0"));
@@ -365,7 +376,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": []})");
 
   // Non-zero size metadata
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         nanoarrow::UniqueBuffer buffer;
         NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderInit(buffer.get(), nullptr));
@@ -385,7 +396,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 2));
@@ -403,77 +414,77 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypePrimitive) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "null"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_BOOL);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "bool"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT8);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "int", "bitWidth": 8, "isSigned": true})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_UINT8);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "int", "bitWidth": 8, "isSigned": false})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_HALF_FLOAT);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "HALF"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_FLOAT);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "SINGLE"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_DOUBLE);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "DOUBLE"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "utf8"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_LARGE_STRING);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "largeutf8"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_BINARY);
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "binary"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_LARGE_BINARY);
       },
@@ -482,7 +493,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypePrimitive) {
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
@@ -492,7 +503,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "fixedsizebinary", "byteWidth": 123})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
@@ -502,7 +513,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "decimal", "bitWidth": 128, "precision": 10, "scale": 3})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
@@ -511,7 +522,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "struct"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_LIST));
@@ -522,7 +533,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "list"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_MAP));
@@ -535,7 +546,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "map", "keysSorted": false})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_MAP));
@@ -549,7 +560,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "map", "keysSorted": true})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_LARGE_LIST));
@@ -560,7 +571,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "largelist"})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
@@ -572,7 +583,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "fixedsizelist", "listSize": 12})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
@@ -582,7 +593,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "union", "mode": "SPARSE", "typeIds": []})");
 
-  TestColumn(
+  TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -582,7 +582,9 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "fixedsizelist", "listSize": 12})");
+}
 
+TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
   TestWriteJSON(
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
@@ -597,9 +599,37 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       [](ArrowSchema* schema) {
         ArrowSchemaInit(schema);
         NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_SPARSE_UNION, 2));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_STRING));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "union", "mode": "SPARSE", "typeIds": [0,1]})");
+
+  TestWriteJSON(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
             ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_DENSE_UNION, 0));
         return NANOARROW_OK;
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "union", "mode": "DENSE", "typeIds": []})");
+
+  TestWriteJSON(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_DENSE_UNION, 2));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_STRING));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "union", "mode": "DENSE", "typeIds": [0,1]})");
 }

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -307,6 +307,21 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
       R"({"count": 0, "columns": []})");
 }
 
+TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 2));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_NA));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_STRING));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteSchemaJSON,
+      R"({"fields": [{"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, {"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null}], "metadata": null})");
+}
+
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
   TestColumn(
       [](ArrowSchema* schema) {

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -319,7 +319,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
         return NANOARROW_OK;
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteSchemaJSON,
-      R"({"fields": [{"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, {"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null}], "metadata": null})");
+      R"({"fields": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, )"
+      R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null}], )"
+      R"("metadata": null})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
@@ -377,7 +380,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
         return NANOARROW_OK;
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
-      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]})");
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], )"
+      R"("metadata": [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {
@@ -392,7 +396,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {
         return NANOARROW_OK;
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
-      R"({"name": null, "nullable": true, "type": {"name": "struct"}, "children": [{"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, {"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null}], "metadata": null})");
+      R"({"name": null, "nullable": true, "type": {"name": "struct"}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, )"
+      R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null}], )"
+      R"("metadata": null})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypePrimitive) {

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -295,4 +295,12 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
       R"({"count": 0, "columns": []})");
 }
 
-TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNull) { ASSERT_EQ(4, 4); }
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNull) {
+  TestColumn(
+      [](ArrowSchema* schema) {
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
+}

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -309,6 +309,34 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
+        schema->flags = 0;
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      R"({"name": null, "nullable": false, "type": {"name": "null"}, "children": [], "metadata": null})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, "colname"));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      R"({"name": "colname", "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
+  TestColumn(
+      [](ArrowSchema* schema) {
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypePrimitive) {

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -37,6 +37,12 @@ ArrowErrorCode WriteColumnJSON(std::ostream& out, const ArrowSchema* schema,
   return writer.WriteColumn(out, schema, array_view);
 }
 
+ArrowErrorCode WriteFieldJSON(std::ostream& out, const ArrowSchema* schema,
+                              ArrowArrayView* array_view) {
+  TestingJSONWriter writer;
+  return writer.WriteField(out, schema);
+}
+
 void TestColumn(std::function<ArrowErrorCode(ArrowSchema*)> type_expr,
                 std::function<ArrowErrorCode(ArrowArray*)> append_expr,
                 ArrowErrorCode (*test_expr)(std::ostream&, const ArrowSchema*,
@@ -288,3 +294,5 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteBatchJSON,
       R"({"count": 0, "columns": []})");
 }
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNull) { ASSERT_EQ(4, 4); }

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -400,4 +400,104 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
       },
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
       R"({"name": "fixedsizebinary", "byteWidth": 123})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeDecimal(schema, NANOARROW_TYPE_DECIMAL128, 10, 3));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "decimal", "bitWidth": 128, "precision": 10, "scale": 3})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "struct"})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_LIST));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "list"})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_MAP));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0]->children[0], NANOARROW_TYPE_STRING));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0]->children[1], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "map", "keysSorted": false})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_MAP));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0]->children[0], NANOARROW_TYPE_STRING));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0]->children[1], NANOARROW_TYPE_INT32));
+        schema->flags = ARROW_FLAG_MAP_KEYS_SORTED;
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "map", "keysSorted": true})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_LARGE_LIST));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "largelist"})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeFixedSize(schema, NANOARROW_TYPE_FIXED_SIZE_LIST, 12));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "fixedsizelist", "listSize": 12})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_SPARSE_UNION, 0));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "union", "mode": "SPARSE", "typeIds": []})");
+
+  TestColumn(
+      [](ArrowSchema* schema) {
+        ArrowSchemaInit(schema);
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_DENSE_UNION, 0));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      R"({"name": "union", "mode": "DENSE", "typeIds": []})");
 }


### PR DESCRIPTION
Adds methods to the `TestingJSONWriter` to write `Schema`, `Field`, and `Type`. There are some unsupported types but I'd like to get some end-to-end bits working before rounding out type support!