### PR TITLE
feat: Add integration testing JSON reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,13 @@ if(NANOARROW_BUILD_TESTS)
 
   fetchcontent_makeavailable(googletest)
 
+  # JSON for integration testing
+  fetchcontent_declare(nlohmann_json
+                       URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
+                       URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
+  )
+  fetchcontent_makeavailable(nlohmann_json)
+
   add_executable(utils_test src/nanoarrow/utils_test.cc)
   add_executable(buffer_test src/nanoarrow/buffer_test.cc)
   add_executable(array_test src/nanoarrow/array_test.cc)
@@ -235,7 +242,12 @@ if(NANOARROW_BUILD_TESTS)
                         coverage_config)
   target_link_libraries(array_stream_test nanoarrow gtest_main coverage_config)
   target_link_libraries(nanoarrow_hpp_test nanoarrow gtest_main coverage_config)
-  target_link_libraries(nanoarrow_testing_test nanoarrow gtest_main coverage_config)
+  target_link_libraries(nanoarrow_testing_test
+                        nanoarrow
+                        gtest_main
+                        nlohmann_json::nlohmann_json
+                        coverage_config)
+  target_compile_definitions(nanoarrow_testing_test PUBLIC NANOARROW_TESTING_WITH_NLOHMANN_JSON)
 
   include(GoogleTest)
   # Some users have reported a timeout with the default value of 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,8 +250,6 @@ if(NANOARROW_BUILD_TESTS)
                         gtest_main
                         nlohmann_json::nlohmann_json
                         coverage_config)
-  target_compile_definitions(nanoarrow_testing_test
-                             PUBLIC NANOARROW_TESTING_WITH_NLOHMANN_JSON)
 
   include(GoogleTest)
   # Some users have reported a timeout with the default value of 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,13 +187,6 @@ if(NANOARROW_BUILD_TESTS)
     set(NANOARROW_ARROW_TARGET arrow_shared)
   endif()
 
-  # JSON for integration testing
-  fetchcontent_declare(nlohmann_json
-                       URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
-                       URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
-  )
-  fetchcontent_makeavailable(nlohmann_json)
-
   # Use an old version of googletest if we have to to support gcc 4.8
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION
                                                  VERSION_GREATER_EQUAL "5.0.0")
@@ -209,6 +202,16 @@ if(NANOARROW_BUILD_TESTS)
   endif()
 
   fetchcontent_makeavailable(googletest)
+
+  # JSON library for integration testing
+  # Also used by some versions of Arrow, so check if this is already available
+  if(NOT TARGET nlohmann_json::nlohmann_json)
+    fetchcontent_declare(nlohmann_json
+                         URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
+                         URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
+    )
+    fetchcontent_makeavailable(nlohmann_json)
+  endif()
 
   add_executable(utils_test src/nanoarrow/utils_test.cc)
   add_executable(buffer_test src/nanoarrow/buffer_test.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,13 @@ if(NANOARROW_BUILD_TESTS)
     set(NANOARROW_ARROW_TARGET arrow_shared)
   endif()
 
+  # JSON for integration testing
+  fetchcontent_declare(nlohmann_json
+                       URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
+                       URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
+  )
+  fetchcontent_makeavailable(nlohmann_json)
+
   # Use an old version of googletest if we have to to support gcc 4.8
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION
                                                  VERSION_GREATER_EQUAL "5.0.0")
@@ -202,13 +209,6 @@ if(NANOARROW_BUILD_TESTS)
   endif()
 
   fetchcontent_makeavailable(googletest)
-
-  # JSON for integration testing
-  fetchcontent_declare(nlohmann_json
-                       URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
-                       URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
-  )
-  fetchcontent_makeavailable(nlohmann_json)
 
   add_executable(utils_test src/nanoarrow/utils_test.cc)
   add_executable(buffer_test src/nanoarrow/buffer_test.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,8 @@ if(NANOARROW_BUILD_TESTS)
                         gtest_main
                         nlohmann_json::nlohmann_json
                         coverage_config)
-  target_compile_definitions(nanoarrow_testing_test PUBLIC NANOARROW_TESTING_WITH_NLOHMANN_JSON)
+  target_compile_definitions(nanoarrow_testing_test
+                             PUBLIC NANOARROW_TESTING_WITH_NLOHMANN_JSON)
 
   include(GoogleTest)
   # Some users have reported a timeout with the default value of 5

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -20,6 +20,11 @@
 
 #include "nanoarrow.hpp"
 
+#if defined(NANOARROW_TESTING_WITH_NLOHMANN_JSON)
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+#endif
+
 #ifndef NANOARROW_TESTING_HPP_INCLUDED
 #define NANOARROW_TESTING_HPP_INCLUDED
 
@@ -612,6 +617,16 @@ class TestingJSONWriter {
     std::streamsize previous_precision_;
   };
 };
+
+#if defined(NANOARROW_TESTING_WITH_NLOHMANN_JSON)
+
+/// \brief Writer for the Arrow integration testing JSON format
+class TestingJSONReader {
+ public:
+  ArrowErrorCode ReadField(const std::string& value) { return ENOTSUP; }
+};
+
+#endif
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -793,7 +793,7 @@ class TestingJSONReader {
                                   "Type[name=='int'] bitWidth must be integer"));
 
     const auto& issigned = value["isSigned"];
-    NANOARROW_RETURN_NOT_OK(Check(bitwidth.is_boolean(), error,
+    NANOARROW_RETURN_NOT_OK(Check(issigned.is_boolean(), error,
                                   "Type[name=='int'] isSigned must be boolean"));
 
     ArrowType type = NANOARROW_TYPE_UNINITIALIZED;

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #include "nanoarrow.hpp"
@@ -766,18 +767,15 @@ class TestingJSONReader {
     } else if (name_str == "fixedsizebinary") {
       NANOARROW_RETURN_NOT_OK(SetTypeFixedSizeBinary(schema, value, error));
     } else if (name_str == "list") {
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetType(schema, NANOARROW_TYPE_LIST),
-                                         error);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetFormat(schema, "+l"), error);
     } else if (name_str == "largelist") {
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          ArrowSchemaSetType(schema, NANOARROW_TYPE_LARGE_LIST), error);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetFormat(schema, "+L"), error);
     } else if (name_str == "fixedsizelist") {
       NANOARROW_RETURN_NOT_OK(SetTypeFixedSizeList(schema, value, error));
     } else if (name_str == "union") {
       NANOARROW_RETURN_NOT_OK(SetTypeUnion(schema, value, error));
     } else if (name_str == "struct") {
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          ArrowSchemaSetType(schema, NANOARROW_TYPE_STRUCT), error);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetFormat(schema, "+s"), error);
     } else {
       ArrowErrorSet(error, "Unsupported Type name: '%s'", name_str.c_str());
       return ENOTSUP;
@@ -958,10 +956,11 @@ class TestingJSONReader {
         Check(list_size.is_number_integer(), error,
               "Type[name=='fixedsizelist'] listSize must be integer"));
 
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-        ArrowSchemaSetTypeFixedSize(schema, NANOARROW_TYPE_FIXED_SIZE_LIST,
-                                    list_size.get<int>()),
-        error);
+    std::stringstream format_builder;
+    format_builder << "+w:" << list_size;
+    std::string format = format_builder.str();
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetFormat(schema, format.c_str()),
+                                       error);
     return NANOARROW_OK;
   }
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -19,11 +19,9 @@
 #include <sstream>
 #include <string>
 
-#include "nanoarrow.hpp"
-
-#if defined(NANOARROW_TESTING_WITH_NLOHMANN_JSON)
 #include <nlohmann/json.hpp>
-#endif
+
+#include "nanoarrow.hpp"
 
 #ifndef NANOARROW_TESTING_HPP_INCLUDED
 #define NANOARROW_TESTING_HPP_INCLUDED
@@ -618,8 +616,6 @@ class TestingJSONWriter {
   };
 };
 
-#if defined(NANOARROW_TESTING_WITH_NLOHMANN_JSON)
-
 /// \brief Reader for the Arrow integration testing JSON format
 class TestingJSONReader {
   using json = nlohmann::json;
@@ -734,7 +730,6 @@ class TestingJSONReader {
     // Validate!
     ArrowSchemaView schema_view;
     NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
-
     return NANOARROW_OK;
   }
 
@@ -1067,8 +1062,6 @@ class TestingJSONReader {
     }
   }
 };
-
-#endif
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -726,6 +726,11 @@ class TestingJSONReader {
     }
 
     NANOARROW_RETURN_NOT_OK(SetMetadata(schema, value["metadata"], error));
+
+    // Validate!
+    ArrowSchemaView schema_view;
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
+
     return NANOARROW_OK;
   }
 
@@ -770,6 +775,8 @@ class TestingJSONReader {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetFormat(schema, "+L"), error);
     } else if (name_str == "fixedsizelist") {
       NANOARROW_RETURN_NOT_OK(SetTypeFixedSizeList(schema, value, error));
+    } else if (name_str == "map") {
+      NANOARROW_RETURN_NOT_OK(SetTypeMap(schema, value, error));
     } else if (name_str == "union") {
       NANOARROW_RETURN_NOT_OK(SetTypeUnion(schema, value, error));
     } else if (name_str == "struct") {
@@ -994,9 +1001,9 @@ class TestingJSONReader {
         NANOARROW_RETURN_NOT_OK(
             Check(type_id.is_number_integer(), error,
                   "Type[name=='union'] typeIds item must be integer"));
-        type_ids_format << type_ids;
+        type_ids_format << type_id;
 
-        if ((i + 1) < type_id.size()) {
+        if ((i + 1) < type_ids.size()) {
           type_ids_format << ",";
         }
       }

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -635,8 +635,7 @@ class TestingJSONReader {
       ArrowSchemaMove(schema.get(), out);
       return NANOARROW_OK;
     } catch (std::exception& e) {
-      ArrowErrorSet(error, "%s", "Exception in TestingJSONReader::ReadSchema(): %s",
-                    e.what());
+      ArrowErrorSet(error, "Exception in TestingJSONReader::ReadSchema(): %s", e.what());
       return EINVAL;
     }
   }
@@ -651,8 +650,7 @@ class TestingJSONReader {
       ArrowSchemaMove(schema.get(), out);
       return NANOARROW_OK;
     } catch (std::exception& e) {
-      ArrowErrorSet(error, "%s", "Exception in TestingJSONReader::ReadField(): %s",
-                    e.what());
+      ArrowErrorSet(error, "Exception in TestingJSONReader::ReadField(): %s", e.what());
       return EINVAL;
     }
   }

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -620,7 +620,7 @@ class TestingJSONWriter {
 
 #if defined(NANOARROW_TESTING_WITH_NLOHMANN_JSON)
 
-/// \brief Writer for the Arrow integration testing JSON format
+/// \brief Reader for the Arrow integration testing JSON format
 class TestingJSONReader {
   using json = nlohmann::json;
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -745,6 +745,12 @@ class TestingJSONReader {
     } else if (name_str == "bool") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetType(schema, NANOARROW_TYPE_BOOL),
                                          error);
+    } else if (name_str == "int") {
+      NANOARROW_RETURN_NOT_OK(SetTypeInt(schema, value, error));
+    } else if (name_str == "floatingpoint") {
+      NANOARROW_RETURN_NOT_OK(SetTypeFloatingPoint(schema, value, error));
+    } else if (name_str == "decimal") {
+      NANOARROW_RETURN_NOT_OK(SetTypeDecimal(schema, value, error));
     } else if (name_str == "utf8") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowSchemaSetType(schema, NANOARROW_TYPE_STRING), error);
@@ -757,12 +763,18 @@ class TestingJSONReader {
     } else if (name_str == "largebinary") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowSchemaSetType(schema, NANOARROW_TYPE_LARGE_BINARY), error);
+    } else if (name_str == "fixedsizebinary") {
+      NANOARROW_RETURN_NOT_OK(SetTypeFixedSizeBinary(schema, value, error));
     } else if (name_str == "list") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaSetType(schema, NANOARROW_TYPE_LIST),
                                          error);
     } else if (name_str == "largelist") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowSchemaSetType(schema, NANOARROW_TYPE_LARGE_LIST), error);
+    } else if (name_str == "fixedsizelist") {
+      NANOARROW_RETURN_NOT_OK(SetTypeFixedSizeList(schema, value, error));
+    } else if (name_str == "union") {
+      NANOARROW_RETURN_NOT_OK(SetTypeUnion(schema, value, error));
     } else if (name_str == "struct") {
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowSchemaSetType(schema, NANOARROW_TYPE_STRUCT), error);

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -669,7 +669,7 @@ class TestingJSONReader {
 
     const auto& fields = value["fields"];
     NANOARROW_RETURN_NOT_OK(
-        Check(fields.is_array(), error, "Field fields must be array"));
+        Check(fields.is_array(), error, "Schema fields must be array"));
     NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowSchemaAllocateChildren(schema, fields.size()),
                                        error);
     for (int64_t i = 0; i < schema->n_children; i++) {
@@ -677,6 +677,10 @@ class TestingJSONReader {
     }
 
     NANOARROW_RETURN_NOT_OK(SetMetadata(schema, value["metadata"], error));
+
+    // Validate!
+    ArrowSchemaView schema_view;
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
     return NANOARROW_OK;
   }
 

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -727,3 +727,24 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldNested) {
   ASSERT_EQ(schema->n_children, 1);
   EXPECT_STREQ(schema->children[0]->format, "n");
 }
+
+void TestFieldRoundtrip(const std::string& field_json) {
+  nanoarrow::UniqueSchema schema;
+  TestingJSONReader reader;
+  TestingJSONWriter writer;
+  ArrowError error;
+  error.message[0] = '\0';
+
+  int result = reader.ReadField(field_json, schema.get(), &error);
+  EXPECT_STREQ(error.message, "");
+  ASSERT_EQ(result, NANOARROW_OK);
+
+  std::stringstream field_json_roundtrip;
+  ASSERT_EQ(writer.WriteField(field_json_roundtrip, schema.get()), NANOARROW_OK);
+  EXPECT_EQ(field_json_roundtrip.str(), field_json);
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtrip) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
+}

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -736,57 +736,91 @@ void TestFieldRoundtrip(const std::string& field_json) {
   error.message[0] = '\0';
 
   int result = reader.ReadField(field_json, schema.get(), &error);
-  EXPECT_STREQ(error.message, "");
-  ASSERT_EQ(result, NANOARROW_OK);
+  ASSERT_EQ(result, NANOARROW_OK) << "Error: " << error.message;
 
   std::stringstream field_json_roundtrip;
   ASSERT_EQ(writer.WriteField(field_json_roundtrip, schema.get()), NANOARROW_OK);
   EXPECT_EQ(field_json_roundtrip.str(), field_json);
 }
 
-TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtrip) {
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "bool"}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "largeutf8"}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "binary"}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "largebinary"}, "children": [], "metadata": null})");
-  // {"name": "int", "bitWidth": 8, "isSigned": true}
+void TestTypeRoundtrip(const std::string& type_json) {
+  std::stringstream field_json_builder;
+  field_json_builder << R"({"name": null, "nullable": true, "type": )" << type_json
+                     << R"(, "children": [], "metadata": null})";
+  TestFieldRoundtrip(field_json_builder.str());
 }
 
-TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtripInt) {
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 8, "isSigned": true}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 16, "isSigned": true}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 32, "isSigned": true}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 64, "isSigned": true}, "children": [], "metadata": null})");
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldPrimitive) {
+  TestTypeRoundtrip(R"({"name": "null"})");
+  TestTypeRoundtrip(R"({"name": "bool"})");
+  TestTypeRoundtrip(R"({"name": "utf8"})");
+  TestTypeRoundtrip(R"({"name": "largeutf8"})");
+  TestTypeRoundtrip(R"({"name": "binary"})");
+  TestTypeRoundtrip(R"({"name": "largebinary"})");
 }
 
-TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtripUInt) {
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 8, "isSigned": false}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 16, "isSigned": false}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 32, "isSigned": false}, "children": [], "metadata": null})");
-  TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 64, "isSigned": false}, "children": [], "metadata": null})");
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldInt) {
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 8, "isSigned": true})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 16, "isSigned": true})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 32, "isSigned": true})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 64, "isSigned": true})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldUInt) {
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 8, "isSigned": false})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 16, "isSigned": false})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 32, "isSigned": false})");
+  TestTypeRoundtrip(R"({"name": "int", "bitWidth": 64, "isSigned": false})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldFloatingPoint) {
+  TestTypeRoundtrip(R"({"name": "floatingpoint", "precision": "HALF"})");
+  TestTypeRoundtrip(R"({"name": "floatingpoint", "precision": "SINGLE"})");
+  TestTypeRoundtrip(R"({"name": "floatingpoint", "precision": "DOUBLE"})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldFixedSizeBinary) {
+  TestTypeRoundtrip(R"({"name": "fixedsizebinary", "byteWidth": 123})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldDecimal) {
+  TestTypeRoundtrip(
+      R"({"name": "decimal", "bitWidth": 128, "precision": 10, "scale": 3})");
+  TestTypeRoundtrip(
+      R"({"name": "decimal", "bitWidth": 256, "precision": 10, "scale": 3})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMap) {
+  // Sorted keys
   TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "HALF"}, "children": [], "metadata": null})");
+      R"({"name": null, "nullable": true, "type": {"name": "map", "keysSorted": true}, "children": [)"
+      R"({"name": "entries", "nullable": false, "type": {"name": "struct"}, "children": [)"
+      R"({"name": null, "nullable": false, "type": {"name": "utf8"}, "children": [], "metadata": null}, )"
+      R"({"name": null, "nullable": true, "type": {"name": "bool"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})"
+      R"(], "metadata": null})");
+
+  // Unsorted keys
   TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "SINGLE"}, "children": [], "metadata": null})");
+      R"({"name": null, "nullable": true, "type": {"name": "map", "keysSorted": false}, "children": [)"
+      R"({"name": "entries", "nullable": false, "type": {"name": "struct"}, "children": [)"
+      R"({"name": null, "nullable": false, "type": {"name": "utf8"}, "children": [], "metadata": null}, )"
+      R"({"name": null, "nullable": true, "type": {"name": "bool"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})"
+      R"(], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldFixedSizeList) {
   TestFieldRoundtrip(
-      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "DOUBLE"}, "children": [], "metadata": null})");
+      R"({"name": null, "nullable": true, "type": {"name": "fixedsizelist", "listSize": 12}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldUnion) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "union", "mode": "DENSE", "typeIds": [10,20]}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}, )"
+      R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})");
 }

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -747,4 +747,46 @@ void TestFieldRoundtrip(const std::string& field_json) {
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtrip) {
   TestFieldRoundtrip(
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "bool"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "largeutf8"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "binary"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "largebinary"}, "children": [], "metadata": null})");
+  // {"name": "int", "bitWidth": 8, "isSigned": true}
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtripInt) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 8, "isSigned": true}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 16, "isSigned": true}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 32, "isSigned": true}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 64, "isSigned": true}, "children": [], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldRoundtripUInt) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 8, "isSigned": false}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 16, "isSigned": false}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 32, "isSigned": false}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "int", "bitWidth": 64, "isSigned": false}, "children": [], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldFloatingPoint) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "HALF"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "SINGLE"}, "children": [], "metadata": null})");
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "floatingpoint", "precision": "DOUBLE"}, "children": [], "metadata": null})");
 }

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -635,6 +635,22 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
       R"({"name": "union", "mode": "DENSE", "typeIds": [0,1]})");
 }
 
+TEST(NanoarrowTestingTest, NanoarrowTestingTestReadSchema) {
+  nanoarrow::UniqueSchema schema;
+  TestingJSONReader reader;
+
+  ASSERT_EQ(
+      reader.ReadSchema(
+          R"({"fields": [)"
+          R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null}], )"
+          R"("metadata": null})",
+          schema.get()),
+      NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "+s");
+  ASSERT_EQ(schema->n_children, 1);
+  EXPECT_STREQ(schema->children[0]->format, "n");
+}
+
 TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldBasic) {
   nanoarrow::UniqueSchema schema;
   TestingJSONReader reader;

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -864,6 +864,31 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMap) {
       R"(], "metadata": null})");
 }
 
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldStruct) {
+  // Empty
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "struct"}, "children": [)"
+      R"(], "metadata": null})");
+
+  // Non-empty
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "struct"}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})");
+}
+
+TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldList) {
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "list"}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})");
+
+  TestFieldRoundtrip(
+      R"({"name": null, "nullable": true, "type": {"name": "largelist"}, "children": [)"
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": null})"
+      R"(], "metadata": null})");
+}
+
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldFixedSizeList) {
   TestFieldRoundtrip(
       R"({"name": null, "nullable": true, "type": {"name": "fixedsizelist", "listSize": 12}, "children": [)"


### PR DESCRIPTION
This PR adds a `TestingJSONReader`. It uses https://github.com/nlohmann/json to do the parsing. This doesn't implement parsing a record batch or array yet, and there are a few missing types (the same missing types as the writer). I'd like to do those as a follow-up.

The testing for this is mostly roundtrip testing, which is maybe not ideal but also maybe OK because the writer is an independent implementation. When the ability to compare schemas for equality gets added that can be tacked on to the roundtrip test utility function as well.