### PR TITLE
feat(r): Provide LinkingTo headers for extension packages

### DIFF
--- a/r/R/array-stream.R
+++ b/r/R/array-stream.R
@@ -65,12 +65,15 @@ basic_array_stream <- function(batches, schema = NULL, validate = TRUE) {
 #' @param array_stream A [nanoarrow_array_stream][as_nanoarrow_array_stream]
 #' @param finalizer A function that will be called with zero arguments.
 #'
-#' @return `array_stream`, invisibly
+#' @return A newly allocated `array_stream` whose release callback will call
+#'   the supplied finalizer.
 #' @export
 #'
 #' @examples
-#' stream <- basic_array_stream(list(1:5))
-#' array_stream_set_finalizer(stream, function() message("All done!"))
+#' stream <- array_stream_set_finalizer(
+#'   basic_array_stream(list(1:5)),
+#'   function() message("All done!")
+#' )
 #' stream$release()
 #'
 array_stream_set_finalizer <- function(array_stream, finalizer) {
@@ -81,7 +84,9 @@ array_stream_set_finalizer <- function(array_stream, finalizer) {
   class(prot) <- "nanoarrow_array_stream_finalizer"
 
   nanoarrow_pointer_set_protected(array_stream, prot)
-  invisible(array_stream)
+  out <- nanoarrow_allocate_array_stream()
+  nanoarrow_pointer_export(array_stream, out)
+  out
 }
 
 #' Convert an object to a nanoarrow array_stream

--- a/r/inst/include/nanoarrow/r.h
+++ b/r/inst/include/nanoarrow/r.h
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef R_NANOARROW_H_INCLUDED
-#define R_NANOARROW_H_INCLUDED
+#ifndef NANOARROW_R_H_INCLUDED
+#define NANOARROW_R_H_INCLUDED
+
+#include <R.h>
+#include <Rinternals.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,6 +113,25 @@ struct ArrowArrayStream {
 
 #endif  // ARROW_C_STREAM_INTERFACE
 #endif  // ARROW_FLAG_DICTIONARY_ORDERED
+
+// Returns the underlying struct ArrowSchema* from an external pointer,
+// checking and erroring for invalid objects, pointers, and arrays.
+static inline struct ArrowSchema* nanoarrow_schema_from_xptr(SEXP schema_xptr) {
+  if (!Rf_inherits(schema_xptr, "nanoarrow_schema")) {
+    Rf_error("`schema` argument that does not inherit from 'nanoarrow_schema'");
+  }
+
+  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
+  if (schema == NULL) {
+    Rf_error("nanoarrow_schema() is an external pointer to NULL");
+  }
+
+  if (schema->release == NULL) {
+    Rf_error("nanoarrow_schema() has already been released");
+  }
+
+  return schema;
+}
 
 #ifdef __cplusplus
 }

--- a/r/man/array_stream_set_finalizer.Rd
+++ b/r/man/array_stream_set_finalizer.Rd
@@ -12,7 +12,8 @@ array_stream_set_finalizer(array_stream, finalizer)
 \item{finalizer}{A function that will be called with zero arguments.}
 }
 \value{
-\code{array_stream}, invisibly
+A newly allocated \code{array_stream} whose release callback will call
+the supplied finalizer.
 }
 \description{
 In some cases, R functions that return a \link[=as_nanoarrow_array_stream]{nanoarrow_array_stream}
@@ -26,8 +27,10 @@ environments will be garbage-collected when \code{nanoarrow:::preserved_empty()}
 is run.
 }
 \examples{
-stream <- basic_array_stream(list(1:5))
-array_stream_set_finalizer(stream, function() message("All done!"))
+stream <- array_stream_set_finalizer(
+  basic_array_stream(list(1:5)),
+  function() message("All done!")
+)
 stream$release()
 
 }

--- a/r/src/Makevars
+++ b/r/src/Makevars
@@ -1,0 +1,1 @@
+PKG_CPPFLAGS=-I../inst/include

--- a/r/src/Makevars
+++ b/r/src/Makevars
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 PKG_CPPFLAGS=-I../inst/include

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -39,7 +39,7 @@ void finalize_array_xptr(SEXP array_xptr) {
 }
 
 SEXP nanoarrow_c_array_init(SEXP schema_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   SEXP array_xptr = PROTECT(array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
 
@@ -266,7 +266,7 @@ SEXP nanoarrow_c_array_validate_after_modify(SEXP array_xptr, SEXP schema_xptr) 
   // This operation will invalidate array_xptr (but this is OK since we very
   // specifically just allocated it).
   struct ArrowArray* array = array_from_xptr(array_xptr);
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   struct ArrowError error;
 
   // Even though array was initialized using ArrowArrayInit(), it doesn't have
@@ -305,7 +305,7 @@ SEXP nanoarrow_c_array_set_schema(SEXP array_xptr, SEXP schema_xptr, SEXP valida
   if (validate) {
     // If adding a schema, validate the schema and the pair
     struct ArrowArray* array = array_from_xptr(array_xptr);
-    struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+    struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
     struct ArrowArrayView array_view;
     struct ArrowError error;

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -29,8 +29,9 @@
 
 SEXP nanoarrow_c_array_init(SEXP schema_xptr) {
   struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
+
   SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
-  struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
+  struct ArrowArray* array = nanoarrow_output_array_from_xptr(array_xptr);
 
   struct ArrowError error;
   int result = ArrowArrayInitFromSchema(array, schema, &error);
@@ -263,7 +264,8 @@ SEXP nanoarrow_c_array_validate_after_modify(SEXP array_xptr, SEXP schema_xptr) 
   // what the storage type would be when it was being constructed. Here we create
   // a version that does and move buffers recursively into it.
   SEXP array_dst_xptr = PROTECT(nanoarrow_array_owning_xptr());
-  struct ArrowArray* array_dst = (struct ArrowArray*)R_ExternalPtrAddr(array_dst_xptr);
+  struct ArrowArray* array_dst = nanoarrow_output_array_from_xptr(array_dst_xptr);
+
   int result = ArrowArrayInitFromSchema(array_dst, schema, &error);
   if (result != NANOARROW_OK) {
     Rf_error("ArrowArrayInitFromSchema(): %s", error.message);

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -27,20 +27,9 @@
 #include "schema.h"
 #include "util.h"
 
-void finalize_array_xptr(SEXP array_xptr) {
-  struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
-  if (array != NULL && array->release != NULL) {
-    array->release(array);
-  }
-
-  if (array != NULL) {
-    ArrowFree(array);
-  }
-}
-
 SEXP nanoarrow_c_array_init(SEXP schema_xptr) {
   struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
-  SEXP array_xptr = PROTECT(array_owning_xptr());
+  SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
 
   struct ArrowError error;
@@ -55,7 +44,7 @@ SEXP nanoarrow_c_array_init(SEXP schema_xptr) {
 }
 
 SEXP nanoarrow_c_array_set_length(SEXP array_xptr, SEXP length_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   if (TYPEOF(length_sexp) != REALSXP || Rf_length(length_sexp) != 1) {
     Rf_error("array$length must be double(1)");
   }
@@ -70,7 +59,7 @@ SEXP nanoarrow_c_array_set_length(SEXP array_xptr, SEXP length_sexp) {
 }
 
 SEXP nanoarrow_c_array_set_null_count(SEXP array_xptr, SEXP null_count_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   if (TYPEOF(null_count_sexp) != REALSXP || Rf_length(null_count_sexp) != 1) {
     Rf_error("array$null_count must be double(1)");
   }
@@ -85,7 +74,7 @@ SEXP nanoarrow_c_array_set_null_count(SEXP array_xptr, SEXP null_count_sexp) {
 }
 
 SEXP nanoarrow_c_array_set_offset(SEXP array_xptr, SEXP offset_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   if (TYPEOF(offset_sexp) != REALSXP || Rf_length(offset_sexp) != 1) {
     Rf_error("array$offset must be double(1)");
   }
@@ -100,7 +89,7 @@ SEXP nanoarrow_c_array_set_offset(SEXP array_xptr, SEXP offset_sexp) {
 }
 
 SEXP nanoarrow_c_array_set_buffers(SEXP array_xptr, SEXP buffers_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
 
   int64_t n_buffers = Rf_xlength(buffers_sexp);
   if (n_buffers > 3) {
@@ -163,7 +152,7 @@ static void free_all_children(struct ArrowArray* array) {
 }
 
 SEXP nanoarrow_c_array_set_children(SEXP array_xptr, SEXP children_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
 
   release_all_children(array);
 
@@ -185,7 +174,7 @@ SEXP nanoarrow_c_array_set_children(SEXP array_xptr, SEXP children_sexp) {
     // The arrays here will be moved, invalidating the arrays in the passed
     // list (the export step is handled in R)
     SEXP child_xptr = VECTOR_ELT(children_sexp, i);
-    struct ArrowArray* child = array_from_xptr(child_xptr);
+    struct ArrowArray* child = nanoarrow_array_from_xptr(child_xptr);
     ArrowArrayMove(child, array->children[i]);
   }
 
@@ -193,7 +182,7 @@ SEXP nanoarrow_c_array_set_children(SEXP array_xptr, SEXP children_sexp) {
 }
 
 SEXP nanoarrow_c_array_set_dictionary(SEXP array_xptr, SEXP dictionary_xptr) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
 
   // If there's already a dictionary, make sure we release it
   if (array->dictionary != NULL) {
@@ -215,7 +204,7 @@ SEXP nanoarrow_c_array_set_dictionary(SEXP array_xptr, SEXP dictionary_xptr) {
       }
     }
 
-    struct ArrowArray* dictionary = array_from_xptr(dictionary_xptr);
+    struct ArrowArray* dictionary = nanoarrow_array_from_xptr(dictionary_xptr);
     ArrowArrayMove(dictionary, array->dictionary);
   }
 
@@ -265,7 +254,7 @@ SEXP nanoarrow_c_array_validate_after_modify(SEXP array_xptr, SEXP schema_xptr) 
   // but after we send the array into the wild, that information is lost.
   // This operation will invalidate array_xptr (but this is OK since we very
   // specifically just allocated it).
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   struct ArrowError error;
 
@@ -273,7 +262,7 @@ SEXP nanoarrow_c_array_validate_after_modify(SEXP array_xptr, SEXP schema_xptr) 
   // all the information about storage types since it didn't necessarily know
   // what the storage type would be when it was being constructed. Here we create
   // a version that does and move buffers recursively into it.
-  SEXP array_dst_xptr = PROTECT(array_owning_xptr());
+  SEXP array_dst_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array_dst = (struct ArrowArray*)R_ExternalPtrAddr(array_dst_xptr);
   int result = ArrowArrayInitFromSchema(array_dst, schema, &error);
   if (result != NANOARROW_OK) {
@@ -304,7 +293,7 @@ SEXP nanoarrow_c_array_set_schema(SEXP array_xptr, SEXP schema_xptr, SEXP valida
   int validate = LOGICAL(validate_sexp)[0];
   if (validate) {
     // If adding a schema, validate the schema and the pair
-    struct ArrowArray* array = array_from_xptr(array_xptr);
+    struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
     struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
     struct ArrowArrayView array_view;
@@ -343,7 +332,7 @@ static SEXP borrow_array_xptr(struct ArrowArray* array, SEXP shelter) {
 }
 
 SEXP borrow_array_child_xptr(SEXP array_xptr, int64_t i) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   SEXP schema_xptr = R_ExternalPtrTag(array_xptr);
   SEXP child_xptr = PROTECT(borrow_array_xptr(array->children[i], array_xptr));
   if (schema_xptr != R_NilValue) {
@@ -391,7 +380,7 @@ static SEXP borrow_buffer(struct ArrowArrayView* array_view, int64_t i, SEXP she
 }
 
 SEXP nanoarrow_c_array_proxy(SEXP array_xptr, SEXP array_view_xptr, SEXP recursive_sexp) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   int recursive = LOGICAL(recursive_sexp)[0];
   struct ArrowArrayView* array_view = NULL;
   if (array_view_xptr != R_NilValue) {

--- a/r/src/array.h
+++ b/r/src/array.h
@@ -151,7 +151,7 @@ static inline SEXP array_ensure_independent(struct ArrowArray* array) {
 
   // Move array to the newly created owner
   struct ArrowArray* original_array =
-      (struct ArrowArray*)R_ExternalPtrAddr(original_array_xptr);
+      nanoarrow_output_array_from_xptr(original_array_xptr);
   memcpy(original_array, array, sizeof(struct ArrowArray));
   array->release = NULL;
 

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -144,7 +144,7 @@ static void finalize_wrapper_array_stream(struct ArrowArrayStream* array_stream)
     struct WrapperArrayStreamData* data =
         (struct WrapperArrayStreamData*)array_stream->private_data;
 
-    // Release the parent
+    // Run the parent array stream release callback
     data->parent_array_stream->release(data->parent_array_stream);
 
     // If safe to do so, attempt to do an eager evaluation of a release

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -41,7 +41,7 @@ static SEXP run_finalizer_error_handler(SEXP cond, void* hdata) {
   return R_NilValue;
 }
 
-void run_user_array_stream_finalizer(SEXP array_stream_xptr) {
+static void run_user_array_stream_finalizer(SEXP array_stream_xptr) {
   SEXP protected = PROTECT(R_ExternalPtrProtected(array_stream_xptr));
   R_SetExternalPtrProtected(array_stream_xptr, R_NilValue);
 
@@ -51,20 +51,6 @@ void run_user_array_stream_finalizer(SEXP array_stream_xptr) {
   }
 
   UNPROTECT(1);
-}
-
-void finalize_array_stream_xptr(SEXP array_stream_xptr) {
-  struct ArrowArrayStream* array_stream =
-      (struct ArrowArrayStream*)R_ExternalPtrAddr(array_stream_xptr);
-  if (array_stream != NULL && array_stream->release != NULL) {
-    array_stream->release(array_stream);
-  }
-
-  if (array_stream != NULL) {
-    ArrowFree(array_stream);
-  }
-
-  run_user_array_stream_finalizer(array_stream_xptr);
 }
 
 SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -70,7 +70,7 @@ void finalize_array_stream_xptr(SEXP array_stream_xptr) {
 SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
   struct ArrowArrayStream* array_stream = array_stream_from_xptr(array_stream_xptr);
 
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != 0) {
@@ -102,7 +102,7 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
   int validate = LOGICAL(validate_sexp)[0];
 
   // Schema needs a copy here because ArrowBasicArrayStreamInit() takes ownership
-  SEXP schema_copy_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_copy_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema_copy =
       (struct ArrowSchema*)R_ExternalPtrAddr(schema_copy_xptr);
   schema_export(schema_xptr, schema_copy);

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -85,7 +85,7 @@ SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
 SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr) {
   struct ArrowArrayStream* array_stream = array_stream_from_xptr(array_stream_xptr);
 
-  SEXP array_xptr = PROTECT(array_owning_xptr());
+  SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
   int result = ArrowArrayStreamGetNext(array_stream, array, NULL);
   if (result != NANOARROW_OK) {

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -58,7 +58,8 @@ SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
       nanoarrow_array_stream_from_xptr(array_stream_xptr);
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
+
   int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != 0) {
     Rf_error("array_stream->get_schema(): [%d] %s", result,
@@ -74,7 +75,8 @@ SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr) {
       nanoarrow_array_stream_from_xptr(array_stream_xptr);
 
   SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
-  struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
+  struct ArrowArray* array = nanoarrow_output_array_from_xptr(array_xptr);
+
   int result = ArrowArrayStreamGetNext(array_stream, array, NULL);
   if (result != NANOARROW_OK) {
     Rf_error("array_stream->get_next(): [%d] %s", result,
@@ -91,13 +93,12 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
 
   // Schema needs a copy here because ArrowBasicArrayStreamInit() takes ownership
   SEXP schema_copy_xptr = PROTECT(nanoarrow_schema_owning_xptr());
-  struct ArrowSchema* schema_copy =
-      (struct ArrowSchema*)R_ExternalPtrAddr(schema_copy_xptr);
+  struct ArrowSchema* schema_copy = nanoarrow_output_schema_from_xptr(schema_copy_xptr);
   schema_export(schema_xptr, schema_copy);
 
   SEXP array_stream_xptr = PROTECT(nanoarow_array_stream_owning_xptr());
   struct ArrowArrayStream* array_stream =
-      (struct ArrowArrayStream*)R_ExternalPtrAddr(array_stream_xptr);
+      nanoarrow_output_array_stream_from_xptr(array_stream_xptr);
 
   int64_t n_arrays = Rf_xlength(batches_sexp);
   if (ArrowBasicArrayStreamInit(array_stream, schema_copy, n_arrays) != NANOARROW_OK) {

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -68,7 +68,8 @@ void finalize_array_stream_xptr(SEXP array_stream_xptr) {
 }
 
 SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
-  struct ArrowArrayStream* array_stream = array_stream_from_xptr(array_stream_xptr);
+  struct ArrowArrayStream* array_stream =
+      nanoarrow_array_stream_from_xptr(array_stream_xptr);
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
@@ -83,7 +84,8 @@ SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
 }
 
 SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr) {
-  struct ArrowArrayStream* array_stream = array_stream_from_xptr(array_stream_xptr);
+  struct ArrowArrayStream* array_stream =
+      nanoarrow_array_stream_from_xptr(array_stream_xptr);
 
   SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
@@ -107,7 +109,7 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
       (struct ArrowSchema*)R_ExternalPtrAddr(schema_copy_xptr);
   schema_export(schema_xptr, schema_copy);
 
-  SEXP array_stream_xptr = PROTECT(array_stream_owning_xptr());
+  SEXP array_stream_xptr = PROTECT(nanoarow_array_stream_owning_xptr());
   struct ArrowArrayStream* array_stream =
       (struct ArrowArrayStream*)R_ExternalPtrAddr(array_stream_xptr);
 
@@ -198,7 +200,7 @@ static int wrapper_array_stream_get_next(struct ArrowArrayStream* array_stream,
 void array_stream_export(SEXP parent_array_stream_xptr,
                          struct ArrowArrayStream* array_stream_copy) {
   struct ArrowArrayStream* parent_array_stream =
-      array_stream_from_xptr(parent_array_stream_xptr);
+      nanoarrow_array_stream_from_xptr(parent_array_stream_xptr);
 
   // If there is no dependent object, don't bother with this wrapper
   SEXP dependent_sexp = R_ExternalPtrProtected(parent_array_stream_xptr);
@@ -209,7 +211,7 @@ void array_stream_export(SEXP parent_array_stream_xptr,
 
   // Allocate a new external pointer for an array stream (for consistency:
   // we always move an array stream when exporting)
-  SEXP parent_array_stream_xptr_new = PROTECT(array_stream_owning_xptr());
+  SEXP parent_array_stream_xptr_new = PROTECT(nanoarow_array_stream_owning_xptr());
   struct ArrowArrayStream* parent_array_stream_new =
       (struct ArrowArrayStream*)R_ExternalPtrAddr(parent_array_stream_xptr_new);
   ArrowArrayStreamMove(parent_array_stream, parent_array_stream_new);

--- a/r/src/array_stream.h
+++ b/r/src/array_stream.h
@@ -21,46 +21,11 @@
 #include <R.h>
 #include <Rinternals.h>
 
+#include <nanoarrow/r.h>
 #include "nanoarrow.h"
 #include "util.h"
 
 void run_user_array_stream_finalizer(SEXP array_stream_xptr);
-void finalize_array_stream_xptr(SEXP array_stream_xptr);
-
-// Returns the underlying struct ArrowSchema* from an external pointer,
-// checking and erroring for invalid objects, pointers, and arrays.
-static inline struct ArrowArrayStream* array_stream_from_xptr(SEXP array_stream_xptr) {
-  if (!Rf_inherits(array_stream_xptr, "nanoarrow_array_stream")) {
-    Rf_error("`array_stream` argument that is not a nanoarrow_array_stream()");
-  }
-
-  struct ArrowArrayStream* array_stream =
-      (struct ArrowArrayStream*)R_ExternalPtrAddr(array_stream_xptr);
-  if (array_stream == NULL) {
-    Rf_error("nanoarrow_array_stream() is an external pointer to NULL");
-  }
-
-  if (array_stream->release == NULL) {
-    Rf_error("nanoarrow_array_stream() has already been released");
-  }
-
-  return array_stream;
-}
-
-// Create an external pointer with the proper class and that will release any
-// non-null, non-released pointer when garbage collected.
-static inline SEXP array_stream_owning_xptr(void) {
-  struct ArrowArrayStream* array_stream =
-      (struct ArrowArrayStream*)ArrowMalloc(sizeof(struct ArrowArrayStream));
-  array_stream->release = NULL;
-
-  SEXP array_stream_xptr =
-      PROTECT(R_MakeExternalPtr(array_stream, R_NilValue, R_NilValue));
-  Rf_setAttrib(array_stream_xptr, R_ClassSymbol, nanoarrow_cls_array_stream);
-  R_RegisterCFinalizer(array_stream_xptr, &finalize_array_stream_xptr);
-  UNPROTECT(1);
-  return array_stream_xptr;
-}
 
 void array_stream_export(SEXP array_stream_xptr,
                          struct ArrowArrayStream* array_stream_copy);

--- a/r/src/array_stream.h
+++ b/r/src/array_stream.h
@@ -25,8 +25,6 @@
 #include "nanoarrow.h"
 #include "util.h"
 
-void run_user_array_stream_finalizer(SEXP array_stream_xptr);
-
 void array_stream_export(SEXP array_stream_xptr,
                          struct ArrowArrayStream* array_stream_copy);
 

--- a/r/src/array_view.c
+++ b/r/src/array_view.c
@@ -35,7 +35,7 @@ static void finalize_array_view_xptr(SEXP array_view_xptr) {
 }
 
 SEXP nanoarrow_c_array_view(SEXP array_xptr, SEXP schema_xptr) {
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowError error;

--- a/r/src/array_view.c
+++ b/r/src/array_view.c
@@ -36,7 +36,7 @@ static void finalize_array_view_xptr(SEXP array_view_xptr) {
 
 SEXP nanoarrow_c_array_view(SEXP array_xptr, SEXP schema_xptr) {
   struct ArrowArray* array = array_from_xptr(array_xptr);
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowError error;
   ArrowErrorSet(&error, "");

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -37,7 +37,7 @@ static void call_as_nanoarrow_array(SEXP x_sexp, struct ArrowArray* array,
   // In many cases we can skip the array_export() step (which adds some complexity
   // and an additional R object to the mix)
   if (Rf_inherits(result, "nanoarrow_array_dont_export")) {
-    struct ArrowArray* array_result = array_from_xptr(result);
+    struct ArrowArray* array_result = nanoarrow_array_from_xptr(result);
     ArrowArrayMove(array_result, array);
   } else {
     array_export(result, array);
@@ -551,7 +551,7 @@ static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_
 }
 
 SEXP nanoarrow_c_as_array_default(SEXP x_sexp, SEXP schema_xptr) {
-  SEXP array_xptr = PROTECT(array_owning_xptr());
+  SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
   struct ArrowError error;
 

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -552,7 +552,7 @@ static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_
 
 SEXP nanoarrow_c_as_array_default(SEXP x_sexp, SEXP schema_xptr) {
   SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
-  struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
+  struct ArrowArray* array = nanoarrow_output_array_from_xptr(array_xptr);
   struct ArrowError error;
 
   as_array_default(x_sexp, array, schema_xptr, &error);

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -380,7 +380,7 @@ static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_
 static void as_array_data_frame(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr,
                                 struct ArrowSchemaView* schema_view,
                                 struct ArrowError* error) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   switch (schema_view->type) {
     case NANOARROW_TYPE_SPARSE_UNION:
@@ -504,7 +504,7 @@ static void as_array_list(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xpt
 
 static void as_array_default(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr,
                              struct ArrowError* error) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowSchemaView schema_view;
   int result = ArrowSchemaViewInit(&schema_view, schema, error);

--- a/r/src/convert.c
+++ b/r/src/convert.c
@@ -174,7 +174,7 @@ static void set_converter_list_of(SEXP converter_xptr, struct RConverter* conver
 static int set_converter_children_schema(SEXP converter_xptr, SEXP schema_xptr) {
   struct RConverter* converter = (struct RConverter*)R_ExternalPtrAddr(converter_xptr);
   SEXP converter_shelter = R_ExternalPtrProtected(converter_xptr);
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   if (schema->n_children != converter->n_children) {
     ArrowErrorSet(&converter->error,
@@ -286,7 +286,7 @@ SEXP nanoarrow_converter_from_ptype(SEXP ptype) {
 int nanoarrow_converter_set_schema(SEXP converter_xptr, SEXP schema_xptr) {
   struct RConverter* converter = (struct RConverter*)R_ExternalPtrAddr(converter_xptr);
   SEXP converter_shelter = R_ExternalPtrProtected(converter_xptr);
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   NANOARROW_RETURN_NOT_OK(
       ArrowSchemaViewInit(&converter->schema_view, schema, &converter->error));
 

--- a/r/src/convert.c
+++ b/r/src/convert.c
@@ -201,7 +201,7 @@ static int set_converter_children_schema(SEXP converter_xptr, SEXP schema_xptr) 
 static int set_converter_children_array(SEXP converter_xptr, SEXP array_xptr) {
   struct RConverter* converter = (struct RConverter*)R_ExternalPtrAddr(converter_xptr);
   SEXP converter_shelter = R_ExternalPtrProtected(converter_xptr);
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
 
   if (array->n_children != converter->n_children) {
     ArrowErrorSet(&converter->error,
@@ -310,7 +310,7 @@ int nanoarrow_converter_set_schema(SEXP converter_xptr, SEXP schema_xptr) {
 int nanoarrow_converter_set_array(SEXP converter_xptr, SEXP array_xptr) {
   struct RConverter* converter = (struct RConverter*)R_ExternalPtrAddr(converter_xptr);
   SEXP converter_shelter = R_ExternalPtrProtected(converter_xptr);
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   NANOARROW_RETURN_NOT_OK(
       ArrowArrayViewSetArray(&converter->array_view, array, &converter->error));
   SET_VECTOR_ELT(converter_shelter, 2, array_xptr);

--- a/r/src/convert_array.c
+++ b/r/src/convert_array.c
@@ -170,7 +170,7 @@ static SEXP convert_array_data_frame(SEXP array_xptr, SEXP ptype_sexp) {
     }
   }
 
-  struct ArrowArray* array = array_from_xptr(array_xptr);
+  struct ArrowArray* array = nanoarrow_array_from_xptr(array_xptr);
   R_xlen_t n_col = array->n_children;
   SEXP result = PROTECT(Rf_allocVector(VECSXP, n_col));
 

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -32,7 +32,7 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
   double size = REAL(size_sexp)[0];
   double n = REAL(n_sexp)[0];
 
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != NANOARROW_OK) {

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -34,7 +34,8 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
   double n = REAL(n_sexp)[0];
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
+
   int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != NANOARROW_OK) {
     Rf_error("ArrowArrayStream::get_schema(): %s",
@@ -51,7 +52,7 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
   }
 
   SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
-  struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
+  struct ArrowArray* array = nanoarrow_output_array_from_xptr(array_xptr);
 
   int64_t n_batches = 0;
   int64_t n_materialized = 0;

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -49,7 +49,7 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
     nanoarrow_converter_stop(converter_xptr);
   }
 
-  SEXP array_xptr = PROTECT(array_owning_xptr());
+  SEXP array_xptr = PROTECT(nanoarrow_array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
 
   int64_t n_batches = 0;

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -28,7 +28,7 @@
 
 SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
                                       SEXP size_sexp, SEXP n_sexp) {
-  struct ArrowArrayStream* array_stream = array_stream_from_xptr(array_stream_xptr);
+  struct ArrowArrayStream* array_stream = nanoarrow_array_stream_from_xptr(array_stream_xptr);
   double size = REAL(size_sexp)[0];
   double n = REAL(n_sexp)[0];
 

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -28,7 +28,8 @@
 
 SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
                                       SEXP size_sexp, SEXP n_sexp) {
-  struct ArrowArrayStream* array_stream = nanoarrow_array_stream_from_xptr(array_stream_xptr);
+  struct ArrowArrayStream* array_stream =
+      nanoarrow_array_stream_from_xptr(array_stream_xptr);
   double size = REAL(size_sexp)[0];
   double n = REAL(n_sexp)[0];
 

--- a/r/src/infer_ptype.c
+++ b/r/src/infer_ptype.c
@@ -70,7 +70,7 @@ enum VectorType nanoarrow_infer_vector_type(enum ArrowType type) {
 
 // The same as the above, but from a nanoarrow_schema()
 enum VectorType nanoarrow_infer_vector_type_schema(SEXP schema_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
@@ -104,7 +104,7 @@ static SEXP call_infer_ptype_other(SEXP schema_xptr) {
 SEXP nanoarrow_c_infer_ptype(SEXP schema_xptr);
 
 static SEXP infer_ptype_data_frame(SEXP schema_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   SEXP result = PROTECT(Rf_allocVector(VECSXP, schema->n_children));
   SEXP result_names = PROTECT(Rf_allocVector(STRSXP, schema->n_children));
 

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -204,7 +204,7 @@ SEXP nanoarrow_c_pointer_move(SEXP ptr_src, SEXP ptr_dst) {
 // keep all the object dependencies alive and/or risk moving a dependency
 // of some other R object.
 SEXP nanoarrow_c_export_schema(SEXP schema_xptr, SEXP ptr_dst) {
-  struct ArrowSchema* obj_src = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* obj_src = nanoarrow_schema_from_xptr(schema_xptr);
   SEXP xptr_dst = PROTECT(nanoarrow_c_pointer(ptr_dst));
 
   struct ArrowSchema* obj_dst = (struct ArrowSchema*)R_ExternalPtrAddr(xptr_dst);

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -26,7 +26,7 @@
 // More reliable way to stringify intptr_t on Windows using C++
 void intptr_as_string(intptr_t ptr_int, char* buf);
 
-SEXP nanoarrow_c_allocate_schema(void) { return schema_owning_xptr(); }
+SEXP nanoarrow_c_allocate_schema(void) { return nanoarrow_schema_owning_xptr(); }
 
 SEXP nanoarrow_c_allocate_array(void) { return array_owning_xptr(); }
 

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -30,7 +30,9 @@ SEXP nanoarrow_c_allocate_schema(void) { return nanoarrow_schema_owning_xptr(); 
 
 SEXP nanoarrow_c_allocate_array(void) { return nanoarrow_array_owning_xptr(); }
 
-SEXP nanoarrow_c_allocate_array_stream(void) { return nanoarow_array_stream_owning_xptr(); }
+SEXP nanoarrow_c_allocate_array_stream(void) {
+  return nanoarow_array_stream_owning_xptr();
+}
 
 SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
   if (TYPEOF(obj_sexp) == EXTPTRSXP) {
@@ -111,7 +113,6 @@ SEXP nanoarrow_c_pointer_release(SEXP ptr) {
     if (obj != NULL && obj->release != NULL) {
       obj->release(obj);
       obj->release = NULL;
-      run_user_array_stream_finalizer(ptr);
     }
   } else {
     Rf_error(

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -30,7 +30,7 @@ SEXP nanoarrow_c_allocate_schema(void) { return nanoarrow_schema_owning_xptr(); 
 
 SEXP nanoarrow_c_allocate_array(void) { return nanoarrow_array_owning_xptr(); }
 
-SEXP nanoarrow_c_allocate_array_stream(void) { return array_stream_owning_xptr(); }
+SEXP nanoarrow_c_allocate_array_stream(void) { return nanoarow_array_stream_owning_xptr(); }
 
 SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
   if (TYPEOF(obj_sexp) == EXTPTRSXP) {

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -28,7 +28,7 @@ void intptr_as_string(intptr_t ptr_int, char* buf);
 
 SEXP nanoarrow_c_allocate_schema(void) { return nanoarrow_schema_owning_xptr(); }
 
-SEXP nanoarrow_c_allocate_array(void) { return array_owning_xptr(); }
+SEXP nanoarrow_c_allocate_array(void) { return nanoarrow_array_owning_xptr(); }
 
 SEXP nanoarrow_c_allocate_array_stream(void) { return array_stream_owning_xptr(); }
 

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -23,20 +23,9 @@
 #include "schema.h"
 #include "util.h"
 
-void finalize_schema_xptr(SEXP schema_xptr) {
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
-  if (schema != NULL && schema->release != NULL) {
-    schema->release(schema);
-  }
-
-  if (schema != NULL) {
-    ArrowFree(schema);
-  }
-}
-
 SEXP nanoarrow_c_schema_init(SEXP type_id_sexp, SEXP nullable_sexp) {
   int type_id = INTEGER(type_id_sexp)[0];
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
 
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   int result = ArrowSchemaInitFromType(schema, type_id);
@@ -69,7 +58,7 @@ SEXP nanoarrow_c_schema_init_date_time(SEXP type_id_sexp, SEXP time_unit_sexp,
     timezone = NULL;
   }
 
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
 
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);
@@ -97,7 +86,7 @@ SEXP nanoarrow_c_schema_init_decimal(SEXP type_id_sexp, SEXP precision_sexp,
   int precision = INTEGER(precision_sexp)[0];
   int scale = INTEGER(scale_sexp)[0];
 
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
 
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);
@@ -124,7 +113,7 @@ SEXP nanoarrow_c_schema_init_fixed_size(SEXP type_id_sexp, SEXP fixed_size_sexp,
   int type_id = INTEGER(type_id_sexp)[0];
   int fixed_size = INTEGER(fixed_size_sexp)[0];
 
-  SEXP schema_xptr = PROTECT(schema_owning_xptr());
+  SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
 
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -182,12 +182,12 @@ static SEXP borrow_schema_xptr(struct ArrowSchema* schema, SEXP shelter) {
 }
 
 SEXP borrow_schema_child_xptr(SEXP schema_xptr, int64_t i) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
   return borrow_schema_xptr(schema->children[i], schema_xptr);
 }
 
 SEXP nanoarrow_c_schema_to_list(SEXP schema_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   const char* names[] = {"format",   "name",       "metadata", "flags",
                          "children", "dictionary", ""};
@@ -256,7 +256,7 @@ static SEXP mkStringView(struct ArrowStringView* view) {
 }
 
 SEXP nanoarrow_c_schema_parse(SEXP schema_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
@@ -356,7 +356,7 @@ SEXP nanoarrow_c_schema_format(SEXP schema_xptr, SEXP recursive_sexp) {
 }
 
 SEXP nanoarrow_c_schema_set_format(SEXP schema_mut_xptr, SEXP format_sexp) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
 
   if (TYPEOF(format_sexp) != STRSXP || Rf_length(format_sexp) != 1) {
     Rf_error("schema$format must be character(1)");
@@ -371,7 +371,7 @@ SEXP nanoarrow_c_schema_set_format(SEXP schema_mut_xptr, SEXP format_sexp) {
 }
 
 SEXP nanoarrow_c_schema_set_name(SEXP schema_mut_xptr, SEXP name_sexp) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
   int result;
 
   if (name_sexp == R_NilValue) {
@@ -414,7 +414,7 @@ static SEXP buffer_owning_xptr(void) {
 }
 
 SEXP nanoarrow_c_schema_set_metadata(SEXP schema_mut_xptr, SEXP metadata_sexp) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
   int result;
 
   if (Rf_xlength(metadata_sexp) == 0) {
@@ -492,7 +492,7 @@ SEXP nanoarrow_c_schema_set_metadata(SEXP schema_mut_xptr, SEXP metadata_sexp) {
 }
 
 SEXP nanoarrow_c_schema_set_flags(SEXP schema_mut_xptr, SEXP flags_sexp) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
 
   if (TYPEOF(flags_sexp) != INTSXP || Rf_length(flags_sexp) != 1) {
     Rf_error("schema$flags must be integer(1)");
@@ -529,7 +529,7 @@ static void free_all_children(struct ArrowSchema* schema) {
 }
 
 SEXP nanoarrow_c_schema_set_children(SEXP schema_mut_xptr, SEXP children_sexp) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
 
   release_all_children(schema);
 
@@ -556,7 +556,7 @@ SEXP nanoarrow_c_schema_set_children(SEXP schema_mut_xptr, SEXP children_sexp) {
   SEXP children_names = PROTECT(Rf_getAttrib(children_sexp, R_NamesSymbol));
 
   for (int64_t i = 0; i < schema->n_children; i++) {
-    struct ArrowSchema* child = schema_from_xptr(VECTOR_ELT(children_sexp, i));
+    struct ArrowSchema* child = nanoarrow_schema_from_xptr(VECTOR_ELT(children_sexp, i));
     result = ArrowSchemaDeepCopy(child, schema->children[i]);
     if (result != NANOARROW_OK) {
       Rf_error("Error copying new_values$children[[%ld]]", (long)i);
@@ -588,7 +588,7 @@ SEXP nanoarrow_c_schema_set_children(SEXP schema_mut_xptr, SEXP children_sexp) {
 }
 
 SEXP nanoarrow_c_schema_set_dictionary(SEXP schema_mut_xptr, SEXP dictionary_xptr) {
-  struct ArrowSchema* schema = schema_from_xptr(schema_mut_xptr);
+  struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_mut_xptr);
 
   // If there's already a dictionary, make sure we release it
   if (schema->dictionary != NULL) {
@@ -612,7 +612,7 @@ SEXP nanoarrow_c_schema_set_dictionary(SEXP schema_mut_xptr, SEXP dictionary_xpt
       }
     }
 
-    struct ArrowSchema* dictionary = schema_from_xptr(dictionary_xptr);
+    struct ArrowSchema* dictionary = nanoarrow_schema_from_xptr(dictionary_xptr);
     result = ArrowSchemaDeepCopy(dictionary, schema->dictionary);
     if (result != NANOARROW_OK) {
       Rf_error("Error copying schema$dictionary");

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -26,8 +26,8 @@
 SEXP nanoarrow_c_schema_init(SEXP type_id_sexp, SEXP nullable_sexp) {
   int type_id = INTEGER(type_id_sexp)[0];
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
 
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   int result = ArrowSchemaInitFromType(schema, type_id);
   if (result != NANOARROW_OK) {
     Rf_error("ArrowSchemaInitFromType() failed");
@@ -59,8 +59,8 @@ SEXP nanoarrow_c_schema_init_date_time(SEXP type_id_sexp, SEXP time_unit_sexp,
   }
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
 
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);
   int result = ArrowSchemaSetTypeDateTime(schema, type_id, time_unit, timezone);
   if (result != NANOARROW_OK) {
@@ -87,8 +87,8 @@ SEXP nanoarrow_c_schema_init_decimal(SEXP type_id_sexp, SEXP precision_sexp,
   int scale = INTEGER(scale_sexp)[0];
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
 
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);
   int result = ArrowSchemaSetTypeDecimal(schema, type_id, precision, scale);
   if (result != NANOARROW_OK) {
@@ -114,8 +114,8 @@ SEXP nanoarrow_c_schema_init_fixed_size(SEXP type_id_sexp, SEXP fixed_size_sexp,
   int fixed_size = INTEGER(fixed_size_sexp)[0];
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
+  struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);
 
-  struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
   ArrowSchemaInit(schema);
   int result = ArrowSchemaSetTypeFixedSize(schema, type_id, fixed_size);
   if (result != NANOARROW_OK) {

--- a/r/src/schema.h
+++ b/r/src/schema.h
@@ -25,8 +25,6 @@
 #include "nanoarrow.h"
 #include "util.h"
 
-void finalize_schema_xptr(SEXP schema_xptr);
-
 // Returns an external pointer to a schema child. The returned pointer will keep its
 // parent alive: this is typically what you want when printing or performing a conversion,
 // where the borrowed external pointer is ephemeral.
@@ -41,24 +39,6 @@ static inline struct ArrowSchema* nullable_schema_from_xptr(SEXP schema_xptr) {
   } else {
     return nanoarrow_schema_from_xptr(schema_xptr);
   }
-}
-
-// Create an external pointer with the proper class and that will release any
-// non-null, non-released pointer when garbage collected.
-static inline SEXP schema_owning_xptr(void) {
-  struct ArrowSchema* schema =
-      (struct ArrowSchema*)ArrowMalloc(sizeof(struct ArrowSchema));
-  if (schema == NULL) {
-    Rf_error("Failed to allocate ArrowSchema");
-  }
-
-  schema->release = NULL;
-
-  SEXP schema_xptr = PROTECT(R_MakeExternalPtr(schema, R_NilValue, R_NilValue));
-  Rf_setAttrib(schema_xptr, R_ClassSymbol, nanoarrow_cls_schema);
-  R_RegisterCFinalizer(schema_xptr, &finalize_schema_xptr);
-  UNPROTECT(1);
-  return schema_xptr;
 }
 
 static inline void schema_export(SEXP schema_xptr, struct ArrowSchema* schema_copy) {

--- a/r/src/schema.h
+++ b/r/src/schema.h
@@ -21,9 +21,9 @@
 #include <R.h>
 #include <Rinternals.h>
 
+#include <nanoarrow/r.h>
 #include "nanoarrow.h"
 #include "util.h"
-#include <nanoarrow/r.h>
 
 void finalize_schema_xptr(SEXP schema_xptr);
 

--- a/r/tests/testthat/test-array-stream.R
+++ b/r/tests/testthat/test-array-stream.R
@@ -195,14 +195,14 @@ test_that("nanoarrow_array_stream get_next() with schema = NULL", {
 
 test_that("User array stream finalizers are run on explicit release", {
   stream <- basic_array_stream(list(1:5))
-  array_stream_set_finalizer(stream, function() cat("All done!"))
+  stream <- array_stream_set_finalizer(stream, function() cat("All done!"))
   expect_output(stream$release(), "All done!")
   expect_silent(stream$release())
 })
 
 test_that("User array stream finalizers are run on explicit release even when moved", {
   stream <- basic_array_stream(list(1:5))
-  array_stream_set_finalizer(stream, function() cat("All done!"))
+  stream <- array_stream_set_finalizer(stream, function() cat("All done!"))
 
   stream2 <- nanoarrow_allocate_array_stream()
   nanoarrow_pointer_move(stream, stream2)
@@ -214,7 +214,7 @@ test_that("User array stream finalizers are run on explicit release even when mo
 
 test_that("User array stream finalizers are run on explicit release even when exported", {
   stream <- basic_array_stream(list(1:5))
-  array_stream_set_finalizer(stream, function() cat("All done!"))
+  stream <- array_stream_set_finalizer(stream, function() cat("All done!"))
 
   stream2 <- nanoarrow_allocate_array_stream()
   nanoarrow_pointer_export(stream, stream2)
@@ -226,7 +226,7 @@ test_that("User array stream finalizers are run on explicit release even when ex
 
 test_that("Errors from user array stream finalizer are ignored", {
   stream <- basic_array_stream(list(1:5))
-  array_stream_set_finalizer(stream, function() stop("Error that will be ignored"))
+  stream <- array_stream_set_finalizer(stream, function() stop("Error that will be ignored"))
   # Because this comes from REprintf(), it's not a message and not "output"
   # according to testthat, so we use capture.output()
   expect_identical(


### PR DESCRIPTION
In developing geoarrow, an R extension that imports/exports a number of Arrow C data structures wrapped by nanoarrow S3 objects, it has become apparent that the sanitize and allocate operations are non-trivial and basically have to be copied in every package that wants to import/export nanoarrow things. @eddelbuettel has run up against some valid use-cases as well! https://github.com/eddelbuettel/linesplitter/issues/1 , https://github.com/apache/arrow-nanoarrow/issues/187

This PR makes the definition of how Arrow C Data interface objects are encoded as R external pointers available as a public header (such that downstream packages can `LinkingTo: nanoarrow` and `#include <nanoarrow/r.h>`. I think the initial target will just be allocate an owning external pointer and sanitize an input SEXP.

@eddelbuettel Are there any other operations that are blocking any of your projects that would be must-haves in this header?

(I know it's missing array_stream...I forgot about the ability to supply R finalizers and so it's a slightly more complicated change)