### PR TITLE
feat: Add `ArrowXXXCompare()` helpers for comparing schema and array objects

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -279,6 +279,38 @@ ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema, enum ArrowTyp
 int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t n,
                             char recursive);
 
+enum ArrowCompareType {
+  /// \brief Results in successful comparison if x and y point to the same address
+  /// or the buffers pointed to by x and y are identical located at the same address
+  /// and the offset/length are identical.
+  NANOARROW_COMPARE_TYPE_SAME,
+
+  /// \brief Results in successful comparison if the content of all struct fields
+  /// are identical.
+  NANOARROW_COMPARE_TYPE_IDENTICAL,
+
+  /// \brief Results in successful comparison if the logical value or field represented by
+  /// x and y are the same. This may succeeed where comparison with
+  /// NANOARROW_COMPARE_TYPE_IDENTICAL fails if offset/length of an array or child array
+  /// is not identical but the array points to the same logical values.
+  NANOARROW_COMPARE_TYPE_EQUAL,
+
+  /// \brief Results in succcessful comparison as NANOARROW_COMPARE_TYPE_EQUAL except
+  /// ignoring name, nullability, and metadata when comparing schemas.
+  NANOARROW_COMPARE_TYPE_EQUAL_IGNORE_METADATA
+};
+
+/// \brief Compare the content of two schemas
+///
+/// Populates out with the result of the comparison (0 if x and y can be considered
+/// equal according to compare_type or non-zero otherwise) and error with a message,
+/// usually describing the first observed difference. Returns NANOARROW_OK
+/// if the comparison ran without error or an error code otherwise.
+ArrowErrorCode ArrowSchemaCompare(const struct ArrowSchema* x,
+                                  const struct ArrowSchema* y,
+                                  enum ArrowCompareType compare_type, int* out,
+                                  struct ArrowError* error);
+
 /// \brief Set the format field of a schema from an ArrowType
 ///
 /// Initializes the fields and release callback of schema_out. For

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -286,18 +286,10 @@ enum ArrowCompareType {
   NANOARROW_COMPARE_TYPE_SAME,
 
   /// \brief Results in successful comparison if the content of all struct fields
-  /// are identical.
-  NANOARROW_COMPARE_TYPE_IDENTICAL,
-
-  /// \brief Results in successful comparison if the logical value or field represented by
-  /// x and y are the same. This may succeeed where comparison with
-  /// NANOARROW_COMPARE_TYPE_IDENTICAL fails if offset/length of an array or child array
-  /// is not identical but the array points to the same logical values.
-  NANOARROW_COMPARE_TYPE_EQUAL,
-
-  /// \brief Results in succcessful comparison as NANOARROW_COMPARE_TYPE_EQUAL except
-  /// ignoring name, nullability, and metadata when comparing schemas.
-  NANOARROW_COMPARE_TYPE_EQUAL_IGNORE_METADATA
+  /// are identical. This type of comparison may fail if offset/length of an array
+  /// or child array is not identical even if the array points to the same logical
+  /// values.
+  NANOARROW_COMPARE_TYPE_IDENTICAL
 };
 
 /// \brief Compare the content of two schemas

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1524,3 +1524,10 @@ ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
                                           struct ArrowStringView key) {
   return ArrowMetadataBuilderSetInternal(buffer, &key, NULL);
 }
+
+ArrowErrorCode ArrowSchemaCompare(const struct ArrowSchema* x,
+                                  const struct ArrowSchema* y,
+                                  enum ArrowCompareType compare_type, int* out,
+                                  struct ArrowError* error) {
+  return ENOTSUP;
+}


### PR DESCRIPTION
The main reason for this is to support integration testing; however, these are useful for testing and their absence has led to some creative/verbose testing patterns and/or inability to test on platforms where Arrow C++ doesn't build. I am hopeful to be able to implement something like `NANOARROW_COMPARE_TYPE_EQUAL` as well, but I think the "identical" level is all that is required to get integration testing going.