### PR TITLE
chore(extensions/nanoarrow_ipc): Add golden file testing JSON tests to existing arrow-testing tests

### DIFF
--- a/ci/scripts/coverage.sh
+++ b/ci/scripts/coverage.sh
@@ -67,7 +67,7 @@ function main() {
     cmake "${TARGET_NANOARROW_DIR}" \
         -DNANOARROW_BUILD_TESTS=ON -DNANOARROW_CODE_COVERAGE=ON
     cmake --build .
-    ctest .
+    CTEST_OUTPUT_ON_FAILURE=1 ctest .
 
     popd
 
@@ -79,7 +79,7 @@ function main() {
     cmake "${TARGET_NANOARROW_DIR}/extensions/nanoarrow_ipc" \
         -DNANOARROW_IPC_BUILD_TESTS=ON -DNANOARROW_IPC_CODE_COVERAGE=ON
     cmake --build .
-    ctest .
+    CTEST_OUTPUT_ON_FAILURE=1 ctest .
 
     popd
 
@@ -93,7 +93,7 @@ function main() {
     cmake "${TARGET_NANOARROW_DIR}/extensions/nanoarrow_device" \
         -DNANOARROW_DEVICE_BUILD_TESTS=ON -DNANOARROW_DEVICE_CODE_COVERAGE=ON
     cmake --build .
-    ctest .
+    CTEST_OUTPUT_ON_FAILURE=1 ctest .
 
     popd
 

--- a/extensions/nanoarrow_ipc/CMakeLists.txt
+++ b/extensions/nanoarrow_ipc/CMakeLists.txt
@@ -205,6 +205,16 @@ if(NANOARROW_IPC_BUILD_TESTS)
 
   fetchcontent_makeavailable(googletest)
 
+  # JSON library for integration testing
+  # Also used by some versions of Arrow, so check if this is already available
+  if(NOT TARGET nlohmann_json::nlohmann_json)
+    fetchcontent_declare(nlohmann_json
+                         URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
+                         URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
+    )
+    fetchcontent_makeavailable(nlohmann_json)
+  endif()
+
   enable_testing()
 
   add_executable(nanoarrow_ipc_decoder_test src/nanoarrow/nanoarrow_ipc_decoder_test.cc)
@@ -240,6 +250,7 @@ if(NANOARROW_IPC_BUILD_TESTS)
                         nanoarrow_ipc
                         nanoarrow
                         ${NANOARROW_IPC_ARROW_TARGET}
+                        nlohmann_json
                         gtest_main
                         ipc_coverage_config)
   target_link_libraries(nanoarrow_ipc_hpp_test

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
@@ -269,7 +269,7 @@ class TestFile {
 
     nanoarrow::UniqueArrayStream json_stream;
     int result = GetArrowArrayStreamCheckJSON(dir_prefix, json_stream.get(), &error);
-    // Skip instead of faile for ENOTSUP
+    // Skip instead of fail for ENOTSUP
     if (result == ENOTSUP) {
       GTEST_SKIP() << "File contains type(s) not supported by the testing JSON reader: "
                    << error.message;

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
@@ -337,13 +337,15 @@ std::ostream& operator<<(std::ostream& os, const TestFile& obj) {
 
 // Start building the arrow-testing path or skip if the environment
 // variable was not set
-void InitArrowTestingPath(std::ostream& builder) {
+ArrowErrorCode InitArrowTestingPath(std::ostream& builder, ArrowError* error) {
   const char* testing_dir = getenv("NANOARROW_ARROW_TESTING_DIR");
   if (testing_dir == nullptr || strlen(testing_dir) == 0) {
-    GTEST_SKIP() << "NANOARROW_ARROW_TESTING_DIR environment variable not set";
+    ArrowErrorSet(error, "NANOARROW_ARROW_TESTING_DIR environment variable not set");
+    return ENOENT;
   }
 
   builder << testing_dir;
+  return NANOARROW_OK;
 }
 
 class TestFileFixture : public ::testing::TestWithParam<TestFile> {
@@ -353,7 +355,11 @@ class TestFileFixture : public ::testing::TestWithParam<TestFile> {
 
 TEST_P(TestFileFixture, NanoarrowIpcTestFileNativeEndian) {
   std::stringstream dir_builder;
-  InitArrowTestingPath(dir_builder);
+  ArrowError error;
+  ArrowErrorInit(&error);
+  if (InitArrowTestingPath(dir_builder, &error) != NANOARROW_OK) {
+    GTEST_SKIP() << error.message;
+  }
 
 #if defined(__BIG_ENDIAN__)
   dir_builder << "/data/arrow-ipc-stream/integration/1.0.0-bigendian";
@@ -366,7 +372,11 @@ TEST_P(TestFileFixture, NanoarrowIpcTestFileNativeEndian) {
 
 TEST_P(TestFileFixture, NanoarrowIpcTestFileSwapEndian) {
   std::stringstream dir_builder;
-  InitArrowTestingPath(dir_builder);
+  ArrowError error;
+  ArrowErrorInit(&error);
+  if (InitArrowTestingPath(dir_builder, &error) != NANOARROW_OK) {
+    GTEST_SKIP() << error.message;
+  }
 
 #if defined(__BIG_ENDIAN__)
   dir_builder << "/data/arrow-ipc-stream/integration/1.0.0-littleendian";
@@ -379,7 +389,12 @@ TEST_P(TestFileFixture, NanoarrowIpcTestFileSwapEndian) {
 
 TEST_P(TestFileFixture, NanoarrowIpcTestFileCheckJSON) {
   std::stringstream dir_builder;
-  InitArrowTestingPath(dir_builder);
+  ArrowError error;
+  ArrowErrorInit(&error);
+  if (InitArrowTestingPath(dir_builder, &error) != NANOARROW_OK) {
+    GTEST_SKIP() << error.message;
+  }
+
   dir_builder << "/data/arrow-ipc-stream/integration/1.0.0-littleendian";
 
   TestFile param = GetParam();


### PR DESCRIPTION
This PR adds a "golden file" integration test to the existing suite of tests that read files from the arrow-testing repo. The existing test read the IPC stream file using nanoarrow's IPC reader and Arrow C++'s IPC reader and used Arrow C++ to check equality. The added test is more similar to the golden file test described in the integration testing section of the documentation (read IPC, read testing JSON, use nanoarrow testing utils to check equality). This involved some refactoring to re-use the infrastructure properly for both types of tests.

Originally I wrote a dedicated executable and some bash to do these kinds of tests ( https://gist.github.com/paleolimbot/ec2a2067198f0de1901c107c783d3b26 ); however, integrating it into the existing tests is cleaner and makes it easier to run them with valgrind.