### PR TITLE
fix(r): Ensure wrapper array stream eagerly releases the wrapped array stream

### DIFF
--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -164,6 +164,9 @@ static void finalize_wrapper_array_stream(struct ArrowArrayStream* array_stream)
     struct WrapperArrayStreamData* data =
         (struct WrapperArrayStreamData*)array_stream->private_data;
 
+    // Release the parent
+    data->parent_array_stream->release(data->parent_array_stream);
+
     // If safe to do so, attempt to do an eager evaluation of a release
     // callback that may have been registered. If it is not safe to do so,
     // garbage collection will run any finalizers that have been set


### PR DESCRIPTION
Uncovered when investigating https://github.com/apache/arrow-adbc/issues/1348 and https://github.com/apache/arrow-adbc/pull/1334 . Before, the release callback was getting called by the garbage collector (so no memory leak was reported); however, the order of the array stream finalizer and the user-supplied R finalizer was non-deterministic based on when the garbage collector ran.