### PR TITLE
refactor: Add wrappers around callbacks to improve syntax and debuggability

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -68,7 +68,8 @@ jobs:
           sudo ldconfig
           mkdir build
           cd build
-          cmake .. -DNANOARROW_BUILD_TESTS=ON ${{ matrix.config.cmake_args }}
+          cmake .. -DNANOARROW_BUILD_TESTS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            ${{ matrix.config.cmake_args }}
           cmake --build .
 
       - name: Check for non-namespaced symbols in namespaced build

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -243,7 +243,7 @@ NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRING))
 // or it will leak.
 int code = ArrowArrayInitFromSchema(&array, &schema, NULL);
 if (code != NANOARROW_OK) {
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   return code;
 }
 ```

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
@@ -226,7 +226,7 @@ static int ArrowDeviceBasicArrayStreamGetNext(struct ArrowDeviceArrayStream* arr
       private_data->naive_stream.get_next(&private_data->naive_stream, &tmp));
   int result = ArrowDeviceArrayInit(private_data->device, device_array, &tmp);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowArrayRelease(&tmp);
     return result;
   }
 
@@ -244,7 +244,7 @@ static void ArrowDeviceBasicArrayStreamRelease(
     struct ArrowDeviceArrayStream* array_stream) {
   struct ArrowBasicDeviceArrayStreamPrivate* private_data =
       (struct ArrowBasicDeviceArrayStreamPrivate*)array_stream->private_data;
-  private_data->naive_stream.release(&private_data->naive_stream);
+  ArrowArrayStreamRelease(&private_data->naive_stream);
   ArrowFree(private_data);
   array_stream->release = NULL;
 }
@@ -439,19 +439,19 @@ ArrowErrorCode ArrowDeviceArrayViewCopy(struct ArrowDeviceArrayView* src,
   int result =
       ArrowDeviceArrayViewCopyInternal(src->device, &src->array_view, device_dst, &tmp);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowArrayRelease(&tmp);
     return result;
   }
 
   result = ArrowArrayFinishBuilding(&tmp, NANOARROW_VALIDATION_LEVEL_MINIMAL, NULL);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowArrayRelease(&tmp);
     return result;
   }
 
   result = ArrowDeviceArrayInit(device_dst, dst, &tmp);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowArrayRelease(&tmp);
     return result;
   }
 

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.hpp
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.hpp
@@ -36,7 +36,7 @@ static inline void move_pointer(struct ArrowDeviceArray* src,
 
 static inline void release_pointer(struct ArrowDeviceArray* data) {
   if (data->array.release != nullptr) {
-    data->array.release(&data->array);
+    ArrowArrayRelease(&data->array);
   }
 
   data->sync_event = nullptr;

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
@@ -118,7 +118,7 @@ static void ArrowDeviceCudaArrayRelease(struct ArrowArray* array) {
   struct ArrowDeviceCudaArrayPrivate* private_data =
       (struct ArrowDeviceCudaArrayPrivate*)array->private_data;
   cudaEventDestroy(private_data->sync_event);
-  private_data->parent.release(&private_data->parent);
+  ArrowArrayRelease(&private_data->parent);
   ArrowFree(private_data);
   array->release = NULL;
 }

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
@@ -184,7 +184,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
   ASSERT_EQ(ArrowDeviceArrayMoveToDevice(&device_array, gpu, &device_array2), ENOTSUP);
   ASSERT_EQ(ArrowDeviceArrayViewCopy(&device_array_view, gpu, &device_array2),
             NANOARROW_OK);
-  device_array.array.release(&device_array.array);
+  ArrowArrayRelease(&device_array.array);
 
   ASSERT_NE(device_array2.array.release, nullptr);
   ASSERT_EQ(device_array2.device_id, gpu->device_id);
@@ -201,7 +201,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
   } else {
     ASSERT_EQ(ArrowDeviceArrayViewCopy(&device_array_view, cpu, &device_array),
               NANOARROW_OK);
-    device_array2.array.release(&device_array2.array);
+    ArrowArrayRelease(&device_array2.array);
   }
 
   ASSERT_NE(device_array.array.release, nullptr);
@@ -213,7 +213,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
   EXPECT_EQ(memcmp(device_array_view.array_view.buffer_views[2].data.data, "abcdefg", 7),
             0);
 
-  device_array.array.release(&device_array.array);
+  ArrowArrayRelease(&device_array.array);
   ArrowDeviceArrayViewReset(&device_array_view);
 }
 

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal.cc
@@ -146,7 +146,7 @@ static void ArrowDeviceMetalArrayRelease(struct ArrowArray* array) {
   struct ArrowDeviceMetalArrayPrivate* private_data =
       (struct ArrowDeviceMetalArrayPrivate*)array->private_data;
   private_data->event->release();
-  private_data->parent.release(&private_data->parent);
+  ArrowArrayRelease(&private_data->parent);
   ArrowFree(private_data);
   array->release = NULL;
 }

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal_test.cc
@@ -243,7 +243,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
   ASSERT_EQ(ArrowDeviceArrayMoveToDevice(&device_array, metal, &device_array2), ENOTSUP);
   ASSERT_EQ(ArrowDeviceArrayViewCopy(&device_array_view, metal, &device_array2),
             NANOARROW_OK);
-  device_array.array.release(&device_array.array);
+  ArrowArrayRelease(&device_array.array);
 
   ASSERT_NE(device_array2.array.release, nullptr);
   ASSERT_EQ(device_array2.device_id, metal->device_id);
@@ -261,7 +261,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
   EXPECT_EQ(memcmp(device_array_view.array_view.buffer_views[2].data.data, "abcdefg", 7),
             0);
 
-  device_array.array.release(&device_array.array);
+  ArrowArrayRelease(&device_array.array);
   ArrowDeviceArrayViewReset(&device_array_view);
 }
 

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
@@ -99,7 +99,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCpuArrayViewString) {
   ASSERT_NE(device_array2.array.release, nullptr);
   ASSERT_EQ(device_array2.device_id, cpu->device_id);
 
-  device_array2.array.release(&device_array2.array);
+  ArrowArrayRelease(&device_array2.array);
   ArrowDeviceArrayViewReset(&device_array_view);
 }
 

--- a/extensions/nanoarrow_ipc/src/apps/dump_stream.c
+++ b/extensions/nanoarrow_ipc/src/apps/dump_stream.c
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
     }
 
     fprintf(stderr, "stream.get_schema() returned %d with error '%s'\n", result, message);
-    stream.release(&stream);
+    ArrowArrayStreamRelease(&stream);
     return 1;
   }
 
@@ -96,7 +96,7 @@ int main(int argc, char* argv[]) {
   char schema_tmp[8096];
   memset(schema_tmp, 0, sizeof(schema_tmp));
   dump_schema_to_stdout(&schema, 0, schema_tmp, sizeof(schema_tmp));
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   struct ArrowArray array;
   array.release = NULL;
@@ -114,14 +114,14 @@ int main(int argc, char* argv[]) {
       }
 
       fprintf(stderr, "stream.get_next() returned %d with error '%s'\n", result, message);
-      stream.release(&stream);
+      ArrowArrayStreamRelease(&stream);
       return 1;
     }
 
     if (array.release != NULL) {
       row_count += array.length;
       batch_count++;
-      array.release(&array);
+      ArrowArrayRelease(&array);
     } else {
       break;
     }
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
   fprintf(stdout, "Read %ld rows in %ld batch(es) <%.06f seconds>\n", (long)row_count,
           (long)batch_count, elapsed);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
   fclose(file_ptr);
   return 0;
 }

--- a/extensions/nanoarrow_ipc/src/apps/dump_stream.c
+++ b/extensions/nanoarrow_ipc/src/apps/dump_stream.c
@@ -77,14 +77,10 @@ int main(int argc, char* argv[]) {
   clock_t begin = clock();
 
   struct ArrowSchema schema;
-  result = stream.get_schema(&stream, &schema);
+  result = ArrowArrayStreamGetSchema(&stream, &schema, NULL);
   if (result != NANOARROW_OK) {
-    const char* message = stream.get_last_error(&stream);
-    if (message == NULL) {
-      message = "";
-    }
-
-    fprintf(stderr, "stream.get_schema() returned %d with error '%s'\n", result, message);
+    fprintf(stderr, "stream.get_schema() returned %d with error '%s'\n", result,
+            ArrowArrayStreamGetLastError(&stream));
     ArrowArrayStreamRelease(&stream);
     return 1;
   }
@@ -106,14 +102,10 @@ int main(int argc, char* argv[]) {
   begin = clock();
 
   while (1) {
-    result = stream.get_next(&stream, &array);
+    result = ArrowArrayStreamGetNext(&stream, &array, NULL);
     if (result != NANOARROW_OK) {
-      const char* message = stream.get_last_error(&stream);
-      if (message == NULL) {
-        message = "";
-      }
-
-      fprintf(stderr, "stream.get_next() returned %d with error '%s'\n", result, message);
+      fprintf(stderr, "stream.get_next() returned %d with error '%s'\n", result,
+              ArrowArrayStreamGetLastError(&stream));
       ArrowArrayStreamRelease(&stream);
       return 1;
     }

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -246,7 +246,7 @@ void ArrowIpcDecoderReset(struct ArrowIpcDecoder* decoder) {
     ArrowArrayViewReset(&private_data->array_view);
 
     if (private_data->array.release != NULL) {
-      private_data->array.release(&private_data->array);
+      ArrowArrayRelease(&private_data->array);
     }
 
     if (private_data->fields != NULL) {
@@ -1117,7 +1117,7 @@ ArrowErrorCode ArrowIpcDecoderDecodeSchema(struct ArrowIpcDecoder* decoder,
   ArrowSchemaInit(&tmp);
   int result = ArrowSchemaSetTypeStruct(&tmp, n_fields);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowSchemaRelease(&tmp);
     ArrowErrorSet(error, "Failed to allocate struct schema with %ld children",
                   (long)n_fields);
     return result;
@@ -1125,13 +1125,13 @@ ArrowErrorCode ArrowIpcDecoderDecodeSchema(struct ArrowIpcDecoder* decoder,
 
   result = ArrowIpcDecoderSetChildren(&tmp, fields, error);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowSchemaRelease(&tmp);
     return result;
   }
 
   result = ArrowIpcDecoderSetMetadata(&tmp, ns(Schema_custom_metadata(schema)), error);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowSchemaRelease(&tmp);
     return result;
   }
 
@@ -1178,7 +1178,7 @@ ArrowErrorCode ArrowIpcDecoderSetSchema(struct ArrowIpcDecoder* decoder,
   private_data->n_fields = 0;
   ArrowArrayViewReset(&private_data->array_view);
   if (private_data->array.release != NULL) {
-    private_data->array.release(&private_data->array);
+    ArrowArrayRelease(&private_data->array);
   }
   if (private_data->fields != NULL) {
     ArrowFree(private_data->fields);
@@ -1675,7 +1675,7 @@ ArrowErrorCode ArrowIpcDecoderDecodeArray(struct ArrowIpcDecoder* decoder,
   int result =
       ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, validation_level, error);
   if (result != NANOARROW_OK && temp.release != NULL) {
-    temp.release(&temp);
+    ArrowArrayRelease(&temp);
   } else if (result != NANOARROW_OK) {
     return result;
   }
@@ -1699,7 +1699,7 @@ ArrowErrorCode ArrowIpcDecoderDecodeArrayFromShared(
   int result =
       ArrowIpcDecoderDecodeArrayInternal(decoder, i, &temp, validation_level, error);
   if (result != NANOARROW_OK && temp.release != NULL) {
-    temp.release(&temp);
+    ArrowArrayRelease(&temp);
   } else if (result != NANOARROW_OK) {
     return result;
   }

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder_test.cc
@@ -291,7 +291,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleSchema) {
   EXPECT_EQ(schema.children[0]->flags, ARROW_FLAG_NULLABLE);
   EXPECT_STREQ(schema.children[0]->format, "i");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 
@@ -351,7 +351,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
       memcmp(array.children[0]->buffers[1], one_two_three_le, sizeof(one_two_three_le)),
       0);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // Check field extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArray(&decoder, body, 0, &array,
@@ -362,7 +362,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   EXPECT_EQ(array.null_count, 0);
   EXPECT_EQ(memcmp(array.buffers[1], one_two_three_le, sizeof(one_two_three_le)), 0);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // Field extract should fail if compression was set
   decoder.codec = NANOARROW_IPC_COMPRESSION_TYPE_ZSTD;
@@ -389,7 +389,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatch) {
   EXPECT_EQ(ArrowIpcDecoderDecodeHeader(&decoder, data, &error), EINVAL);
   EXPECT_STREQ(error.message, "Expected 0 field nodes in message but found 1");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 
@@ -421,7 +421,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSetSchema) {
   EXPECT_EQ(decoder_private->n_fields, 2);
   EXPECT_EQ(decoder_private->n_buffers, 3);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 
@@ -442,7 +442,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSetSchemaErrors) {
   EXPECT_EQ(ArrowIpcDecoderSetSchema(&decoder, &schema, &error), EINVAL);
   EXPECT_STREQ(error.message, "schema must be a struct type");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 
@@ -531,7 +531,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchFromShared) {
       memcmp(array.children[0]->buffers[1], one_two_three_le, sizeof(one_two_three_le)),
       0);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // Check field extract
   EXPECT_EQ(ArrowIpcDecoderDecodeArrayFromShared(
@@ -546,8 +546,8 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeSimpleRecordBatchFromShared) {
   EXPECT_EQ(array.null_count, 0);
   EXPECT_EQ(memcmp(array.buffers[1], one_two_three_le, sizeof(one_two_three_le)), 0);
 
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
   ArrowBufferReset(&body);
   ArrowIpcDecoderReset(&decoder);
 }
@@ -596,7 +596,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSharedBufferThreadSafeDecode) {
   // Clean up
   ArrowIpcSharedBufferReset(&shared);
   ArrowIpcDecoderReset(&decoder);
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   // Access the data and release from another thread
   std::thread threads[10];
@@ -604,7 +604,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcSharedBufferThreadSafeDecode) {
     threads[i] = std::thread([&arrays, i, &one_two_three_le] {
       memcmp(arrays[i].children[0]->buffers[1], one_two_three_le,
              sizeof(one_two_three_le));
-      arrays[i].release(arrays + i);
+      ArrowArrayRelease(arrays + i);
     });
   }
 
@@ -677,7 +677,7 @@ TEST_P(ArrowTypeParameterizedTestFixture, NanoarrowIpcArrowArrayRoundtrip) {
   EXPECT_EQ(maybe_batch.ValueUnsafe()->ToString(), nulls->ToString());
   EXPECT_TRUE(maybe_batch.ValueUnsafe()->Equals(*nulls));
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 
@@ -928,7 +928,7 @@ TEST_P(ArrowTypeIdParameterizedTestFixture, NanoarrowIpcDecodeSwapEndian) {
                    array_view->buffer_views[1].size_bytes),
             0);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   ArrowIpcDecoderReset(&decoder);
 }
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_files_test.cc
@@ -188,28 +188,26 @@ class TestFile {
         << error.message;
 
     nanoarrow::UniqueSchema schema;
-    int result = stream->get_schema(stream.get(), schema.get());
+    int result = ArrowArrayStreamGetSchema(stream.get(), schema.get(), &error);
     if (result != NANOARROW_OK) {
-      std::string err(stream->get_last_error(stream.get()));
-      if (Check(result, err)) {
+      if (Check(result, error.message)) {
         return;
       }
 
-      GTEST_FAIL() << MakeError(result, err);
+      GTEST_FAIL() << MakeError(result, error.message);
     }
 
     std::vector<nanoarrow::UniqueArray> arrays;
     while (true) {
       nanoarrow::UniqueArray array;
 
-      result = stream->get_next(stream.get(), array.get());
+      result = ArrowArrayStreamGetNext(stream.get(), array.get(), &error);
       if (result != NANOARROW_OK) {
-        std::string err(stream->get_last_error(stream.get()));
-        if (Check(result, err)) {
+        if (Check(result, error.message)) {
           return;
         }
 
-        GTEST_FAIL() << MakeError(result, err);
+        GTEST_FAIL() << MakeError(result, error.message);
       }
 
       if (array->release == nullptr) {

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -189,7 +189,7 @@ static void ArrowIpcArrayStreamReaderRelease(struct ArrowArrayStream* stream) {
   ArrowIpcDecoderReset(&private_data->decoder);
 
   if (private_data->out_schema.release != NULL) {
-    private_data->out_schema.release(&private_data->out_schema);
+    ArrowSchemaRelease(&private_data->out_schema);
   }
 
   ArrowBufferReset(&private_data->header);
@@ -326,7 +326,7 @@ static int ArrowIpcArrayStreamReaderReadSchemaIfNeeded(
 
   // Only support "read the whole thing" for now
   if (private_data->field_index != -1) {
-    tmp.release(&tmp);
+    ArrowSchemaRelease(&tmp);
     ArrowErrorSet(&private_data->error, "Field index != -1 is not yet supported");
     return ENOTSUP;
   }
@@ -335,7 +335,7 @@ static int ArrowIpcArrayStreamReaderReadSchemaIfNeeded(
   int result =
       ArrowIpcDecoderSetSchema(&private_data->decoder, &tmp, &private_data->error);
   if (result != NANOARROW_OK) {
-    tmp.release(&tmp);
+    ArrowSchemaRelease(&tmp);
     return result;
   }
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -96,7 +96,7 @@ TEST(NanoarrowIpcReader, InputStreamBuffer) {
   EXPECT_EQ(stream.read(&stream, nullptr, 0, &size_read_bytes, nullptr), NANOARROW_OK);
   EXPECT_EQ(size_read_bytes, 0);
 
-  ArrowArrayStreamRelease(&stream);
+  stream.release(&stream);
 }
 
 TEST(NanoarrowIpcReader, InputStreamFile) {
@@ -138,7 +138,7 @@ TEST(NanoarrowIpcReader, InputStreamFile) {
   EXPECT_EQ(stream.read(&stream, nullptr, 0, &size_read_bytes, nullptr), NANOARROW_OK);
   EXPECT_EQ(size_read_bytes, 0);
 
-  ArrowArrayStreamRelease(&stream);
+  stream.release(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderBasic) {
@@ -195,7 +195,7 @@ TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
   ASSERT_EQ(ArrowIpcArrayStreamReaderInit(&stream, &input, &options), NANOARROW_OK);
 
   struct ArrowSchema schema;
-  ASSERT_EQ(ArrowArrayStreamGetSchema(&stream, &schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStreamGetSchema(&stream, &schema, nullptr), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
   ArrowSchemaRelease(&schema);
 

--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_reader_test.cc
@@ -96,7 +96,7 @@ TEST(NanoarrowIpcReader, InputStreamBuffer) {
   EXPECT_EQ(stream.read(&stream, nullptr, 0, &size_read_bytes, nullptr), NANOARROW_OK);
   EXPECT_EQ(size_read_bytes, 0);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, InputStreamFile) {
@@ -138,7 +138,7 @@ TEST(NanoarrowIpcReader, InputStreamFile) {
   EXPECT_EQ(stream.read(&stream, nullptr, 0, &size_read_bytes, nullptr), NANOARROW_OK);
   EXPECT_EQ(size_read_bytes, 0);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderBasic) {
@@ -160,12 +160,12 @@ TEST(NanoarrowIpcReader, StreamReaderBasic) {
 
   ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   struct ArrowArray array;
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -173,7 +173,7 @@ TEST(NanoarrowIpcReader, StreamReaderBasic) {
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
@@ -197,12 +197,12 @@ TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
   struct ArrowSchema schema;
   ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   struct ArrowArray array;
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
@@ -210,7 +210,7 @@ TEST(NanoarrowIpcReader, StreamReaderBasicNoSharedBuffers) {
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderBasicWithEndOfStream) {
@@ -233,17 +233,17 @@ TEST(NanoarrowIpcReader, StreamReaderBasicWithEndOfStream) {
   struct ArrowSchema schema;
   ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   struct ArrowArray array;
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 3);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   ASSERT_EQ(stream.get_next(&stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderIncompleteMessageHeader) {
@@ -263,7 +263,7 @@ TEST(NanoarrowIpcReader, StreamReaderIncompleteMessageHeader) {
   EXPECT_STREQ(stream.get_last_error(&stream),
                "Expected >= 280 bytes of remaining data but found 279 bytes in buffer");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderIncompleteMessageBody) {
@@ -287,7 +287,7 @@ TEST(NanoarrowIpcReader, StreamReaderIncompleteMessageBody) {
   EXPECT_STREQ(stream.get_last_error(&stream),
                "Expected to be able to read 16 bytes for message body but got 15");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderExpectedRecordBatch) {
@@ -307,14 +307,14 @@ TEST(NanoarrowIpcReader, StreamReaderExpectedRecordBatch) {
   struct ArrowSchema schema;
   ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+s");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   struct ArrowArray array;
   ASSERT_EQ(stream.get_next(&stream, &array), EINVAL);
   EXPECT_STREQ(stream.get_last_error(&stream),
                "Unexpected message type (expected RecordBatch)");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderExpectedSchema) {
@@ -335,7 +335,7 @@ TEST(NanoarrowIpcReader, StreamReaderExpectedSchema) {
   EXPECT_STREQ(stream.get_last_error(&stream),
                "Unexpected message type at start of input (expected Schema)");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
@@ -368,7 +368,7 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
     ASSERT_NE(stream.get_schema(&stream, &schema), NANOARROW_OK);
     ASSERT_GT(strlen(stream.get_last_error(&stream)), 0);
 
-    stream.release(&stream);
+    ArrowArrayStreamRelease(&stream);
   }
 
   // Do the same exercise removing bytes of the record batch message.
@@ -388,11 +388,11 @@ TEST(NanoarrowIpcTest, StreamReaderInvalidBuffer) {
     ASSERT_EQ(ArrowIpcArrayStreamReaderInit(&stream, &input, nullptr), NANOARROW_OK);
 
     ASSERT_EQ(stream.get_schema(&stream, &schema), NANOARROW_OK);
-    schema.release(&schema);
+    ArrowSchemaRelease(&schema);
     ASSERT_NE(stream.get_next(&stream, &array), NANOARROW_OK);
     ASSERT_GT(strlen(stream.get_last_error(&stream)), 0);
 
-    stream.release(&stream);
+    ArrowArrayStreamRelease(&stream);
   }
 }
 
@@ -418,7 +418,7 @@ TEST(NanoarrowIpcReader, StreamReaderUnsupportedFieldIndex) {
   ASSERT_EQ(stream.get_schema(&stream, &schema), ENOTSUP);
   EXPECT_STREQ(stream.get_last_error(&stream), "Field index != -1 is not yet supported");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderEmptyInput) {
@@ -435,7 +435,7 @@ TEST(NanoarrowIpcReader, StreamReaderEmptyInput) {
   ASSERT_EQ(stream.get_schema(&stream, &schema), ENODATA);
   EXPECT_STREQ(stream.get_last_error(&stream), "No data available on stream");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }
 
 TEST(NanoarrowIpcReader, StreamReaderIncompletePrefix) {
@@ -454,5 +454,5 @@ TEST(NanoarrowIpcReader, StreamReaderIncompletePrefix) {
   EXPECT_STREQ(stream.get_last_error(&stream),
                "Expected at least 8 bytes in remainder of stream");
 
-  stream.release(&stream);
+  ArrowArrayStreamRelease(&stream);
 }

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -56,7 +56,7 @@ cdef void pycapsule_schema_deleter(object schema_capsule) noexcept:
         schema_capsule, 'arrow_schema'
     )
     if schema.release != NULL:
-        schema.release(schema)
+        ArrowSchemaRelease(schema)
 
     free(schema)
 
@@ -74,7 +74,7 @@ cdef void pycapsule_array_deleter(object array_capsule) noexcept:
     )
     # Do not invoke the deleter on a used/moved capsule
     if array.release != NULL:
-        array.release(array)
+        ArrowArrayRelease(array)
 
     free(array)
 
@@ -92,7 +92,7 @@ cdef void pycapsule_stream_deleter(object stream_capsule) noexcept:
     )
     # Do not invoke the deleter on a used/moved capsule
     if stream.release != NULL:
-        stream.release(stream)
+        ArrowArrayStreamRelease(stream)
 
     free(stream)
 
@@ -124,7 +124,7 @@ cdef class SchemaHolder:
 
     def __dealloc__(self):
         if self.c_schema.release != NULL:
-          self.c_schema.release(&self.c_schema)
+          ArrowSchemaRelease(&self.c_schema)
 
     def _addr(self):
         return <uintptr_t>&self.c_schema
@@ -144,7 +144,7 @@ cdef class ArrayHolder:
 
     def __dealloc__(self):
         if self.c_array.release != NULL:
-          self.c_array.release(&self.c_array)
+          ArrowArrayRelease(&self.c_array)
 
     def _addr(self):
         return <uintptr_t>&self.c_array
@@ -163,7 +163,7 @@ cdef class ArrayStreamHolder:
 
     def __dealloc__(self):
         if self.c_array_stream.release != NULL:
-          self.c_array_stream.release(&self.c_array_stream)
+            ArrowArrayStreamRelease(&self.c_array_stream)
 
     def _addr(self):
         return <uintptr_t>&self.c_array_stream
@@ -1176,7 +1176,7 @@ cdef class DeviceArrayHolder:
 
     def __dealloc__(self):
         if self.c_array.array.release != NULL:
-          self.c_array.array.release(&self.c_array.array)
+          ArrowArrayRelease(&self.c_array.array)
 
     def _addr(self):
         return <uintptr_t>&self.c_array

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -72,14 +72,10 @@ SEXP nanoarrow_c_array_stream_get_schema(SEXP array_stream_xptr) {
 
   SEXP schema_xptr = PROTECT(schema_owning_xptr());
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
-  int result = array_stream->get_schema(array_stream, schema);
-
+  int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != 0) {
-    const char* last_error = array_stream->get_last_error(array_stream);
-    if (last_error == NULL) {
-      last_error = "";
-    }
-    Rf_error("array_stream->get_schema(): [%d] %s", result, last_error);
+    Rf_error("array_stream->get_schema(): [%d] %s", result,
+             ArrowArrayStreamGetLastError(array_stream));
   }
 
   UNPROTECT(1);
@@ -91,14 +87,10 @@ SEXP nanoarrow_c_array_stream_get_next(SEXP array_stream_xptr) {
 
   SEXP array_xptr = PROTECT(array_owning_xptr());
   struct ArrowArray* array = (struct ArrowArray*)R_ExternalPtrAddr(array_xptr);
-  int result = array_stream->get_next(array_stream, array);
-
-  if (result != 0) {
-    const char* last_error = array_stream->get_last_error(array_stream);
-    if (last_error == NULL) {
-      last_error = "";
-    }
-    Rf_error("array_stream->get_next(): [%d] %s", result, last_error);
+  int result = ArrowArrayStreamGetNext(array_stream, array, NULL);
+  if (result != NANOARROW_OK) {
+    Rf_error("array_stream->get_next(): [%d] %s", result,
+             ArrowArrayStreamGetLastError(array_stream));
   }
 
   UNPROTECT(1);

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -34,10 +34,10 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
 
   SEXP schema_xptr = PROTECT(schema_owning_xptr());
   struct ArrowSchema* schema = (struct ArrowSchema*)R_ExternalPtrAddr(schema_xptr);
-  int result = array_stream->get_schema(array_stream, schema);
+  int result = ArrowArrayStreamGetSchema(array_stream, schema, NULL);
   if (result != NANOARROW_OK) {
     Rf_error("ArrowArrayStream::get_schema(): %s",
-             array_stream->get_last_error(array_stream));
+             ArrowArrayStreamGetLastError(array_stream));
   }
 
   SEXP converter_xptr = PROTECT(nanoarrow_converter_from_ptype(ptype_sexp));
@@ -55,11 +55,11 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
   int64_t n_batches = 0;
   int64_t n_materialized = 0;
   if (n > 0) {
-    result = array_stream->get_next(array_stream, array);
+    result = ArrowArrayStreamGetNext(array_stream, array, NULL);
     n_batches++;
     if (result != NANOARROW_OK) {
       Rf_error("ArrowArrayStream::get_next(): %s",
-               array_stream->get_last_error(array_stream));
+               ArrowArrayStreamGetLastError(array_stream));
     }
 
     while (array->release != NULL) {
@@ -78,11 +78,11 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
       }
 
       array->release(array);
-      result = array_stream->get_next(array_stream, array);
+      result = ArrowArrayStreamGetNext(array_stream, array, NULL);
       n_batches++;
       if (result != NANOARROW_OK) {
         Rf_error("ArrowArrayStream::get_next(): %s",
-                 array_stream->get_last_error(array_stream));
+                 ArrowArrayStreamGetLastError(array_stream));
       }
     }
   }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -39,7 +39,7 @@ static void ArrowArrayReleaseInternal(struct ArrowArray* array) {
     for (int64_t i = 0; i < array->n_children; i++) {
       if (array->children[i] != NULL) {
         if (array->children[i]->release != NULL) {
-          array->children[i]->release(array->children[i]);
+          ArrowArrayRelease(array->children[i]);
         }
 
         ArrowFree(array->children[i]);
@@ -54,7 +54,7 @@ static void ArrowArrayReleaseInternal(struct ArrowArray* array) {
   // release() callback.
   if (array->dictionary != NULL) {
     if (array->dictionary->release != NULL) {
-      array->dictionary->release(array->dictionary);
+      ArrowArrayRelease(array->dictionary);
     }
 
     ArrowFree(array->dictionary);
@@ -154,7 +154,7 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
 
   int result = ArrowArraySetStorageType(array, storage_type);
   if (result != NANOARROW_OK) {
-    array->release(array);
+    ArrowArrayRelease(array);
     return result;
   }
 
@@ -179,7 +179,7 @@ ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
   if (array_view->n_children > 0) {
     result = ArrowArrayAllocateChildren(array, array_view->n_children);
     if (result != NANOARROW_OK) {
-      array->release(array);
+      ArrowArrayRelease(array);
       return result;
     }
 
@@ -187,7 +187,7 @@ ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
       result =
           ArrowArrayInitFromArrayView(array->children[i], array_view->children[i], error);
       if (result != NANOARROW_OK) {
-        array->release(array);
+        ArrowArrayRelease(array);
         return result;
       }
     }
@@ -196,14 +196,14 @@ ArrowErrorCode ArrowArrayInitFromArrayView(struct ArrowArray* array,
   if (array_view->dictionary != NULL) {
     result = ArrowArrayAllocateDictionary(array);
     if (result != NANOARROW_OK) {
-      array->release(array);
+      ArrowArrayRelease(array);
       return result;
     }
 
     result =
         ArrowArrayInitFromArrayView(array->dictionary, array_view->dictionary, error);
     if (result != NANOARROW_OK) {
-      array->release(array);
+      ArrowArrayRelease(array);
       return result;
     }
   }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -21,7 +21,7 @@
 
 #include "nanoarrow.h"
 
-static void ArrowArrayRelease(struct ArrowArray* array) {
+static void ArrowArrayReleaseInternal(struct ArrowArray* array) {
   // Release buffers held by this array
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)array->private_data;
@@ -132,7 +132,7 @@ ArrowErrorCode ArrowArrayInitFromType(struct ArrowArray* array,
   array->buffers = NULL;
   array->children = NULL;
   array->dictionary = NULL;
-  array->release = &ArrowArrayRelease;
+  array->release = &ArrowArrayReleaseInternal;
   array->private_data = NULL;
 
   struct ArrowArrayPrivateData* private_data =

--- a/src/nanoarrow/array_stream.c
+++ b/src/nanoarrow/array_stream.c
@@ -69,12 +69,12 @@ static void ArrowBasicArrayStreamRelease(struct ArrowArrayStream* array_stream) 
       (struct BasicArrayStreamPrivate*)array_stream->private_data;
 
   if (private_data->schema.release != NULL) {
-    private_data->schema.release(&private_data->schema);
+    ArrowSchemaRelease(&private_data->schema);
   }
 
   for (int64_t i = 0; i < private_data->n_arrays; i++) {
     if (private_data->arrays[i].release != NULL) {
-      private_data->arrays[i].release(&private_data->arrays[i]);
+      ArrowArrayRelease(&private_data->arrays[i]);
     }
   }
 

--- a/src/nanoarrow/array_stream_test.cc
+++ b/src/nanoarrow/array_stream_test.cc
@@ -41,20 +41,20 @@ TEST(ArrayStreamTest, ArrayStreamTestBasic) {
   struct ArrowSchema schema_copy;
   EXPECT_EQ(array_stream.get_schema(&array_stream, &schema_copy), NANOARROW_OK);
   EXPECT_STREQ(schema_copy.format, "i");
-  schema_copy.release(&schema_copy);
+  ArrowSchemaRelease(&schema_copy);
 
   struct ArrowArray array_copy;
   EXPECT_EQ(array_stream.get_next(&array_stream, &array_copy), NANOARROW_OK);
   EXPECT_EQ(array_copy.length, 1);
   EXPECT_EQ(array_copy.n_buffers, 2);
-  array_copy.release(&array_copy);
+  ArrowArrayRelease(&array_copy);
 
   EXPECT_EQ(array_stream.get_next(&array_stream, &array_copy), NANOARROW_OK);
   EXPECT_EQ(array_copy.release, nullptr);
 
   EXPECT_EQ(array_stream.get_last_error(&array_stream), nullptr);
 
-  array_stream.release(&array_stream);
+  ArrowArrayStreamRelease(&array_stream);
   EXPECT_EQ(array_stream.release, nullptr);
 }
 
@@ -72,7 +72,7 @@ TEST(ArrayStreamTest, ArrayStreamTestEmpty) {
     EXPECT_EQ(array.release, nullptr);
   }
 
-  array_stream.release(&array_stream);
+  ArrowArrayStreamRelease(&array_stream);
 }
 
 TEST(ArrayStreamTest, ArrayStreamTestIncomplete) {
@@ -97,10 +97,10 @@ TEST(ArrayStreamTest, ArrayStreamTestIncomplete) {
   // Pull only one of them
   EXPECT_EQ(array_stream.get_next(&array_stream, &array), NANOARROW_OK);
   EXPECT_EQ(array.length, 0);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // The remaining arrays, owned by the stream, should be released here
-  array_stream.release(&array_stream);
+  ArrowArrayStreamRelease(&array_stream);
 }
 
 TEST(ArrayStreamTest, ArrayStreamTestInvalid) {
@@ -121,5 +121,5 @@ TEST(ArrayStreamTest, ArrayStreamTestInvalid) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected array with 2 buffer(s) but found 3 buffer(s)");
 
-  array_stream.release(&array_stream);
+  ArrowArrayStreamRelease(&array_stream);
 }

--- a/src/nanoarrow/array_stream_test.cc
+++ b/src/nanoarrow/array_stream_test.cc
@@ -39,17 +39,17 @@ TEST(ArrayStreamTest, ArrayStreamTestBasic) {
   EXPECT_EQ(ArrowBasicArrayStreamValidate(&array_stream, nullptr), NANOARROW_OK);
 
   struct ArrowSchema schema_copy;
-  EXPECT_EQ(array_stream.get_schema(&array_stream, &schema_copy), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(&array_stream, &schema_copy, nullptr), NANOARROW_OK);
   EXPECT_STREQ(schema_copy.format, "i");
   ArrowSchemaRelease(&schema_copy);
 
   struct ArrowArray array_copy;
-  EXPECT_EQ(array_stream.get_next(&array_stream, &array_copy), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(&array_stream, &array_copy, nullptr), NANOARROW_OK);
   EXPECT_EQ(array_copy.length, 1);
   EXPECT_EQ(array_copy.n_buffers, 2);
   ArrowArrayRelease(&array_copy);
 
-  EXPECT_EQ(array_stream.get_next(&array_stream, &array_copy), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(&array_stream, &array_copy, nullptr), NANOARROW_OK);
   EXPECT_EQ(array_copy.release, nullptr);
 
   EXPECT_EQ(array_stream.get_last_error(&array_stream), nullptr);
@@ -68,7 +68,7 @@ TEST(ArrayStreamTest, ArrayStreamTestEmpty) {
   EXPECT_EQ(ArrowBasicArrayStreamValidate(&array_stream, nullptr), NANOARROW_OK);
 
   for (int i = 0; i < 5; i++) {
-    EXPECT_EQ(array_stream.get_next(&array_stream, &array), NANOARROW_OK);
+    EXPECT_EQ(ArrowArrayStreamGetNext(&array_stream, &array, nullptr), NANOARROW_OK);
     EXPECT_EQ(array.release, nullptr);
   }
 
@@ -95,7 +95,7 @@ TEST(ArrayStreamTest, ArrayStreamTestIncomplete) {
   }
 
   // Pull only one of them
-  EXPECT_EQ(array_stream.get_next(&array_stream, &array), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(&array_stream, &array, nullptr), NANOARROW_OK);
   EXPECT_EQ(array.length, 0);
   ArrowArrayRelease(&array);
 

--- a/src/nanoarrow/array_stream_test.cc
+++ b/src/nanoarrow/array_stream_test.cc
@@ -39,7 +39,8 @@ TEST(ArrayStreamTest, ArrayStreamTestBasic) {
   EXPECT_EQ(ArrowBasicArrayStreamValidate(&array_stream, nullptr), NANOARROW_OK);
 
   struct ArrowSchema schema_copy;
-  EXPECT_EQ(ArrowArrayStreamGetSchema(&array_stream, &schema_copy, nullptr), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(&array_stream, &schema_copy, nullptr),
+            NANOARROW_OK);
   EXPECT_STREQ(schema_copy.format, "i");
   ArrowSchemaRelease(&schema_copy);
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -53,19 +53,19 @@ TEST(ArrayTest, ArrayTestInit) {
 
   EXPECT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
   EXPECT_EQ(array.n_buffers, 0);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   EXPECT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   EXPECT_EQ(array.n_buffers, 1);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   EXPECT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_EQ(array.n_buffers, 2);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   EXPECT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(array.n_buffers, 3);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   EXPECT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_DATE64), EINVAL);
 }
@@ -76,13 +76,13 @@ TEST(ArrayTest, ArrayTestAllocateChildren) {
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAllocateChildren(&array, 0), NANOARROW_OK);
   EXPECT_EQ(array.n_children, 0);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAllocateChildren(
                 &array, std::numeric_limits<int64_t>::max() / sizeof(void*)),
             ENOMEM);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAllocateChildren(&array, 2), NANOARROW_OK);
@@ -98,7 +98,7 @@ TEST(ArrayTest, ArrayTestAllocateChildren) {
 
   EXPECT_EQ(ArrowArrayAllocateChildren(&array, 0), EINVAL);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestAllocateDictionary) {
@@ -113,7 +113,7 @@ TEST(ArrayTest, ArrayTestAllocateDictionary) {
 
   EXPECT_EQ(ArrowArrayAllocateDictionary(&array), EINVAL);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestInitFromSchema) {
@@ -133,8 +133,8 @@ TEST(ArrayTest, ArrayTestInitFromSchema) {
   EXPECT_EQ(array.children[0]->n_buffers, 2);
   EXPECT_EQ(array.children[1]->n_buffers, 3);
 
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(ArrayTest, ArrayTestSetBitmap) {
@@ -151,7 +151,7 @@ TEST(ArrayTest, ArrayTestSetBitmap) {
   EXPECT_EQ(bitmap_buffer[1], 0x01);
   EXPECT_EQ(ArrowArrayValidityBitmap(&array)->buffer.data, array.buffers[0]);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestSetBuffer) {
@@ -185,7 +185,7 @@ TEST(ArrayTest, ArrayTestSetBuffer) {
   // try to set a buffer that isn't, 0, 1, or 2
   EXPECT_EQ(ArrowArraySetBuffer(&array, 3, &buffer0), EINVAL);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestBuildByBuffer) {
@@ -238,7 +238,7 @@ TEST(ArrayTest, ArrayTestBuildByBuffer) {
                "Expected string array buffer 2 to have size >= 11 bytes but found buffer "
                "with 10 bytes");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestExplicitValidationLevel) {
@@ -295,7 +295,7 @@ TEST(ArrayTest, ArrayTestExplicitValidationLevel) {
                "Expected string array buffer 1 to have size >= 12 bytes but found buffer "
                "with 0 bytes");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestValidateMinimalBufferAccess) {
@@ -321,7 +321,7 @@ TEST(ArrayTest, ArrayTestValidateMinimalBufferAccess) {
   // ...restore the pointer so we don't leak memory
   ArrowArrayBuffer(&array, 1)->data = tmp;
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestAppendToNullArray) {
@@ -352,7 +352,7 @@ TEST(ArrayTest, ArrayTestAppendToNullArray) {
   buffer_view.size_bytes = 0;
   EXPECT_EQ(ArrowArrayAppendBytes(&array, buffer_view), EINVAL);
   EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("")), EINVAL);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestAppendToInt64Array) {
@@ -518,7 +518,7 @@ TEST(ArrayTest, ArrayTestAppendEmptyToString) {
   ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("")), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
   EXPECT_NE(array.buffers[2], nullptr);
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestAppendToUInt64Array) {
@@ -888,7 +888,7 @@ TEST(ArrayTest, ArrayTestAppendToBinaryArrayErrors) {
   item.size_bytes = static_cast<int64_t>(INT_MAX) + 1;
   EXPECT_EQ(ArrowArrayAppendBytes(&array, item), EOVERFLOW);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayTestAppendToIntervalArrayYearMonth) {
@@ -1342,8 +1342,8 @@ TEST(ArrayTest, ArrayTestAppendToListArrayErrors) {
   array.children[0]->length = static_cast<int64_t>(INT32_MAX) + 1;
   EXPECT_EQ(ArrowArrayFinishElement(&array), EOVERFLOW);
 
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(ArrayTest, ArrayTestAppendToStructArray) {
@@ -1535,8 +1535,8 @@ TEST(ArrayTest, ArrayTestAppendToUnionArrayErrors) {
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+us:1"), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), EINVAL);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestBasic) {
@@ -1602,7 +1602,7 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_STRING);
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1700,7 +1700,7 @@ TEST(ArrayTest, ArrayViewTestString) {
             EINVAL);
   EXPECT_STREQ(error.message, "[2] Expected element size >= 0");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1771,7 +1771,7 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
             EINVAL);
   EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1857,7 +1857,7 @@ TEST(ArrayTest, ArrayViewTestList) {
             EINVAL);
   EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1890,7 +1890,7 @@ TEST(ArrayTest, ArrayViewTestListGet) {
   EXPECT_EQ(ArrowArrayViewListChildOffset(&array_view, 2), 1);
   EXPECT_EQ(ArrowArrayViewListChildOffset(&array_view, 3), 2);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1923,7 +1923,7 @@ TEST(ArrayTest, ArrayViewTestLargeListGet) {
   EXPECT_EQ(ArrowArrayViewListChildOffset(&array_view, 2), 1);
   EXPECT_EQ(ArrowArrayViewListChildOffset(&array_view, 3), 2);
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -1978,7 +1978,7 @@ TEST(ArrayTest, ArrayViewTestLargeList) {
             EINVAL);
   EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -2044,8 +2044,8 @@ TEST(ArrayTest, ArrayViewTestStructArray) {
   EXPECT_EQ(array_view.children[0]->buffer_views[1].data.as_int32[0], 123);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestFixedSizeListArray) {
@@ -2088,8 +2088,8 @@ TEST(ArrayTest, ArrayViewTestFixedSizeListArray) {
   EXPECT_EQ(array_view.children[0]->buffer_views[1].data.as_int32[0], 123);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestDictionary) {
@@ -2134,7 +2134,7 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   item = ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1);
   EXPECT_EQ(std::string(item.data, item.size_bytes), "def");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // Setting a non-dictionary array should error
   struct ArrowError error;
@@ -2142,7 +2142,7 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
   EXPECT_STREQ(error.message, "Expected dictionary but found NULL");
 
-  array.release(&array);
+  ArrowArrayRelease(&array);
 
   // Setting a dictionary array to a non-dictionary array view should error
   ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
@@ -2151,8 +2151,8 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
   EXPECT_STREQ(error.message, "Expected NULL dictionary but found dictionary member");
 
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }
 
@@ -2260,8 +2260,8 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   EXPECT_EQ(array_view.union_type_id_map[128 + 1], 2);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestDenseUnionGet) {
@@ -2306,8 +2306,8 @@ TEST(ArrayTest, ArrayViewTestDenseUnionGet) {
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 2), NANOARROW_OK);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
@@ -2352,8 +2352,8 @@ TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
   EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 2), NANOARROW_OK);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 template <typename TypeClass>
@@ -2395,8 +2395,8 @@ void TestGetFromNumericArrayView() {
   EXPECT_EQ(buffer_view.size_bytes, 0);
 
   ArrowArrayViewReset(&array_view);
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
 
   // Array without nulls (Arrow does not allocate the validity buffer)
   builder = NumericBuilder<TypeClass>();
@@ -2422,8 +2422,8 @@ void TestGetFromNumericArrayView() {
   EXPECT_EQ(ArrowArrayViewGetUIntUnsafe(&array_view, 1), 2);
 
   ArrowArrayViewReset(&array_view);
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetNumeric) {
@@ -2472,8 +2472,8 @@ void TestGetFromBinary(BuilderClass& builder) {
   EXPECT_EQ(memcmp(buffer_view.data.as_char, "four", buffer_view.size_bytes), 0);
 
   ArrowArrayViewReset(&array_view);
-  array.release(&array);
-  schema.release(&schema);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetString) {
@@ -2526,8 +2526,8 @@ TEST(ArrayViewTest, ArrayViewTestGetIntervalYearMonth) {
   EXPECT_EQ(interval.months, -42);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetIntervalDayTime) {
@@ -2562,8 +2562,8 @@ TEST(ArrayViewTest, ArrayViewTestGetIntervalDayTime) {
   EXPECT_EQ(interval.ms, -42);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetIntervalMonthDayNano) {
@@ -2600,8 +2600,8 @@ TEST(ArrayViewTest, ArrayViewTestGetIntervalMonthDayNano) {
   EXPECT_EQ(interval.ns, -42);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetDecimal128) {
@@ -2637,8 +2637,8 @@ TEST(ArrayViewTest, ArrayViewTestGetDecimal128) {
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), -5678);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetDecimal256) {
@@ -2674,6 +2674,6 @@ TEST(ArrayViewTest, ArrayViewTestGetDecimal256) {
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), -5678);
 
   ArrowArrayViewReset(&array_view);
-  schema.release(&schema);
-  array.release(&array);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayRelease(&array);
 }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -184,6 +184,60 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
 
 /// @}
 
+/// \brief Move the contents of an src ArrowSchema into dst and set src->release to NULL
+/// \ingroup nanoarrow-arrow-cdata
+static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dst);
+
+/// \brief Call the release callback of an ArrowSchema
+/// \ingroup nanoarrow-arrow-cdata
+static inline void ArrowSchemaRelease(struct ArrowSchema* schema);
+
+/// \brief Move the contents of an src ArrowArray into dst and set src->release to NULL
+/// \ingroup nanoarrow-arrow-cdata
+static inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dst);
+
+/// \brief Call the release callback of an ArrowArray
+static inline void ArrowArrayRelease(struct ArrowArray* array);
+
+/// \brief Move the contents of an src ArrowArrayStream into dst and set src->release to
+/// NULL \ingroup nanoarrow-arrow-cdata
+static inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
+                                        struct ArrowArrayStream* dst);
+
+/// \brief Call the get_schema callback of an ArrowArrayStream
+/// \ingroup nanoarrow-arrow-cdata
+///
+/// Unlike the get_schema callback, this wrapper checks the return code
+/// and propagates the error reported by get_last_error into error. This
+/// makes it significantly less verbose to iterate over array streams
+/// using NANOARROW_RETURN_NOT_OK()-style error handling.
+static inline ArrowErrorCode ArrowArrayStreamGetSchema(
+    struct ArrowArrayStream* array_stream, struct ArrowSchema* out,
+    struct ArrowError* error);
+
+/// \brief Call the get_schema callback of an ArrowArrayStream
+/// \ingroup nanoarrow-arrow-cdata
+///
+/// Unlike the get_next callback, this wrapper checks the return code
+/// and propagates the error reported by get_last_error into error. This
+/// makes it significantly less verbose to iterate over array streams
+/// using NANOARROW_RETURN_NOT_OK()-style error handling.
+static inline ArrowErrorCode ArrowArrayStreamGetNext(
+    struct ArrowArrayStream* array_stream, struct ArrowArray* out,
+    struct ArrowError* error);
+
+/// \brief Call the get_next callback of an ArrowArrayStream
+/// \ingroup nanoarrow-arrow-cdata
+///
+/// Unlike the get_next callback, this function never returns NULL (i.e., its
+/// result is safe to use in printf-style error formatters). Null values from the
+/// original callback are reported as "<get_last_error() returned NULL>".
+static inline const char* ArrowArrayStreamGetLastError(
+    struct ArrowArrayStream* array_stream);
+
+/// \brief Call the release callback of an ArrowArrayStream
+static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream);
+
 /// \defgroup nanoarrow-errors Error handling
 ///
 /// Functions generally return an errno-compatible error code; functions that
@@ -203,20 +257,10 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
 ///
 /// @{
 
-/// \brief Error type containing a UTF-8 encoded message.
-struct ArrowError {
-  /// \brief A character buffer with space for an error message.
-  char message[1024];
-};
-
 /// \brief Ensure an ArrowError is null-terminated by zeroing the first character.
 ///
 /// If error is NULL, this function does nothing.
-static inline void ArrowErrorInit(struct ArrowError* error) {
-  if (error) {
-    error->message[0] = '\0';
-  }
-}
+static inline void ArrowErrorInit(struct ArrowError* error);
 
 /// \brief Set the contents of an error using printf syntax.
 ///
@@ -227,7 +271,7 @@ ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
 ///
 /// If error is NULL, returns "", or returns the contents of the error message
 /// otherwise.
-const char* ArrowErrorMessage(struct ArrowError* error);
+static inline const char* ArrowErrorMessage(struct ArrowError* error);
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -254,6 +254,15 @@ static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream
 /// NANOARROW_ASSERT_OK macros are provided to help propagate errors. C++ clients can use
 /// the helpers provided in the nanoarrow.hpp header to facilitate using C++ idioms
 /// for memory management and error propgagtion.
+///
+/// @{
+
+/// \brief Set the contents of an error using printf syntax.
+///
+/// If error is NULL, this function does nothing and returns NANOARROW_OK.
+ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
+
+/// @}
 
 /// \defgroup nanoarrow-utils Utility data structures
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -38,7 +38,6 @@
 #define ArrowNanoarrowVersion NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowNanoarrowVersion)
 #define ArrowNanoarrowVersionInt \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowNanoarrowVersionInt)
-#define ArrowErrorMessage NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowErrorMessage)
 #define ArrowMalloc NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowMalloc)
 #define ArrowRealloc NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowRealloc)
 #define ArrowFree NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowFree)

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -254,26 +254,6 @@ static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream
 /// NANOARROW_ASSERT_OK macros are provided to help propagate errors. C++ clients can use
 /// the helpers provided in the nanoarrow.hpp header to facilitate using C++ idioms
 /// for memory management and error propgagtion.
-///
-/// @{
-
-/// \brief Ensure an ArrowError is null-terminated by zeroing the first character.
-///
-/// If error is NULL, this function does nothing.
-static inline void ArrowErrorInit(struct ArrowError* error);
-
-/// \brief Set the contents of an error using printf syntax.
-///
-/// If error is NULL, this function does nothing and returns NANOARROW_OK.
-ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
-
-/// \brief Get the contents of an error
-///
-/// If error is NULL, returns "", or returns the contents of the error message
-/// otherwise.
-static inline const char* ArrowErrorMessage(struct ArrowError* error);
-
-/// @}
 
 /// \defgroup nanoarrow-utils Utility data structures
 ///

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -86,7 +86,8 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayStreamTest) {
   EXPECT_EQ(ArrowSchemaInitFromType(schema_in.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
   auto array_stream = nanoarrow::EmptyArrayStream::MakeUnique(schema_in.get());
   EXPECT_NE(array_stream->release, nullptr);
-  EXPECT_EQ(array_stream->get_schema(array_stream.get(), schema.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(array_stream.get(), schema.get(), nullptr),
+            NANOARROW_OK);
   EXPECT_STREQ(schema->format, "i");
   schema.reset();
   schema->format = NULL;
@@ -95,7 +96,8 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayStreamTest) {
   nanoarrow::UniqueArrayStream array_stream2 = std::move(array_stream);
   EXPECT_EQ(array_stream->release, nullptr);
   EXPECT_NE(array_stream2->release, nullptr);
-  EXPECT_EQ(array_stream2->get_schema(array_stream2.get(), schema.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(array_stream2.get(), schema.get(), nullptr),
+            NANOARROW_OK);
   EXPECT_STREQ(schema->format, "i");
   schema.reset();
   schema->format = NULL;
@@ -104,7 +106,8 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayStreamTest) {
   nanoarrow::UniqueArrayStream array_stream3(array_stream2.get());
   EXPECT_EQ(array_stream2->release, nullptr);
   EXPECT_NE(array_stream3->release, nullptr);
-  EXPECT_EQ(array_stream3->get_schema(array_stream2.get(), schema.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(array_stream2.get(), schema.get(), nullptr),
+            NANOARROW_OK);
   EXPECT_STREQ(schema->format, "i");
 
   // releasing should clear the release callback
@@ -195,11 +198,12 @@ TEST(NanoarrowHppTest, NanoarrowHppEmptyArrayStreamTest) {
   nanoarrow::UniqueArrayStream array_stream;
   nanoarrow::EmptyArrayStream(schema_in.get()).ToArrayStream(array_stream.get());
 
-  EXPECT_EQ(array_stream->get_schema(array_stream.get(), schema.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetSchema(array_stream.get(), schema.get(), nullptr),
+            NANOARROW_OK);
   EXPECT_STREQ(schema->format, "i");
-  EXPECT_EQ(array_stream->get_next(array_stream.get(), &array), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(array_stream.get(), &array, nullptr), NANOARROW_OK);
   EXPECT_EQ(array.release, nullptr);
-  EXPECT_STREQ(array_stream->get_last_error(array_stream.get()), "");
+  EXPECT_STREQ(ArrowArrayStreamGetLastError(array_stream.get()), "");
 }
 
 TEST(NanoarrowHppTest, NanoarrowHppVectorArrayStreamTest) {
@@ -224,13 +228,15 @@ TEST(NanoarrowHppTest, NanoarrowHppVectorArrayStreamTest) {
             NANOARROW_OK);
 
   nanoarrow::UniqueArray array;
-  EXPECT_EQ(array_stream->get_next(array_stream.get(), array.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(array_stream.get(), array.get(), nullptr),
+            NANOARROW_OK);
 
   ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(array_view.get(), 0), 1234);
   array.reset();
 
-  EXPECT_EQ(array_stream->get_next(array_stream.get(), array.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayStreamGetNext(array_stream.get(), array.get(), nullptr),
+            NANOARROW_OK);
   EXPECT_EQ(array->release, nullptr);
 
   EXPECT_STREQ(array_stream->get_last_error(array_stream.get()), "");

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -67,7 +67,7 @@ class TestingJSONWriter {
     out << R"({"schema": )";
 
     nanoarrow::UniqueSchema schema;
-    NANOARROW_RETURN_NOT_OK(stream->get_schema(stream, schema.get()));
+    NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetSchema(stream, schema.get(), nullptr));
     NANOARROW_RETURN_NOT_OK(WriteSchema(out, schema.get()));
 
     nanoarrow::UniqueArrayView array_view;
@@ -79,7 +79,7 @@ class TestingJSONWriter {
     nanoarrow::UniqueArray array;
     std::string sep;
     do {
-      NANOARROW_RETURN_NOT_OK(stream->get_next(stream, array.get()));
+      NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetNext(stream, array.get(), nullptr));
       if (array->release == nullptr) {
         break;
       }
@@ -1825,10 +1825,10 @@ class TestingJSONComparison {
     // Read both schemas
     nanoarrow::UniqueSchema actual_schema;
     nanoarrow::UniqueSchema expected_schema;
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(actual->get_schema(actual, actual_schema.get()),
-                                       error);
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-        expected->get_schema(expected, expected_schema.get()), error);
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayStreamGetSchema(actual, actual_schema.get(), error));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayStreamGetSchema(expected, expected_schema.get(), error));
 
     // Compare them and return if they are not equal
     NANOARROW_RETURN_NOT_OK(
@@ -1850,10 +1850,9 @@ class TestingJSONComparison {
       // Read a batch from each stream
       actual_array.reset();
       expected_array.reset();
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(actual->get_next(actual, actual_array.get()),
-                                         error);
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          expected->get_next(expected, expected_array.get()), error);
+      NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetNext(actual, actual_array.get(), error));
+      NANOARROW_RETURN_NOT_OK(
+          ArrowArrayStreamGetNext(expected, expected_array.get(), error));
 
       // Check the finished/unfinished status of both streams
       if (actual_array->release == nullptr && expected_array->release != nullptr) {

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -243,10 +243,9 @@ ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
 #define NANOARROW_ASSERT_OK(EXPR) \
   _NANOARROW_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, #EXPR)
 
-#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)            \
-  do {                                                    \
-    const int NAME = (EXPR);                              \
-    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(NAME, EXPR_STR); \
+#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)         \
+  do {                                                 \
+    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(0, EXPR_STR); \
   } while (0)
 
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)
@@ -265,8 +264,8 @@ static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* 
 
 static inline void ArrowSchemaRelease(struct ArrowSchema* schema) {
   NANOARROW_DCHECK(schema != NULL);
-
   schema->release(schema);
+  NANOARROW_DCHECK(schema->release == NULL);
 }
 
 static inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dst) {
@@ -279,8 +278,8 @@ static inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dst
 
 static inline void ArrowArrayRelease(struct ArrowArray* array) {
   NANOARROW_DCHECK(array != NULL);
-
   array->release(array);
+  NANOARROW_DCHECK(array->release == NULL);
 }
 
 static inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
@@ -333,6 +332,7 @@ static inline ArrowErrorCode ArrowArrayStreamGetNext(
 static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream) {
   NANOARROW_DCHECK(array_stream != NULL);
   array_stream->release(array_stream);
+  NANOARROW_DCHECK(array_stream->release == NULL);
 }
 
 static char _ArrowIsLittleEndian(void) {

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -207,11 +207,24 @@ static inline const char* ArrowErrorMessage(struct ArrowError* error) {
   }
 }
 
-/// \brief Set the contents of an error using printf syntax.
+/// \brief Set the contents of an error from an existing null-terminated string
 /// \ingroup nanoarrow-errors
 ///
-/// If error is NULL, this function does nothing and returns NANOARROW_OK.
-ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
+/// If error is NULL, this function does nothing.
+static inline void ArrowErrorSetString(struct ArrowError* error, const char* src) {
+  if (error == NULL) {
+    return;
+  }
+
+  int64_t src_len = strlen(src);
+  if (src_len >= ((int64_t)sizeof(error->message))) {
+    memcpy(error->message, src, sizeof(error->message) - 1);
+    error->message[sizeof(error->message) - 1] = '\0';
+  } else {
+    memcpy(error->message, src, src_len);
+    error->message[src_len] = '\0';
+  }
+}
 
 /// \brief Check the result of an expression and return it if not NANOARROW_OK
 /// \ingroup nanoarrow-errors
@@ -323,7 +336,7 @@ static inline ArrowErrorCode ArrowArrayStreamGetSchema(
 
   int result = array_stream->get_schema(array_stream, out);
   if (result != NANOARROW_OK && error != NULL) {
-    ArrowErrorSet(error, "%s", ArrowArrayStreamGetLastError(array_stream));
+    ArrowErrorSetString(error, ArrowArrayStreamGetLastError(array_stream));
   }
 
   return result;
@@ -336,7 +349,7 @@ static inline ArrowErrorCode ArrowArrayStreamGetNext(
 
   int result = array_stream->get_next(array_stream, out);
   if (result != NANOARROW_OK && error != NULL) {
-    ArrowErrorSet(error, "%s", ArrowArrayStreamGetLastError(array_stream));
+    ArrowErrorSetString(error, ArrowArrayStreamGetLastError(array_stream));
   }
 
   return result;

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -269,9 +269,9 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 #define NANOARROW_ASSERT_OK(EXPR) \
   _NANOARROW_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, #EXPR)
 
-#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)                       \
-  do {                                                               \
-    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(ENOTRECOVERABLE, EXPR_STR); \
+#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)          \
+  do {                                                  \
+    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(-1, EXPR_STR); \
   } while (0)
 
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -184,12 +184,21 @@ struct ArrowError {
   char message[1024];
 };
 
+/// \brief Ensure an ArrowError is null-terminated by zeroing the first character.
+/// \ingroup nanoarrow-errors
+///
+/// If error is NULL, this function does nothing.
 static inline void ArrowErrorInit(struct ArrowError* error) {
   if (error != NULL) {
     error->message[0] = '\0';
   }
 }
 
+/// \brief Get the contents of an error
+/// \ingroup nanoarrow-errors
+///
+/// If error is NULL, returns "", or returns the contents of the error message
+/// otherwise.
 static inline const char* ArrowErrorMessage(struct ArrowError* error) {
   if (error == NULL) {
     return "";
@@ -198,6 +207,10 @@ static inline const char* ArrowErrorMessage(struct ArrowError* error) {
   }
 }
 
+/// \brief Set the contents of an error using printf syntax.
+/// \ingroup nanoarrow-errors
+///
+/// If error is NULL, this function does nothing and returns NANOARROW_OK.
 ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
 
 /// \brief Check the result of an expression and return it if not NANOARROW_OK

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -243,11 +243,11 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
       _NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, ERROR_EXPR, #EXPR)
 
 #if defined(NANOARROW_DEBUG) && !defined(NANOARROW_PRINT_AND_DIE)
-#define NANOARROW_PRINT_AND_DIE(VALUE, EXPR_STR)                                  \
-  do {                                                                            \
-    fprintf(stderr, "%s failed with errno %d\n* %s:%d\n", EXPR_STR, (int)(VALUE), \
-            __FILE__, (int)__LINE__);                                             \
-    abort();                                                                      \
+#define NANOARROW_PRINT_AND_DIE(VALUE, EXPR_STR)                                 \
+  do {                                                                           \
+    fprintf(stderr, "%s failed with code %d\n* %s:%d\n", EXPR_STR, (int)(VALUE), \
+            __FILE__, (int)__LINE__);                                            \
+    abort();                                                                     \
   } while (0)
 #endif
 
@@ -269,9 +269,9 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 #define NANOARROW_ASSERT_OK(EXPR) \
   _NANOARROW_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, #EXPR)
 
-#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)         \
-  do {                                                 \
-    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(0, EXPR_STR); \
+#define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)                       \
+  do {                                                               \
+    if (!(EXPR)) NANOARROW_PRINT_AND_DIE(ENOTRECOVERABLE, EXPR_STR); \
   } while (0)
 
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -22,7 +22,7 @@
 
 #include "nanoarrow.h"
 
-static void ArrowSchemaRelease(struct ArrowSchema* schema) {
+static void ArrowSchemaReleaseInternal(struct ArrowSchema* schema) {
   if (schema->format != NULL) ArrowFree((void*)schema->format);
   if (schema->name != NULL) ArrowFree((void*)schema->name);
   if (schema->metadata != NULL) ArrowFree((void*)schema->metadata);
@@ -171,7 +171,7 @@ void ArrowSchemaInit(struct ArrowSchema* schema) {
   schema->children = NULL;
   schema->dictionary = NULL;
   schema->private_data = NULL;
-  schema->release = &ArrowSchemaRelease;
+  schema->release = &ArrowSchemaReleaseInternal;
 }
 
 ArrowErrorCode ArrowSchemaSetType(struct ArrowSchema* schema, enum ArrowType type) {

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -34,7 +34,7 @@ static void ArrowSchemaReleaseInternal(struct ArrowSchema* schema) {
     for (int64_t i = 0; i < schema->n_children; i++) {
       if (schema->children[i] != NULL) {
         if (schema->children[i]->release != NULL) {
-          schema->children[i]->release(schema->children[i]);
+          ArrowSchemaRelease(schema->children[i]);
         }
 
         ArrowFree(schema->children[i]);
@@ -49,7 +49,7 @@ static void ArrowSchemaReleaseInternal(struct ArrowSchema* schema) {
   // release() callback.
   if (schema->dictionary != NULL) {
     if (schema->dictionary->release != NULL) {
-      schema->dictionary->release(schema->dictionary);
+      ArrowSchemaRelease(schema->dictionary);
     }
 
     ArrowFree(schema->dictionary);
@@ -207,7 +207,7 @@ ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema, enum ArrowTyp
 
   int result = ArrowSchemaSetType(schema, type);
   if (result != NANOARROW_OK) {
-    schema->release(schema);
+    ArrowSchemaRelease(schema);
     return result;
   }
 
@@ -489,7 +489,7 @@ ArrowErrorCode ArrowSchemaDeepCopy(const struct ArrowSchema* schema,
 
   int result = ArrowSchemaSetFormat(schema_out, schema->format);
   if (result != NANOARROW_OK) {
-    schema_out->release(schema_out);
+    ArrowSchemaRelease(schema_out);
     return result;
   }
 
@@ -497,26 +497,26 @@ ArrowErrorCode ArrowSchemaDeepCopy(const struct ArrowSchema* schema,
 
   result = ArrowSchemaSetName(schema_out, schema->name);
   if (result != NANOARROW_OK) {
-    schema_out->release(schema_out);
+    ArrowSchemaRelease(schema_out);
     return result;
   }
 
   result = ArrowSchemaSetMetadata(schema_out, schema->metadata);
   if (result != NANOARROW_OK) {
-    schema_out->release(schema_out);
+    ArrowSchemaRelease(schema_out);
     return result;
   }
 
   result = ArrowSchemaAllocateChildren(schema_out, schema->n_children);
   if (result != NANOARROW_OK) {
-    schema_out->release(schema_out);
+    ArrowSchemaRelease(schema_out);
     return result;
   }
 
   for (int64_t i = 0; i < schema->n_children; i++) {
     result = ArrowSchemaDeepCopy(schema->children[i], schema_out->children[i]);
     if (result != NANOARROW_OK) {
-      schema_out->release(schema_out);
+      ArrowSchemaRelease(schema_out);
       return result;
     }
   }
@@ -524,13 +524,13 @@ ArrowErrorCode ArrowSchemaDeepCopy(const struct ArrowSchema* schema,
   if (schema->dictionary != NULL) {
     result = ArrowSchemaAllocateDictionary(schema_out);
     if (result != NANOARROW_OK) {
-      schema_out->release(schema_out);
+      ArrowSchemaRelease(schema_out);
       return result;
     }
 
     result = ArrowSchemaDeepCopy(schema->dictionary, schema_out->dictionary);
     if (result != NANOARROW_OK) {
-      schema_out->release(schema_out);
+      ArrowSchemaRelease(schema_out);
       return result;
     }
   }

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -63,14 +63,14 @@ TEST(SchemaTest, SchemaInit) {
   EXPECT_EQ(schema.children[0]->release, nullptr);
   EXPECT_EQ(schema.children[1]->release, nullptr);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   EXPECT_EQ(schema.release, nullptr);
 
   ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaAllocateChildren(
                 &schema, std::numeric_limits<int64_t>::max() / sizeof(void*)),
             ENOMEM);
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 static void ExpectSchemaInitOk(enum ArrowType type,
@@ -333,7 +333,7 @@ TEST(SchemaTest, SchemaInitUnion) {
   EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_NA, 1), EINVAL);
   EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, -1), EINVAL);
   EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 128), EINVAL);
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 0),
@@ -341,7 +341,7 @@ TEST(SchemaTest, SchemaInitUnion) {
   EXPECT_STREQ(schema.format, "+us:");
   EXPECT_EQ(schema.n_children, 0);
   // The zero-case union isn't supported by Arrow C++'s C data interface implementation
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeUnion(&schema, NANOARROW_TYPE_SPARSE_UNION, 1),
@@ -396,7 +396,7 @@ TEST(SchemaTest, SchemaSetFormat) {
   EXPECT_EQ(ArrowSchemaSetFormat(&schema, nullptr), NANOARROW_OK);
   EXPECT_EQ(schema.format, nullptr);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaTest, SchemaSetName) {
@@ -409,7 +409,7 @@ TEST(SchemaTest, SchemaSetName) {
   EXPECT_EQ(ArrowSchemaSetName(&schema, nullptr), NANOARROW_OK);
   EXPECT_EQ(schema.name, nullptr);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaTest, SchemaSetMetadata) {
@@ -425,7 +425,7 @@ TEST(SchemaTest, SchemaSetMetadata) {
   EXPECT_EQ(ArrowSchemaSetMetadata(&schema, nullptr), NANOARROW_OK);
   EXPECT_EQ(schema.metadata, nullptr);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaTest, SchemaAllocateDictionary) {
@@ -435,7 +435,7 @@ TEST(SchemaTest, SchemaAllocateDictionary) {
   EXPECT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(schema.dictionary->release, nullptr);
   EXPECT_EQ(ArrowSchemaAllocateDictionary(&schema), EEXIST);
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaTest, SchemaCopySimpleType) {
@@ -448,7 +448,7 @@ TEST(SchemaTest, SchemaCopySimpleType) {
   ASSERT_NE(schema_copy.release, nullptr);
   EXPECT_STREQ(schema.format, "i");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   schema_copy.release(&schema_copy);
 }
 
@@ -466,7 +466,7 @@ TEST(SchemaTest, SchemaCopyNestedType) {
   EXPECT_STREQ(schema_copy.children[0]->format, "i");
   EXPECT_STREQ(schema_copy.children[0]->name, "col1");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   schema_copy.release(&schema_copy);
 }
 
@@ -482,7 +482,7 @@ TEST(SchemaTest, SchemaCopyDictType) {
   ASSERT_NE(schema_copy.dictionary, nullptr);
   EXPECT_STREQ(schema_copy.dictionary->format, "l");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   schema_copy.release(&schema_copy);
 }
 
@@ -500,7 +500,7 @@ TEST(SchemaTest, SchemaCopyFlags) {
   ASSERT_EQ(schema.flags, schema_copy.flags);
   ASSERT_FALSE(schema_copy.flags & ARROW_FLAG_NULLABLE);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
   schema_copy.release(&schema_copy);
 }
 
@@ -523,7 +523,7 @@ TEST(SchemaTest, SchemaCopyMetadata) {
   EXPECT_EQ(int_field->name(), int_field_roundtrip->name());
   EXPECT_EQ(int_field_roundtrip->metadata()->Get("some_key").ValueOrDie(), "some_value");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitErrors) {
@@ -559,7 +559,7 @@ TEST(SchemaViewTest, SchemaViewInitErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Error parsing schema->format 'n*': parsed 1/2 characters");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 void ExpectSimpleTypeOk(std::shared_ptr<DataType> arrow_t, enum ArrowType nanoarrow_t,
@@ -584,7 +584,7 @@ void ExpectSimpleTypeOk(std::shared_ptr<DataType> arrow_t, enum ArrowType nanoar
 
   EXPECT_EQ(ArrowSchemaToStdString(&schema), formatted);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitSimple) {
@@ -599,7 +599,7 @@ TEST(SchemaViewTest, SchemaViewInitSimple) {
   EXPECT_EQ(schema_view.extension_name.data, nullptr);
   EXPECT_EQ(schema_view.extension_metadata.data, nullptr);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "na");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ExpectSimpleTypeOk(boolean(), NANOARROW_TYPE_BOOL, 1, "bool");
   ExpectSimpleTypeOk(int8(), NANOARROW_TYPE_INT8, 8, "int8");
@@ -626,7 +626,7 @@ TEST(SchemaViewTest, SchemaViewInitSimpleErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected schema with 0 children but found 2 children");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitDecimal) {
@@ -651,7 +651,7 @@ TEST(SchemaViewTest, SchemaViewInitDecimal) {
   EXPECT_EQ(schema_view.decimal_precision, 5);
   EXPECT_EQ(schema_view.decimal_scale, 6);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "decimal128(5, 6)");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*decimal256(5, 6), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -670,7 +670,7 @@ TEST(SchemaViewTest, SchemaViewInitDecimal) {
   EXPECT_EQ(schema_view.decimal_precision, 5);
   EXPECT_EQ(schema_view.decimal_scale, 6);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "decimal256(5, 6)");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitDecimalErrors) {
@@ -715,7 +715,7 @@ TEST(SchemaViewTest, SchemaViewInitDecimalErrors) {
                "Error parsing schema->format: Expected decimal bitwidth of 128 or 256 "
                "but found 127");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
@@ -738,7 +738,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(schema_view.fixed_size, 123);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "fixed_size_binary(123)");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*utf8(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -754,7 +754,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 32);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "string");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*binary(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -770,7 +770,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 32);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "binary");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*large_binary(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -786,7 +786,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 64);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "large_binary");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*large_utf8(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -802,7 +802,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 64);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "large_string");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitBinaryAndStringErrors) {
@@ -831,7 +831,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndStringErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected size > 0 for fixed size binary but found size 0");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeDate) {
@@ -844,14 +844,14 @@ TEST(SchemaViewTest, SchemaViewInitTimeDate) {
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_DATE32);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "date32");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*date64(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_DATE64);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "date64");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeTime) {
@@ -865,7 +865,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTime) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_SECOND);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "time32('s')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*time32(TimeUnit::MILLI), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -873,7 +873,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTime) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MILLI);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "time32('ms')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*time64(TimeUnit::MICRO), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -881,7 +881,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTime) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MICRO);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "time64('us')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*time64(TimeUnit::NANO), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -889,7 +889,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTime) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_NANO);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "time64('ns')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeTimestamp) {
@@ -904,7 +904,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTimestamp) {
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_SECOND);
   EXPECT_STREQ(schema_view.timezone, "America/Halifax");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "timestamp('s', 'America/Halifax')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*timestamp(TimeUnit::MILLI, "America/Halifax"), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -913,7 +913,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTimestamp) {
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MILLI);
   EXPECT_STREQ(schema_view.timezone, "America/Halifax");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "timestamp('ms', 'America/Halifax')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*timestamp(TimeUnit::MICRO, "America/Halifax"), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -922,7 +922,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTimestamp) {
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MICRO);
   EXPECT_STREQ(schema_view.timezone, "America/Halifax");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "timestamp('us', 'America/Halifax')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*timestamp(TimeUnit::NANO, "America/Halifax"), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -931,7 +931,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeTimestamp) {
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_NANO);
   EXPECT_STREQ(schema_view.timezone, "America/Halifax");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "timestamp('ns', 'America/Halifax')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeDuration) {
@@ -945,7 +945,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeDuration) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_SECOND);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "duration('s')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*duration(TimeUnit::MILLI), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -953,7 +953,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeDuration) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MILLI);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "duration('ms')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*duration(TimeUnit::MICRO), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -961,7 +961,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeDuration) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_MICRO);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "duration('us')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*duration(TimeUnit::NANO), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -969,7 +969,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeDuration) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT64);
   EXPECT_EQ(schema_view.time_unit, NANOARROW_TIME_UNIT_NANO);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "duration('ns')");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeInterval) {
@@ -982,21 +982,21 @@ TEST(SchemaViewTest, SchemaViewInitTimeInterval) {
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_INTERVAL_MONTHS);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INTERVAL_MONTHS);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "interval_months");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*day_time_interval(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_INTERVAL_DAY_TIME);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INTERVAL_DAY_TIME);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "interval_day_time");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*month_day_nano_interval(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "interval_month_day_nano");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitTimeErrors) {
@@ -1046,7 +1046,7 @@ TEST(SchemaViewTest, SchemaViewInitTimeErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Error parsing schema->format: Expected ':' following 'tss' but found ''");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedList) {
@@ -1068,7 +1068,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedList) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 32);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "list<item: int32>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*large_list(int32()), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -1084,7 +1084,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedList) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 64);
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "large_list<item: int32>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*fixed_size_list(int32(), 123), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -1102,7 +1102,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedList) {
   EXPECT_EQ(schema_view.fixed_size, 123);
   EXPECT_EQ(schema_view.layout.child_size_elements, 123);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "fixed_size_list(123)<item: int32>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewNestedListErrors) {
@@ -1126,7 +1126,7 @@ TEST(SchemaViewTest, SchemaViewNestedListErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected schema with 1 children but found 0 children");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedStruct) {
@@ -1154,7 +1154,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedStruct) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, schema.children[0], &error), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, schema.children[1], &error), NANOARROW_OK);
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedStructErrors) {
@@ -1181,7 +1181,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedStructErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected valid schema at schema->children[0] but found NULL");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedMap) {
@@ -1202,7 +1202,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedMap) {
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema),
             "map<entries: struct<key: int32, value: int32>>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
@@ -1216,7 +1216,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected schema with 1 children but found 2 children");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+m"), NANOARROW_OK);
@@ -1227,7 +1227,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected child of map type to have 2 children but found 0");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   ASSERT_EQ(ArrowSchemaSetFormat(&schema, "+m"), NANOARROW_OK);
@@ -1244,7 +1244,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected format of child of map type to be '+s' but found '+us:0,1'");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   EXPECT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_MAP), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaSetType(schema.children[0]->children[0], NANOARROW_TYPE_INT32),
@@ -1262,7 +1262,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedMapErrors) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Expected key of map type to be non-nullable but was nullable");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
@@ -1285,7 +1285,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_STREQ(schema_view.union_type_ids, "0");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "dense_union([0])<col: int32>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ARROW_EXPECT_OK(ExportType(*sparse_union({field("col", int32())}), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
@@ -1302,7 +1302,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnion) {
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_STREQ(schema_view.union_type_ids, "0");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "sparse_union([0])<col: int32>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitNestedUnionErrors) {
@@ -1338,7 +1338,7 @@ TEST(SchemaViewTest, SchemaViewInitNestedUnionErrors) {
                "Error parsing schema->format: Expected union type_ids parameter to be a "
                "comma-separated list of 0 values between 0 and 127 but found ','");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitInvalidSpecErrors) {
@@ -1353,7 +1353,7 @@ TEST(SchemaViewTest, SchemaViewInitInvalidSpecErrors) {
                "Error parsing schema->format: Expected nested type "
                "format string but found '+Z'");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitDictionary) {
@@ -1366,7 +1366,7 @@ TEST(SchemaViewTest, SchemaViewInitDictionary) {
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_DICTIONARY);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "dictionary(int32)<string>");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitDictionaryErrors) {
@@ -1378,7 +1378,7 @@ TEST(SchemaViewTest, SchemaViewInitDictionaryErrors) {
   ASSERT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Expected non-released schema");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 
   ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
@@ -1388,7 +1388,7 @@ TEST(SchemaViewTest, SchemaViewInitDictionaryErrors) {
   EXPECT_STREQ(
       ArrowErrorMessage(&error),
       "Expected dictionary schema index type to be an integral type but found '+s'");
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitExtension) {
@@ -1411,7 +1411,7 @@ TEST(SchemaViewTest, SchemaViewInitExtension) {
             "test metadata");
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "arrow.test.ext_name{int32}");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaViewInitExtensionDictionary) {
@@ -1437,7 +1437,7 @@ TEST(SchemaViewTest, SchemaViewInitExtensionDictionary) {
   EXPECT_EQ(ArrowSchemaToStdString(&schema),
             "arrow.test.ext_name{dictionary(int32)<string>}");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaFormatNotRecursive) {
@@ -1446,7 +1446,7 @@ TEST(SchemaViewTest, SchemaFormatNotRecursive) {
       ExportType(*struct_({field("col1", int32()), field("col2", int64())}), &schema));
   EXPECT_EQ(ArrowSchemaToStdString(&schema, false), "struct");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaFormatEmptyNested) {
@@ -1454,7 +1454,7 @@ TEST(SchemaViewTest, SchemaFormatEmptyNested) {
   ARROW_EXPECT_OK(ExportType(*struct_({}), &schema));
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "struct<>");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(SchemaViewTest, SchemaFormatInvalid) {
@@ -1469,7 +1469,7 @@ TEST(SchemaViewTest, SchemaFormatInvalid) {
             "[invalid: Error parsing schema->format: Expected a null-terminated string "
             "but found NULL]");
 
-  schema.release(&schema);
+  ArrowSchemaRelease(&schema);
 }
 
 TEST(MetadataTest, Metadata) {

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -449,7 +449,7 @@ TEST(SchemaTest, SchemaCopySimpleType) {
   EXPECT_STREQ(schema.format, "i");
 
   ArrowSchemaRelease(&schema);
-  schema_copy.release(&schema_copy);
+  ArrowSchemaRelease(&schema_copy);
 }
 
 TEST(SchemaTest, SchemaCopyNestedType) {
@@ -467,7 +467,7 @@ TEST(SchemaTest, SchemaCopyNestedType) {
   EXPECT_STREQ(schema_copy.children[0]->name, "col1");
 
   ArrowSchemaRelease(&schema);
-  schema_copy.release(&schema_copy);
+  ArrowSchemaRelease(&schema_copy);
 }
 
 TEST(SchemaTest, SchemaCopyDictType) {
@@ -483,7 +483,7 @@ TEST(SchemaTest, SchemaCopyDictType) {
   EXPECT_STREQ(schema_copy.dictionary->format, "l");
 
   ArrowSchemaRelease(&schema);
-  schema_copy.release(&schema_copy);
+  ArrowSchemaRelease(&schema_copy);
 }
 
 TEST(SchemaTest, SchemaCopyFlags) {
@@ -501,7 +501,7 @@ TEST(SchemaTest, SchemaCopyFlags) {
   ASSERT_FALSE(schema_copy.flags & ARROW_FLAG_NULLABLE);
 
   ArrowSchemaRelease(&schema);
-  schema_copy.release(&schema_copy);
+  ArrowSchemaRelease(&schema_copy);
 }
 
 TEST(SchemaTest, SchemaCopyMetadata) {

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -28,7 +28,7 @@ const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 
 int ArrowNanoarrowVersionInt(void) { return NANOARROW_VERSION_INT; }
 
-int ArrowErrorSet(struct ArrowError* error, const char* fmt, ...) {
+ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...) {
   if (error == NULL) {
     return NANOARROW_OK;
   }
@@ -46,14 +46,6 @@ int ArrowErrorSet(struct ArrowError* error, const char* fmt, ...) {
     return ERANGE;
   } else {
     return NANOARROW_OK;
-  }
-}
-
-const char* ArrowErrorMessage(struct ArrowError* error) {
-  if (error == NULL) {
-    return "";
-  } else {
-    return error->message;
   }
 }
 

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -62,6 +62,25 @@ TEST(ErrorTest, ErrorTestSetOverrun) {
   EXPECT_EQ(ArrowErrorSet(&error, "%ls", bad_string), EINVAL);
 }
 
+TEST(ErrorTest, ErrorTestSetString) {
+  struct ArrowError error;
+  ArrowErrorSetString(&error, "a pretty short error string");
+  EXPECT_STREQ(ArrowErrorMessage(&error), "a pretty short error string");
+}
+
+TEST(ErrorTest, ErrorTestSetStringOverrun) {
+  struct ArrowError error;
+  char big_error[2048];
+  const char* a_few_chars = "abcdefg";
+  for (int i = 0; i < 2047; i++) {
+    big_error[i] = a_few_chars[i % strlen(a_few_chars)];
+  }
+  big_error[2047] = '\0';
+
+  ArrowErrorSetString(&error, big_error);
+  EXPECT_EQ(std::string(ArrowErrorMessage(&error)), std::string(big_error, 1023));
+}
+
 #if defined(NANOARROW_DEBUG)
 #undef NANOARROW_PRINT_AND_DIE
 #define NANOARROW_PRINT_AND_DIE(VALUE, EXPR_STR)             \


### PR DESCRIPTION
This PR adds thin wrappers around C function pointers (like is done in Arrow C++) for Arrow C Data/Stream interface structures and uses them in all tests and internal code. The motivation for this was:

- Calling `x.release(&x)` is a tiny bit verbose and involves specifying `x` twice
- Wrappers make it easier to debug (by breakpoint or via debug checks)
- Iterating through streams is very verbose if you want to catch all the error messages (in some places of the code it looks like I didn't bother, and in other places it looks like I assumed that the result of `get_last_error` was non-NULL, which is not true). The wrappers let you do `NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetNext(stream, out, error))` which better integrates into the nanoarrow error handling pattern.

The changes are:

- Release functions were added to nanoarrow_types.h
- A few error handling functions were moved to nanoarrow_types.h since they were used in the wrappers
- All function pointer calls I could find were updated to use the wrapper functions