### PR TITLE
Correct typo in testing.rst

### DIFF
--- a/docs/source/reference/testing.rst
+++ b/docs/source/reference/testing.rst
@@ -15,7 +15,7 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-Teseting API Reference
+Testing API Reference
 ======================
 
 .. doxygengroup:: nanoarrow_testing


### PR DESCRIPTION
This corrects a one-char typo