### PR TITLE
refactor: Improve syntax for implementing `ArrowArrayStream` from C++

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.hpp
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc.hpp
@@ -15,40 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "nanoarrow_ipc.h"
-
 #ifndef NANOARROW_IPC_HPP_INCLUDED
 #define NANOARROW_IPC_HPP_INCLUDED
+
+#include "nanoarrow.hpp"
+#include "nanoarrow_ipc.h"
 
 namespace nanoarrow {
 
 namespace internal {
 
-static inline void init_pointer(struct ArrowIpcDecoder* data) {
+template <>
+inline void init_pointer(struct ArrowIpcDecoder* data) {
   data->private_data = nullptr;
 }
 
-static inline void move_pointer(struct ArrowIpcDecoder* src,
-                                struct ArrowIpcDecoder* dst) {
+template <>
+inline void move_pointer(struct ArrowIpcDecoder* src, struct ArrowIpcDecoder* dst) {
   memcpy(dst, src, sizeof(struct ArrowIpcDecoder));
   src->private_data = nullptr;
 }
 
-static inline void release_pointer(struct ArrowIpcDecoder* data) {
+template <>
+inline void release_pointer(struct ArrowIpcDecoder* data) {
   ArrowIpcDecoderReset(data);
 }
 
-static inline void init_pointer(struct ArrowIpcInputStream* data) {
+template <>
+inline void init_pointer(struct ArrowIpcInputStream* data) {
   data->release = nullptr;
 }
 
-static inline void move_pointer(struct ArrowIpcInputStream* src,
-                                struct ArrowIpcInputStream* dst) {
+template <>
+inline void move_pointer(struct ArrowIpcInputStream* src,
+                         struct ArrowIpcInputStream* dst) {
   memcpy(dst, src, sizeof(struct ArrowIpcInputStream));
   src->release = nullptr;
 }
 
-static inline void release_pointer(struct ArrowIpcInputStream* data) {
+template <>
+inline void release_pointer(struct ArrowIpcInputStream* data) {
   if (data->release != nullptr) {
     data->release(data);
   }
@@ -56,8 +62,6 @@ static inline void release_pointer(struct ArrowIpcInputStream* data) {
 
 }  // namespace internal
 }  // namespace nanoarrow
-
-#include "nanoarrow.hpp"
 
 namespace nanoarrow {
 

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -326,6 +326,8 @@ using UniqueArrayView = internal::Unique<struct ArrowArrayView>;
 template <typename T>
 class ArrayStreamFactory {
  public:
+
+  /// \brief Take ownership of instance and populate callbacks of out
   static void InitArrayStream(T* instance, struct ArrowArrayStream* out) {
     out->get_schema = &get_schema_wrapper;
     out->get_next = &get_next_wrapper;

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -88,70 +88,108 @@ namespace internal {
 ///
 /// @{
 
-static inline void init_pointer(struct ArrowSchema* data) { data->release = nullptr; }
+template <typename T>
+static inline void init_pointer(T* data);
 
-static inline void move_pointer(struct ArrowSchema* src, struct ArrowSchema* dst) {
-  ArrowSchemaMove(src, dst);
-}
+template <typename T>
+static inline void move_pointer(T* src, T* dst);
 
-static inline void release_pointer(struct ArrowSchema* data) {
-  if (data->release != nullptr) {
-    data->release(data);
-  }
-}
+template <typename T>
+static inline void release_pointer(T* data);
 
-static inline void init_pointer(struct ArrowArray* data) { data->release = nullptr; }
-
-static inline void move_pointer(struct ArrowArray* src, struct ArrowArray* dst) {
-  ArrowArrayMove(src, dst);
-}
-
-static inline void release_pointer(struct ArrowArray* data) {
-  if (data->release != nullptr) {
-    data->release(data);
-  }
-}
-
-static inline void init_pointer(struct ArrowArrayStream* data) {
+template <>
+inline void init_pointer(struct ArrowSchema* data) {
   data->release = nullptr;
 }
 
-static inline void move_pointer(struct ArrowArrayStream* src,
-                                struct ArrowArrayStream* dst) {
-  ArrowArrayStreamMove(src, dst);
+template <>
+inline void move_pointer(struct ArrowSchema* src, struct ArrowSchema* dst) {
+  ArrowSchemaMove(src, dst);
 }
 
-static inline void release_pointer(ArrowArrayStream* data) {
+template <>
+inline void release_pointer(struct ArrowSchema* data) {
   if (data->release != nullptr) {
     data->release(data);
   }
 }
 
-static inline void init_pointer(struct ArrowBuffer* data) { ArrowBufferInit(data); }
+template <>
+inline void init_pointer(struct ArrowArray* data) {
+  data->release = nullptr;
+}
 
-static inline void move_pointer(struct ArrowBuffer* src, struct ArrowBuffer* dst) {
+template <>
+inline void move_pointer(struct ArrowArray* src, struct ArrowArray* dst) {
+  ArrowArrayMove(src, dst);
+}
+
+template <>
+inline void release_pointer(struct ArrowArray* data) {
+  if (data->release != nullptr) {
+    data->release(data);
+  }
+}
+
+template <>
+inline void init_pointer(struct ArrowArrayStream* data) {
+  data->release = nullptr;
+}
+
+template <>
+inline void move_pointer(struct ArrowArrayStream* src, struct ArrowArrayStream* dst) {
+  ArrowArrayStreamMove(src, dst);
+}
+
+template <>
+inline void release_pointer(ArrowArrayStream* data) {
+  if (data->release != nullptr) {
+    data->release(data);
+  }
+}
+
+template <>
+inline void init_pointer(struct ArrowBuffer* data) {
+  ArrowBufferInit(data);
+}
+
+template <>
+inline void move_pointer(struct ArrowBuffer* src, struct ArrowBuffer* dst) {
   ArrowBufferMove(src, dst);
 }
 
-static inline void release_pointer(struct ArrowBuffer* data) { ArrowBufferReset(data); }
+template <>
+inline void release_pointer(struct ArrowBuffer* data) {
+  ArrowBufferReset(data);
+}
 
-static inline void init_pointer(struct ArrowBitmap* data) { ArrowBitmapInit(data); }
+template <>
+inline void init_pointer(struct ArrowBitmap* data) {
+  ArrowBitmapInit(data);
+}
 
-static inline void move_pointer(struct ArrowBitmap* src, struct ArrowBitmap* dst) {
+template <>
+inline void move_pointer(struct ArrowBitmap* src, struct ArrowBitmap* dst) {
   ArrowBitmapMove(src, dst);
 }
 
-static inline void release_pointer(struct ArrowBitmap* data) { ArrowBitmapReset(data); }
+template <>
+inline void release_pointer(struct ArrowBitmap* data) {
+  ArrowBitmapReset(data);
+}
 
-static inline void init_pointer(struct ArrowArrayView* data) {
+template <>
+inline void init_pointer(struct ArrowArrayView* data) {
   ArrowArrayViewInitFromType(data, NANOARROW_TYPE_UNINITIALIZED);
 }
 
-static inline void move_pointer(struct ArrowArrayView* src, struct ArrowArrayView* dst) {
+template <>
+inline void move_pointer(struct ArrowArrayView* src, struct ArrowArrayView* dst) {
   ArrowArrayViewMove(src, dst);
 }
 
-static inline void release_pointer(struct ArrowArrayView* data) {
+template <>
+inline void release_pointer(struct ArrowArrayView* data) {
   ArrowArrayViewReset(data);
 }
 

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -326,7 +326,6 @@ using UniqueArrayView = internal::Unique<struct ArrowArrayView>;
 template <typename T>
 class ArrayStreamFactory {
  public:
-
   /// \brief Take ownership of instance and populate callbacks of out
   static void InitArrayStream(T* instance, struct ArrowArrayStream* out) {
     out->get_schema = &get_schema_wrapper;

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -191,7 +191,9 @@ TEST(NanoarrowHppTest, NanoarrowHppEmptyArrayStreamTest) {
 
   nanoarrow::UniqueSchema schema_in;
   EXPECT_EQ(ArrowSchemaInitFromType(schema_in.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
-  auto array_stream = nanoarrow::EmptyArrayStream::MakeUnique(schema_in.get());
+
+  nanoarrow::UniqueArrayStream array_stream;
+  nanoarrow::EmptyArrayStream(schema_in.get()).ToArrayStream(array_stream.get());
 
   EXPECT_EQ(array_stream->get_schema(array_stream.get(), schema.get()), NANOARROW_OK);
   EXPECT_STREQ(schema->format, "i");
@@ -214,8 +216,9 @@ TEST(NanoarrowHppTest, NanoarrowHppVectorArrayStreamTest) {
   nanoarrow::UniqueSchema schema_in;
   EXPECT_EQ(ArrowSchemaInitFromType(schema_in.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
 
-  auto array_stream =
-      nanoarrow::VectorArrayStream::MakeUnique(schema_in.get(), array_in.get());
+  nanoarrow::UniqueArrayStream array_stream;
+  nanoarrow::VectorArrayStream(schema_in.get(), array_in.get())
+      .ToArrayStream(array_stream.get());
 
   EXPECT_EQ(array_stream->get_next(array_stream.get(), array.get()), NANOARROW_OK);
   ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_INT32);

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -203,10 +203,6 @@ TEST(NanoarrowHppTest, NanoarrowHppEmptyArrayStreamTest) {
 }
 
 TEST(NanoarrowHppTest, NanoarrowHppVectorArrayStreamTest) {
-  nanoarrow::UniqueSchema schema;
-  nanoarrow::UniqueArray array;
-  nanoarrow::UniqueArrayView array_view;
-
   nanoarrow::UniqueArray array_in;
   EXPECT_EQ(ArrowArrayInitFromType(array_in.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(array_in.get()), NANOARROW_OK);
@@ -220,12 +216,22 @@ TEST(NanoarrowHppTest, NanoarrowHppVectorArrayStreamTest) {
   nanoarrow::VectorArrayStream(schema_in.get(), array_in.get())
       .ToArrayStream(array_stream.get());
 
+  nanoarrow::UniqueSchema schema;
+  ASSERT_EQ(array_stream->get_schema(array_stream.get(), schema.get()), NANOARROW_OK);
+
+  nanoarrow::UniqueArrayView array_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr),
+            NANOARROW_OK);
+
+  nanoarrow::UniqueArray array;
   EXPECT_EQ(array_stream->get_next(array_stream.get(), array.get()), NANOARROW_OK);
-  ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_INT32);
+
   ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(array_view.get(), 0), 1234);
   array.reset();
 
   EXPECT_EQ(array_stream->get_next(array_stream.get(), array.get()), NANOARROW_OK);
   EXPECT_EQ(array->release, nullptr);
+
+  EXPECT_STREQ(array_stream->get_last_error(array_stream.get()), "");
 }


### PR DESCRIPTION
An early commit implemented `nanoarrow::EmptyArrayStream` and `nanoarrow::VectorArrayStream` in the nanoarrow.hpp C++ helpers. The intention at the time was to make it "easy"/idiomatic to use a C++ object to back an `ArrowArrayStream`; however, it was in practice difficult to actually make work (I tried briefly and gave up when writing a [dummy ADBC driver](https://github.com/voltrondata-labs/blog-posts-code/blob/main/2023-08-nanoarrow-adbc/simple_csv_reader.cc#L52-L177) for [this blog post](https://voltrondata.com/resources/nanoarrow-lightweight-embeddable-arrow-implementation-data-pipelines).

This PR deprecates the original syntax and migrates it to the following.

Implementation:

```cpp
class StreamImpl {
 public:
  // Public methods (e.g., constructor) used from C++ to initialize relevant data

  // Idiomatic exporter to move data + lifecycle responsibility to an instance
  // managed by the ArrowArrayStream callbacks
  void ToArrayStream(struct ArrowArrayStream* out) {
    ArrayStreamFactory<StreamImpl>::InitArrayStream(new StreamImpl(...), out);
  }

 private:
  // Make relevant methods available to the ArrayStreamFactory
  friend class ArrayStreamFactory<StreamImpl>;

  // Method implementations (called from C, not normally interacted with from C++)
  int GetSchema(struct ArrowSchema* schema) { return ENOTSUP; }
  int GetNext(struct ArrowArray* array) { return ENOTSUP; }
  const char* GetLastError() { nullptr; }
};
```

Usage:

```cpp
// Call constructor and/or public methods to initialize relevant data
StreamImpl impl;

// Export to ArrowArrayStream after data are finalized
UniqueArrayStream stream;
impl.ToArrayStream(stream.get());
```

I'm open to suggestions on how to make that better! It might be that the `ToArrayStream()` bit is confusing (i.e., just use `ArrayStreamFactory<>::InitArrayStream(new StreamImpl())` directory) but it also seemed better to keep the lines where a raw pointer was floating around to be entirely contained within the `StreamImpl` class.

It also fixes an issue with the `XXX_pointer()` functions, which because of the way they were declared, required that `nanoarrow.hpp` be confusingly included *after* `nanoarrow_ipc.hpp`. The correct way to do this (I think) was to declare the template and add implementations (rather than use overloads).