### PR TITLE
chore: Enable more compiler warnings

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Check R CMD INSTALL
         env:
           PKG_CPPFLAGS: "-DNANOARROW_DEBUG"
-          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-sign-conversion"
+          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion"
         run: |
           R CMD INSTALL r --preclean
         shell: bash

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -64,11 +64,13 @@ jobs:
         if: matrix.config.r == 'devel'
         run: sudo apt-get install -y valgrind
 
-      # Until new pkgbuild is on CRAN, we do the install step to ensure
-      # the C library is vendored from this commit
-      - name: Vendor nanoarrow into the R package
+      # Check package install with extra warning flags
+      - name: Check R CMD INSTALL
+        env:
+          PKG_CPPFLAGS: "-DNANOARROW_DEBUG"
+          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-sign-conversion"
         run: |
-          R CMD INSTALL r
+          R CMD INSTALL r --preclean
         shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -60,15 +60,13 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install valgrind on r-devel
-        if: matrix.config.r == 'devel'
-        run: sudo apt-get install -y valgrind
-
-      # Check package install with extra warning flags
+      # Check package install with extra warning flags except on Windows,
+      # where the R headers cause some problems
       - name: Check R CMD INSTALL
+        if: matrix.config.os != "windows-latest"
         env:
           PKG_CPPFLAGS: "-DNANOARROW_DEBUG"
-          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion"
+          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion -Wno-cast-function-type"
         run: |
           R CMD INSTALL r --preclean
         shell: bash

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -63,7 +63,7 @@ jobs:
       # Check package install with extra warning flags except on Windows,
       # where the R headers cause some problems
       - name: Check R CMD INSTALL
-        if: matrix.config.os != "windows-latest"
+        if: matrix.config.os != 'windows-latest'
         env:
           PKG_CPPFLAGS: "-DNANOARROW_DEBUG"
           PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion -Wno-cast-function-type"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,20 +127,24 @@ else()
                              PRIVATE -Wall
                                      -Werror
                                      -Wextra
+                                     -Wpedantic
                                      -Wno-type-limits
                                      -Wno-unused-parameter
                                      -Wmaybe-uninitialized
-                                     -Wpedantic
-                                     -Wunused-result)
+                                     -Wunused-result
+                                     -Wconversion
+                                     -Wno-sign-conversion)
     elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
                                                         "Clang")
       target_compile_options(nanoarrow
                              PRIVATE -Wall
                                      -Werror
                                      -Wextra
+                                     -Wpedantic
                                      -Wdocumentation
                                      -Wno-unused-parameter
-                                     -Wshorten-64-to-32)
+                                     -Wconversion
+                                     -Wno-sign-conversion)
     endif()
   endif()
 

--- a/r/R/buffer.R
+++ b/r/R/buffer.R
@@ -42,14 +42,21 @@ as_nanoarrow_buffer.nanoarrow_buffer <- function(x, ...) {
 
 #' @export
 as_nanoarrow_buffer.default <- function(x, ...) {
+  msg <- NULL
   result <- tryCatch(
     .Call(nanoarrow_c_as_buffer_default, x),
-    error = function(...) NULL
+    error = function(e) {
+      msg <<- conditionMessage(e)
+      NULL
+    }
   )
 
-  if (is.null(result)) {
+  if (is.null(result) && is.null(msg)) {
     cls <- paste(class(x), collapse = "/")
     stop(sprintf("Can't convert object of type %s to nanoarrow_buffer", cls))
+  } else if (is.null(result)) {
+    cls <- paste(class(x), collapse = "/")
+    stop(sprintf("Can't convert object of type %s to nanoarrow_buffer: %s", cls, msg))
   }
 
   result

--- a/r/src/altrep.c
+++ b/r/src/altrep.c
@@ -77,7 +77,7 @@ static SEXP nanoarrow_altstring_elt(SEXP altrep_sexp, R_xlen_t i) {
   }
 
   struct ArrowStringView item = ArrowArrayViewGetStringUnsafe(&converter->array_view, i);
-  return Rf_mkCharLenCE(item.data, item.size_bytes, CE_UTF8);
+  return Rf_mkCharLenCE(item.data, (int)item.size_bytes, CE_UTF8);
 }
 
 static SEXP nanoarrow_altstring_materialize(SEXP altrep_sexp) {

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -55,7 +55,7 @@ SEXP nanoarrow_c_array_set_length(SEXP array_xptr, SEXP length_sexp) {
     Rf_error("array$length must be finite and greater than zero");
   }
 
-  array->length = length;
+  array->length = (int64_t)length;
   return R_NilValue;
 }
 
@@ -70,7 +70,7 @@ SEXP nanoarrow_c_array_set_null_count(SEXP array_xptr, SEXP null_count_sexp) {
     Rf_error("array$null_count must be finite and greater than -1");
   }
 
-  array->null_count = null_count;
+  array->null_count = (int64_t)null_count;
   return R_NilValue;
 }
 
@@ -85,7 +85,7 @@ SEXP nanoarrow_c_array_set_offset(SEXP array_xptr, SEXP offset_sexp) {
     Rf_error("array$offset must be finite and greater than zero");
   }
 
-  array->offset = offset;
+  array->offset = (int64_t)offset;
   return R_NilValue;
 }
 

--- a/r/src/array.c
+++ b/r/src/array.c
@@ -220,8 +220,8 @@ static int move_array_buffers(struct ArrowArray* src, struct ArrowArray* dst,
   dst->offset = src->offset;
 
   if (src->n_buffers != dst->n_buffers) {
-    ArrowErrorSet(error, "Expected %ld buffer(s) but got %ld", dst->n_buffers,
-                  src->n_buffers);
+    ArrowErrorSet(error, "Expected %ld buffer(s) but got %ld", (long)dst->n_buffers,
+                  (long)src->n_buffers);
     return EINVAL;
   }
 
@@ -230,8 +230,8 @@ static int move_array_buffers(struct ArrowArray* src, struct ArrowArray* dst,
   }
 
   if (src->n_children != dst->n_children) {
-    ArrowErrorSet(error, "Expected %ld child(ren) but got %ld", dst->n_children,
-                  src->n_children);
+    ArrowErrorSet(error, "Expected %ld child(ren) but got %ld", (long)dst->n_children,
+                  (long)src->n_children);
     return EINVAL;
   }
 

--- a/r/src/array_view.c
+++ b/r/src/array_view.c
@@ -39,7 +39,7 @@ SEXP nanoarrow_c_array_view(SEXP array_xptr, SEXP schema_xptr) {
   struct ArrowSchema* schema = nanoarrow_schema_from_xptr(schema_xptr);
 
   struct ArrowError error;
-  ArrowErrorSet(&error, "");
+  ArrowErrorInit(&error);
 
   struct ArrowArrayView* array_view =
       (struct ArrowArrayView*)ArrowMalloc(sizeof(struct ArrowArrayView));

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -344,7 +344,7 @@ static void as_array_chr(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       if (result != NANOARROW_OK) {
         Rf_error("ArrowBufferAppend() failed");
       }
-      cumulative_len += item_size;
+      cumulative_len += (int32_t)item_size;
 
       vmaxset(vmax);
     }
@@ -476,7 +476,7 @@ static void as_array_list(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xpt
       Rf_error("ArrowBufferAppend() failed");
     }
 
-    cumulative_len += item_size;
+    cumulative_len += (int32_t)item_size;
     ArrowBufferAppendUnsafe(offset_buffer, &cumulative_len, sizeof(int32_t));
   }
 

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -98,7 +98,6 @@ static void as_array_int(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       ArrowBitmapAppendUnsafe(&bitmap, is_valid, 1);
     }
 
-    bitmap.size_bits = len;
     ArrowArraySetValidityBitmap(array, &bitmap);
   }
 
@@ -173,7 +172,6 @@ static void as_array_lgl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       ArrowBitmapAppendUnsafe(&bitmap, is_valid, 1);
     }
 
-    bitmap.size_bits = len;
     ArrowArraySetValidityBitmap(array, &bitmap);
   }
 
@@ -291,7 +289,6 @@ static void as_array_dbl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       ArrowBitmapAppendUnsafe(&bitmap, is_valid, 1);
     }
 
-    bitmap.size_bits = len;
     ArrowArraySetValidityBitmap(array, &bitmap);
   }
 
@@ -373,7 +370,6 @@ static void as_array_chr(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       ArrowBitmapAppendUnsafe(&bitmap, is_valid, 1);
     }
 
-    bitmap.size_bits = len;
     ArrowArraySetValidityBitmap(array, &bitmap);
   }
 
@@ -502,7 +498,6 @@ static void as_array_list(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xpt
       ArrowBitmapAppendUnsafe(&bitmap, is_valid, 1);
     }
 
-    bitmap.size_bits = len;
     ArrowArraySetValidityBitmap(array, &bitmap);
   }
 

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -224,7 +224,7 @@ static void as_array_dbl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
       if (R_IsNA(x_data[i]) || R_IsNaN(x_data[i])) {
         buffer_data[i] = 0;
       } else {
-        buffer_data[i] = x_data[i];
+        buffer_data[i] = (int64_t)x_data[i];
       }
     }
 
@@ -250,7 +250,7 @@ static void as_array_dbl(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
         n_overflow++;
         buffer_data[i] = 0;
       } else {
-        buffer_data[i] = x_data[i];
+        buffer_data[i] = (int32_t)x_data[i];
       }
     }
 

--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -65,6 +65,7 @@ SEXP nanoarrow_c_as_buffer_default(SEXP x_sexp) {
         data = CHAR(x_sexp);
         break;
       }
+      break;
     default:
       Rf_error("Unsupported type");
   }
@@ -178,8 +179,8 @@ SEXP nanoarrow_c_buffer_info(SEXP buffer_xptr) {
                          ""};
   SEXP info = PROTECT(Rf_mkNamed(VECSXP, names));
   SET_VECTOR_ELT(info, 0, R_MakeExternalPtr(buffer->data, NULL, buffer_xptr));
-  SET_VECTOR_ELT(info, 1, Rf_ScalarReal(buffer->size_bytes));
-  SET_VECTOR_ELT(info, 2, Rf_ScalarReal(buffer->capacity_bytes));
+  SET_VECTOR_ELT(info, 1, Rf_ScalarReal((double)buffer->size_bytes));
+  SET_VECTOR_ELT(info, 2, Rf_ScalarReal((double)buffer->capacity_bytes));
   SET_VECTOR_ELT(info, 3, buffer_type_sexp);
   SET_VECTOR_ELT(info, 4, buffer_data_type_sexp);
   SET_VECTOR_ELT(info, 5, Rf_ScalarInteger(element_size_bits));

--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -64,6 +64,8 @@ SEXP nanoarrow_c_as_buffer_default(SEXP x_sexp) {
       if (x_sexp != NA_STRING) {
         data = CHAR(x_sexp);
         break;
+      } else {
+        Rf_error("NA_character_ not supported in as_nanoarrow_buffer()");
       }
       break;
     default:

--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -189,7 +189,7 @@ SEXP nanoarrow_c_buffer_info(SEXP buffer_xptr) {
 
 SEXP nanoarrow_c_buffer_head_bytes(SEXP buffer_xptr, SEXP max_bytes_sexp) {
   struct ArrowBuffer* buffer = buffer_from_xptr(buffer_xptr);
-  int64_t max_bytes = REAL(max_bytes_sexp)[0];
+  int64_t max_bytes = (int64_t)REAL(max_bytes_sexp)[0];
 
   if (buffer->size_bytes <= max_bytes) {
     return buffer_xptr;

--- a/r/src/buffer.h
+++ b/r/src/buffer.h
@@ -72,11 +72,11 @@ static inline SEXP buffer_borrowed_xptr(const void* addr, int64_t size_bytes,
 static inline void buffer_borrowed_xptr_set_type(SEXP buffer_xptr,
                                                  enum ArrowBufferType buffer_type,
                                                  enum ArrowType buffer_data_type,
-                                                 int32_t element_size_bits) {
+                                                 int64_t element_size_bits) {
   SEXP buffer_types_sexp = PROTECT(Rf_allocVector(INTSXP, 3));
   INTEGER(buffer_types_sexp)[0] = buffer_type;
   INTEGER(buffer_types_sexp)[1] = buffer_data_type;
-  INTEGER(buffer_types_sexp)[2] = element_size_bits;
+  INTEGER(buffer_types_sexp)[2] = (int32_t)element_size_bits;
   R_SetExternalPtrTag(buffer_xptr, buffer_types_sexp);
   UNPROTECT(1);
 }

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -30,8 +30,8 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
                                       SEXP size_sexp, SEXP n_sexp) {
   struct ArrowArrayStream* array_stream =
       nanoarrow_array_stream_from_xptr(array_stream_xptr);
-  int64_t size = (int64_t)REAL(size_sexp)[0];
-  int64_t n = (int64_t)REAL(n_sexp)[0];
+  int64_t size = (int64_t)(REAL(size_sexp)[0]);
+  int64_t n = (int64_t)(REAL(n_sexp)[0]);
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -31,7 +31,14 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
   struct ArrowArrayStream* array_stream =
       nanoarrow_array_stream_from_xptr(array_stream_xptr);
   int64_t size = (int64_t)(REAL(size_sexp)[0]);
-  int64_t n = (int64_t)(REAL(n_sexp)[0]);
+
+  double n_real = REAL(n_sexp)[0];
+  int n;
+  if (R_FINITE(n_real)) {
+    n = (int)n_real;
+  } else {
+    n = INT_MAX;
+  }
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);

--- a/r/src/convert_array_stream.c
+++ b/r/src/convert_array_stream.c
@@ -30,8 +30,8 @@ SEXP nanoarrow_c_convert_array_stream(SEXP array_stream_xptr, SEXP ptype_sexp,
                                       SEXP size_sexp, SEXP n_sexp) {
   struct ArrowArrayStream* array_stream =
       nanoarrow_array_stream_from_xptr(array_stream_xptr);
-  double size = REAL(size_sexp)[0];
-  double n = REAL(n_sexp)[0];
+  int64_t size = (int64_t)REAL(size_sexp)[0];
+  int64_t n = (int64_t)REAL(n_sexp)[0];
 
   SEXP schema_xptr = PROTECT(nanoarrow_schema_owning_xptr());
   struct ArrowSchema* schema = nanoarrow_output_schema_from_xptr(schema_xptr);

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -89,7 +89,7 @@ void nanoarrow_set_rownames(SEXP x, R_xlen_t len) {
   if (len <= INT_MAX) {
     SEXP rownames = PROTECT(Rf_allocVector(INTSXP, 2));
     INTEGER(rownames)[0] = NA_INTEGER;
-    INTEGER(rownames)[1] = -len;
+    INTEGER(rownames)[1] = (int)-len;
     Rf_setAttrib(x, R_RowNamesSymbol, rownames);
     UNPROTECT(1);
   } else {

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -89,7 +89,7 @@ void nanoarrow_set_rownames(SEXP x, R_xlen_t len) {
   if (len <= INT_MAX) {
     SEXP rownames = PROTECT(Rf_allocVector(INTSXP, 2));
     INTEGER(rownames)[0] = NA_INTEGER;
-    INTEGER(rownames)[1] = (int)-len;
+    INTEGER(rownames)[1] = (int)(-len);
     Rf_setAttrib(x, R_RowNamesSymbol, rownames);
     UNPROTECT(1);
   } else {

--- a/r/src/materialize.c
+++ b/r/src/materialize.c
@@ -93,7 +93,7 @@ void nanoarrow_set_rownames(SEXP x, R_xlen_t len) {
     Rf_setAttrib(x, R_RowNamesSymbol, rownames);
     UNPROTECT(1);
   } else {
-    SEXP length_dbl = PROTECT(Rf_ScalarReal(len));
+    SEXP length_dbl = PROTECT(Rf_ScalarReal((double)len));
     SEXP seq_len_symbol = PROTECT(Rf_install("seq_len"));
     SEXP seq_len_call = PROTECT(Rf_lang2(seq_len_symbol, length_dbl));
     SEXP rownames_call = PROTECT(Rf_lang2(R_AsCharacterSymbol, seq_len_call));
@@ -294,9 +294,9 @@ static int nanoarrow_materialize_other(struct RConverter* converter,
       (struct ArrowArray*)converter->array_view.array, schema_xptr, converter_xptr));
   Rf_setAttrib(array_xptr, R_ClassSymbol, nanoarrow_cls_array);
 
-  SEXP offset_sexp =
-      PROTECT(Rf_ScalarReal(converter->src.array_view->offset + converter->src.offset));
-  SEXP length_sexp = PROTECT(Rf_ScalarReal(converter->src.length));
+  SEXP offset_sexp = PROTECT(
+      Rf_ScalarReal((double)(converter->src.array_view->offset + converter->src.offset)));
+  SEXP length_sexp = PROTECT(Rf_ScalarReal((double)converter->src.length));
 
   SEXP fun = PROTECT(Rf_install("convert_fallback_other"));
   SEXP call = PROTECT(

--- a/r/src/materialize_chr.h
+++ b/r/src/materialize_chr.h
@@ -79,7 +79,7 @@ static inline int nanoarrow_materialize_chr(struct RConverter* converter) {
     } else {
       item = ArrowArrayViewGetStringUnsafe(src->array_view, src->offset + i);
       SET_STRING_ELT(dst->vec_sexp, dst->offset + i,
-                     Rf_mkCharLenCE(item.data, item.size_bytes, CE_UTF8));
+                     Rf_mkCharLenCE(item.data, (int)item.size_bytes, CE_UTF8));
     }
   }
 

--- a/r/src/materialize_common.h
+++ b/r/src/materialize_common.h
@@ -109,7 +109,7 @@ struct RConverter {
 
 static inline void warn_lossy_conversion(int64_t count, const char* msg) {
   SEXP fun = PROTECT(Rf_install("warn_lossy_conversion"));
-  SEXP count_sexp = PROTECT(Rf_ScalarReal(count));
+  SEXP count_sexp = PROTECT(Rf_ScalarReal((double)count));
   SEXP msg_sexp = PROTECT(Rf_mkString(msg));
   SEXP call = PROTECT(Rf_lang3(fun, count_sexp, msg_sexp));
   Rf_eval(call, nanoarrow_ns_pkg);

--- a/r/src/materialize_int.h
+++ b/r/src/materialize_int.h
@@ -80,7 +80,7 @@ static inline int nanoarrow_materialize_int(struct ArrayViewSlice* src,
       // No need to bounds check for these types
       for (R_xlen_t i = 0; i < dst->length; i++) {
         result[dst->offset + i] =
-            ArrowArrayViewGetIntUnsafe(src->array_view, src->offset + i);
+            (int32_t)ArrowArrayViewGetIntUnsafe(src->array_view, src->offset + i);
       }
 
       // Set any nulls to NA_INTEGER
@@ -107,7 +107,7 @@ static inline int nanoarrow_materialize_int(struct ArrayViewSlice* src,
               result[dst->offset + i] = NA_INTEGER;
               n_bad_values++;
             } else {
-              result[dst->offset + i] = value;
+              result[dst->offset + i] = (int32_t)value;
             }
           } else {
             result[dst->offset + i] = NA_INTEGER;
@@ -120,7 +120,7 @@ static inline int nanoarrow_materialize_int(struct ArrayViewSlice* src,
             result[dst->offset + i] = NA_INTEGER;
             n_bad_values++;
           } else {
-            result[dst->offset + i] = value;
+            result[dst->offset + i] = (int32_t)value;
           }
         }
       }

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -38,7 +38,7 @@ SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
   if (TYPEOF(obj_sexp) == EXTPTRSXP) {
     return obj_sexp;
   } else if (TYPEOF(obj_sexp) == REALSXP && Rf_length(obj_sexp) == 1) {
-    intptr_t ptr_int = REAL(obj_sexp)[0];
+    intptr_t ptr_int = (intptr_t)REAL(obj_sexp)[0];
     return R_MakeExternalPtr((void*)ptr_int, R_NilValue, R_NilValue);
   } else if (TYPEOF(obj_sexp) == STRSXP && Rf_length(obj_sexp) == 1) {
     const char* text = CHAR(STRING_ELT(obj_sexp, 0));

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -38,6 +38,8 @@ SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
   if (TYPEOF(obj_sexp) == EXTPTRSXP) {
     return obj_sexp;
   } else if (TYPEOF(obj_sexp) == REALSXP && Rf_length(obj_sexp) == 1) {
+    // Note that this is not a good idea to actually do; however, is provided for
+    // backward compatibility with early versions of the arrow R package.
     intptr_t ptr_int = (intptr_t)(REAL(obj_sexp)[0]);
     return R_MakeExternalPtr((void*)ptr_int, R_NilValue, R_NilValue);
   } else if (TYPEOF(obj_sexp) == STRSXP && Rf_length(obj_sexp) == 1) {
@@ -56,8 +58,10 @@ SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
 }
 
 SEXP nanoarrow_c_pointer_addr_dbl(SEXP ptr) {
+  // Note that this is not a good idea to actually do; however, is provided for
+  // backward compatibility with early versions of the arrow R package.
   uintptr_t ptr_int = (uintptr_t)R_ExternalPtrAddr(nanoarrow_c_pointer(ptr));
-  return Rf_ScalarReal(ptr_int);
+  return Rf_ScalarReal((double)ptr_int);
 }
 
 SEXP nanoarrow_c_pointer_addr_chr(SEXP ptr) {

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -38,7 +38,7 @@ SEXP nanoarrow_c_pointer(SEXP obj_sexp) {
   if (TYPEOF(obj_sexp) == EXTPTRSXP) {
     return obj_sexp;
   } else if (TYPEOF(obj_sexp) == REALSXP && Rf_length(obj_sexp) == 1) {
-    intptr_t ptr_int = (intptr_t)REAL(obj_sexp)[0];
+    intptr_t ptr_int = (intptr_t)(REAL(obj_sexp)[0]);
     return R_MakeExternalPtr((void*)ptr_int, R_NilValue, R_NilValue);
   } else if (TYPEOF(obj_sexp) == STRSXP && Rf_length(obj_sexp) == 1) {
     const char* text = CHAR(STRING_ELT(obj_sexp, 0));

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -141,7 +141,11 @@ static SEXP schema_metadata_to_list(const char* metadata) {
   }
 
   struct ArrowMetadataReader reader;
-  ArrowMetadataReaderInit(&reader, metadata);
+  int result = ArrowMetadataReaderInit(&reader, metadata);
+  if (result != NANOARROW_OK) {
+    Rf_error("ArrowMetadataReaderInit() failed");
+  }
+
   SEXP names = PROTECT(Rf_allocVector(STRSXP, reader.remaining_keys));
   SEXP values = PROTECT(Rf_allocVector(VECSXP, reader.remaining_keys));
 
@@ -149,7 +153,11 @@ static SEXP schema_metadata_to_list(const char* metadata) {
   struct ArrowStringView value;
   R_xlen_t i = 0;
   while (reader.remaining_keys > 0) {
-    ArrowMetadataReaderRead(&reader, &key, &value);
+    result = ArrowMetadataReaderRead(&reader, &key, &value);
+    if (result != NANOARROW_OK) {
+      Rf_error("ArrowMetadataReaderRead() failed");
+    }
+
     SET_STRING_ELT(names, i, Rf_mkCharLenCE(key.data, key.size_bytes, CE_UTF8));
     SEXP value_raw = PROTECT(Rf_allocVector(RAWSXP, value.size_bytes));
     memcpy(RAW(value_raw), value.data, value.size_bytes);

--- a/r/src/schema.c
+++ b/r/src/schema.c
@@ -311,7 +311,7 @@ SEXP nanoarrow_c_schema_parse(SEXP schema_xptr) {
       schema_view.type == NANOARROW_TYPE_SPARSE_UNION) {
     int8_t type_ids[128];
     int num_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids, type_ids);
-    if (num_type_ids == -1) {
+    if (num_type_ids == -1 || num_type_ids > 127) {
       Rf_error("Invalid type IDs in union type: '%s'", schema_view.union_type_ids);
     }
 

--- a/r/src/util.c
+++ b/r/src/util.c
@@ -54,11 +54,11 @@ void nanoarrow_init_cached_sexps(void) {
 }
 
 SEXP nanoarrow_c_preserved_count(void) {
-  return Rf_ScalarReal(nanoarrow_preserved_count());
+  return Rf_ScalarReal((double)nanoarrow_preserved_count());
 }
 
 SEXP nanoarrow_c_preserved_empty(void) {
-  return Rf_ScalarReal(nanoarrow_preserved_empty());
+  return Rf_ScalarReal((double)nanoarrow_preserved_empty());
 }
 
 SEXP nanoarrow_c_preserve_and_release_on_other_thread(SEXP obj) {

--- a/r/src/util.h
+++ b/r/src/util.h
@@ -60,9 +60,9 @@ static inline void check_trivial_alloc(const void* ptr, const char* ptr_type) {
 // possible.
 static inline SEXP length_sexp_from_int64(int64_t value) {
   if (value < INT_MAX) {
-    return Rf_ScalarInteger(value);
+    return Rf_ScalarInteger((int)value);
   } else {
-    return Rf_ScalarReal(value);
+    return Rf_ScalarReal((double)value);
   }
 }
 

--- a/r/tests/testthat/test-buffer.R
+++ b/r/tests/testthat/test-buffer.R
@@ -63,6 +63,11 @@ test_that("buffers can be printed", {
 
 test_that("as_nanoarrow_buffer() errors for unsupported types", {
   expect_error(
+    as_nanoarrow_buffer(NA_character_),
+    "NA_character_ not supported"
+  )
+
+  expect_error(
     as_nanoarrow_buffer(environment()),
     "Can't convert object of type environment to nanoarrow_buffer"
   )

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -585,8 +585,8 @@ ArrowErrorCode ArrowArrayViewInitFromSchema(struct ArrowArrayView* array_view,
     }
 
     memset(array_view->union_type_id_map, -1, 256);
-    int8_t n_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids,
-                                                array_view->union_type_id_map + 128);
+    int32_t n_type_ids = _ArrowParseUnionTypeIds(schema_view.union_type_ids,
+                                                 array_view->union_type_id_map + 128);
     for (int8_t child_index = 0; child_index < n_type_ids; child_index++) {
       int8_t type_id = array_view->union_type_id_map[128 + child_index];
       array_view->union_type_id_map[type_id] = child_index;

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -1151,7 +1151,7 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
             error,
             "[%ld] Expected union offset for child id %d to be between 0 and %ld but "
             "found offset value %ld",
-            (long)i, (int)child_id, (long)child_length, offset);
+            (long)i, (int)child_id, (long)child_length, (long)offset);
         return EINVAL;
       }
     }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -415,7 +415,7 @@ static ArrowErrorCode ArrowArrayFinalizeBuffers(struct ArrowArray* array) {
     case NANOARROW_TYPE_LARGE_BINARY:
     case NANOARROW_TYPE_LARGE_STRING:
       if (ArrowArrayBuffer(array, 2)->data == NULL) {
-        ArrowBufferAppendUInt8(ArrowArrayBuffer(array, 2), 0);
+        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt8(ArrowArrayBuffer(array, 2), 0));
       }
       break;
     default:

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -61,7 +61,7 @@ static inline int8_t _ArrowArrayUnionTypeId(struct ArrowArray* array,
   return child_index;
 }
 
-static inline int8_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) {
+static inline int32_t _ArrowParseUnionTypeIds(const char* type_ids, int8_t* out) {
   if (*type_ids == '\0') {
     return 0;
   }
@@ -113,7 +113,7 @@ static inline int8_t _ArrowParsedUnionTypeIdsWillEqualChildIndices(const int8_t*
 static inline int8_t _ArrowUnionTypeIdsWillEqualChildIndices(const char* type_id_str,
                                                              int64_t n_children) {
   int8_t type_ids[128];
-  int8_t n_type_ids = _ArrowParseUnionTypeIds(type_id_str, type_ids);
+  int32_t n_type_ids = _ArrowParseUnionTypeIds(type_id_str, type_ids);
   return _ArrowParsedUnionTypeIdsWillEqualChildIndices(type_ids, n_type_ids, n_children);
 }
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -140,7 +140,7 @@ TEST(ArrayTest, ArrayTestInitFromSchema) {
 TEST(ArrayTest, ArrayTestSetBitmap) {
   struct ArrowBitmap bitmap;
   ArrowBitmapInit(&bitmap);
-  ArrowBitmapAppend(&bitmap, true, 9);
+  ASSERT_EQ(ArrowBitmapAppend(&bitmap, true, 9), NANOARROW_OK);
 
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
@@ -162,11 +162,11 @@ TEST(ArrayTest, ArrayTestSetBuffer) {
 
   struct ArrowBuffer buffer0, buffer1, buffer2;
   ArrowBufferInit(&buffer0);
-  ArrowBufferAppend(&buffer0, validity_bitmap, 1);
+  ASSERT_EQ(ArrowBufferAppend(&buffer0, validity_bitmap, 1), NANOARROW_OK);
   ArrowBufferInit(&buffer1);
-  ArrowBufferAppend(&buffer1, offsets, 9 * sizeof(int32_t));
+  ASSERT_EQ(ArrowBufferAppend(&buffer1, offsets, 9 * sizeof(int32_t)), NANOARROW_OK);
   ArrowBufferInit(&buffer2);
-  ArrowBufferAppend(&buffer2, data, strlen(data));
+  ASSERT_EQ(ArrowBufferAppend(&buffer2, data, strlen(data)), NANOARROW_OK);
 
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
@@ -1558,7 +1558,7 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   struct ArrowArray array;
 
   // Build with no validity buffer
-  ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT32), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppendInt32(ArrowArrayBuffer(&array, 1), 11), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppendInt32(ArrowArrayBuffer(&array, 1), 12), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppendInt32(ArrowArrayBuffer(&array, 1), 13), NANOARROW_OK);

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -334,7 +334,7 @@ static inline void ArrowBitsUnpackInt32(const uint8_t* bits, int64_t start_offse
   }
 
   // last byte
-  const int bits_remaining = i_end % 8 == 0 ? 8 : i_end % 8;
+  const int bits_remaining = (int)(i_end % 8 == 0 ? 8 : i_end % 8);
   for (int i = 0; i < bits_remaining; i++) {
     *out++ = ArrowBitGet(&bits[bytes_last_valid], i);
   }

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -245,17 +245,17 @@ static inline void _ArrowBitsUnpackInt32(const uint8_t word, int32_t* out) {
 }
 
 static inline void _ArrowBitmapPackInt8(const int8_t* values, uint8_t* out) {
-  *out = (values[0] | ((values[1] + 0x1) & 0x2) | ((values[2] + 0x3) & 0x4) |
-          ((values[3] + 0x7) & 0x8) | ((values[4] + 0xf) & 0x10) |
-          ((values[5] + 0x1f) & 0x20) | ((values[6] + 0x3f) & 0x40) |
-          ((values[7] + 0x7f) & 0x80));
+  *out = (uint8_t)(values[0] | ((values[1] + 0x1) & 0x2) | ((values[2] + 0x3) & 0x4) |
+                   ((values[3] + 0x7) & 0x8) | ((values[4] + 0xf) & 0x10) |
+                   ((values[5] + 0x1f) & 0x20) | ((values[6] + 0x3f) & 0x40) |
+                   ((values[7] + 0x7f) & 0x80));
 }
 
 static inline void _ArrowBitmapPackInt32(const int32_t* values, uint8_t* out) {
-  *out = (values[0] | ((values[1] + 0x1) & 0x2) | ((values[2] + 0x3) & 0x4) |
-          ((values[3] + 0x7) & 0x8) | ((values[4] + 0xf) & 0x10) |
-          ((values[5] + 0x1f) & 0x20) | ((values[6] + 0x3f) & 0x40) |
-          ((values[7] + 0x7f) & 0x80));
+  *out = (uint8_t)(values[0] | ((values[1] + 0x1) & 0x2) | ((values[2] + 0x3) & 0x4) |
+                   ((values[3] + 0x7) & 0x8) | ((values[4] + 0xf) & 0x10) |
+                   ((values[5] + 0x1f) & 0x20) | ((values[6] + 0x3f) & 0x40) |
+                   ((values[7] + 0x7f) & 0x80));
 }
 
 static inline int8_t ArrowBitGet(const uint8_t* bits, int64_t i) {
@@ -555,7 +555,7 @@ static inline void ArrowBitmapAppendInt32Unsafe(struct ArrowBitmap* bitmap,
   if ((out_i_cursor % 8) != 0) {
     int64_t n_partial_bits = _ArrowRoundUpToMultipleOf8(out_i_cursor) - out_i_cursor;
     for (int i = 0; i < n_partial_bits; i++) {
-      ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, values[i]);
+      ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, (uint8_t)values[i]);
     }
 
     out_cursor++;
@@ -578,7 +578,7 @@ static inline void ArrowBitmapAppendInt32Unsafe(struct ArrowBitmap* bitmap,
     // Zero out the last byte
     *out_cursor = 0x00;
     for (int i = 0; i < n_remaining; i++) {
-      ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, values_cursor[i]);
+      ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, (uint8_t)values_cursor[i]);
     }
     out_cursor++;
   }

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -295,7 +295,7 @@ static inline void ArrowBitsUnpackInt8(const uint8_t* bits, int64_t start_offset
   }
 
   // last byte
-  const int bits_remaining = i_end % 8 == 0 ? 8 : i_end % 8;
+  const int bits_remaining = (int)(i_end % 8 == 0 ? 8 : i_end % 8);
   for (int i = 0; i < bits_remaining; i++) {
     *out++ = ArrowBitGet(&bits[bytes_last_valid], i);
   }

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -512,7 +512,7 @@ TEST(BitmapTest, BitmapTestResize) {
 
   // Check normal usage, which is resize to the final length
   // after appending a bunch of values
-  ArrowBitmapResize(&bitmap, 200, false);
+  ASSERT_EQ(ArrowBitmapResize(&bitmap, 200, false), NANOARROW_OK);
   EXPECT_EQ(bitmap.buffer.size_bytes, 0);
   EXPECT_EQ(bitmap.buffer.capacity_bytes, 200 / 8);
   EXPECT_EQ(bitmap.size_bits, 0);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -259,7 +259,8 @@ static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream
 /// \brief Set the contents of an error using printf syntax.
 ///
 /// If error is NULL, this function does nothing and returns NANOARROW_OK.
-ArrowErrorCode ArrowErrorSet(struct ArrowError* error, const char* fmt, ...);
+NANOARROW_CHECK_PRINTF_ATTRIBUTE ArrowErrorCode ArrowErrorSet(struct ArrowError* error,
+                                                              const char* fmt, ...);
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1133,7 +1133,7 @@ ArrowErrorCode ArrowBasicArrayStreamValidate(const struct ArrowArrayStream* arra
 /// @}
 
 // Undefine ArrowErrorCode, which may have been defined to annotate functions that return
-// it to warn for an unsused result.
+// it to warn for an unused result.
 #if defined(ArrowErrorCode)
 #undef ArrowErrorCode
 #endif

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -259,8 +259,8 @@ static inline void ArrowArrayStreamRelease(struct ArrowArrayStream* array_stream
 /// \brief Set the contents of an error using printf syntax.
 ///
 /// If error is NULL, this function does nothing and returns NANOARROW_OK.
-NANOARROW_CHECK_PRINTF_ATTRIBUTE ArrowErrorCode ArrowErrorSet(struct ArrowError* error,
-                                                              const char* fmt, ...);
+NANOARROW_CHECK_PRINTF_ATTRIBUTE int ArrowErrorSet(struct ArrowError* error,
+                                                   const char* fmt, ...);
 
 /// @}
 
@@ -301,8 +301,7 @@ void ArrowSchemaInit(struct ArrowSchema* schema);
 /// ArrowSchemaSetType() for the common case of constructing an
 /// unparameterized type. The caller is responsible for calling the schema->release
 /// callback if NANOARROW_OK is returned.
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema,
-                                                              enum ArrowType type);
+ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema, enum ArrowType type);
 
 /// \brief Get a human-readable summary of a Schema
 ///
@@ -321,16 +320,14 @@ int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t
 /// allocated, initialized, and named; however, the caller must
 /// ArrowSchemaSetType() on the preinitialized children. Schema must have been initialized
 /// using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetType(struct ArrowSchema* schema,
-                                                         enum ArrowType type);
+ArrowErrorCode ArrowSchemaSetType(struct ArrowSchema* schema, enum ArrowType type);
 
 /// \brief Set the format field and initialize children of a struct schema
 ///
 /// The specified number of children are initialized; however, the caller is responsible
 /// for calling ArrowSchemaSetType() and ArrowSchemaSetName() on each child.
 /// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchema* schema,
-                                                               int64_t n_children);
+ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchema* schema, int64_t n_children);
 
 /// \brief Set the format field of a fixed-size schema
 ///
@@ -340,17 +337,17 @@ NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchem
 /// allocated, initialized, and named; however, the caller must
 /// ArrowSchemaSetType() the first child. Schema must have been initialized using
 /// ArrowSchemaInit() or ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeFixedSize(
-    struct ArrowSchema* schema, enum ArrowType type, int32_t fixed_size);
+ArrowErrorCode ArrowSchemaSetTypeFixedSize(struct ArrowSchema* schema,
+                                           enum ArrowType type, int32_t fixed_size);
 
 /// \brief Set the format field of a decimal schema
 ///
 /// Returns EINVAL for scale <= 0 or for type that is not
 /// NANOARROW_TYPE_DECIMAL128 or NANOARROW_TYPE_DECIMAL256. Schema must have been
 /// initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
-                          int32_t decimal_precision, int32_t decimal_scale);
+ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
+                                         int32_t decimal_precision,
+                                         int32_t decimal_scale);
 
 /// \brief Set the format field of a time, timestamp, or duration schema
 ///
@@ -359,60 +356,55 @@ ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
 /// NANOARROW_TYPE_TIMESTAMP, or NANOARROW_TYPE_DURATION. The
 /// timezone parameter must be NULL for a non-timestamp type. Schema must have been
 /// initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowSchemaSetTypeDateTime(struct ArrowSchema* schema, enum ArrowType type,
-                           enum ArrowTimeUnit time_unit, const char* timezone);
+ArrowErrorCode ArrowSchemaSetTypeDateTime(struct ArrowSchema* schema, enum ArrowType type,
+                                          enum ArrowTimeUnit time_unit,
+                                          const char* timezone);
 
 /// \brief Seet the format field of a union schema
 ///
 /// Returns EINVAL for a type that is not NANOARROW_TYPE_DENSE_UNION
 /// or NANOARROW_TYPE_SPARSE_UNION. The specified number of children are
 /// allocated, and initialized.
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeUnion(struct ArrowSchema* schema,
-                                                              enum ArrowType type,
-                                                              int64_t n_children);
+ArrowErrorCode ArrowSchemaSetTypeUnion(struct ArrowSchema* schema, enum ArrowType type,
+                                       int64_t n_children);
 
 /// \brief Make a (recursive) copy of a schema
 ///
 /// Allocates and copies fields of schema into schema_out.
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowSchemaDeepCopy(const struct ArrowSchema* schema, struct ArrowSchema* schema_out);
+ArrowErrorCode ArrowSchemaDeepCopy(const struct ArrowSchema* schema,
+                                   struct ArrowSchema* schema_out);
 
 /// \brief Copy format into schema->format
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema,
-                                                           const char* format);
+ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema, const char* format);
 
 /// \brief Copy name into schema->name
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema,
-                                                         const char* name);
+ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema, const char* name);
 
 /// \brief Copy metadata into schema->metadata
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy.
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetMetadata(struct ArrowSchema* schema,
-                                                             const char* metadata);
+ArrowErrorCode ArrowSchemaSetMetadata(struct ArrowSchema* schema, const char* metadata);
 
 /// \brief Allocate the schema->children array
 ///
 /// Includes the memory for each child struct ArrowSchema.
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowSchemaAllocateChildren(struct ArrowSchema* schema, int64_t n_children);
+ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
+                                           int64_t n_children);
 
 /// \brief Allocate the schema->dictionary member
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
+ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
 
 /// @}
 
@@ -436,13 +428,13 @@ struct ArrowMetadataReader {
 };
 
 /// \brief Initialize an ArrowMetadataReader
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowMetadataReaderInit(struct ArrowMetadataReader* reader, const char* metadata);
+ArrowErrorCode ArrowMetadataReaderInit(struct ArrowMetadataReader* reader,
+                                       const char* metadata);
 
 /// \brief Read the next key/value pair from an ArrowMetadataReader
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataReaderRead(
-    struct ArrowMetadataReader* reader, struct ArrowStringView* key_out,
-    struct ArrowStringView* value_out);
+ArrowErrorCode ArrowMetadataReaderRead(struct ArrowMetadataReader* reader,
+                                       struct ArrowStringView* key_out,
+                                       struct ArrowStringView* value_out);
 
 /// \brief The number of bytes in in a key/value metadata string
 int64_t ArrowMetadataSizeOf(const char* metadata);
@@ -453,31 +445,32 @@ char ArrowMetadataHasKey(const char* metadata, struct ArrowStringView key);
 /// \brief Extract a value from schema metadata
 ///
 /// If key does not exist in metadata, value_out is unmodified
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataGetValue(
-    const char* metadata, struct ArrowStringView key, struct ArrowStringView* value_out);
+ArrowErrorCode ArrowMetadataGetValue(const char* metadata, struct ArrowStringView key,
+                                     struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs
 ///
 /// metadata can be an existing metadata string or NULL to initialize
 /// an empty metadata string.
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer,
-                                                               const char* metadata);
+ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
 
 /// \brief Append a key/value pair to a buffer containing serialized metadata
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderAppend(
-    struct ArrowBuffer* buffer, struct ArrowStringView key, struct ArrowStringView value);
+ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key,
+                                          struct ArrowStringView value);
 
 /// \brief Set a key/value pair to a buffer containing serialized metadata
 ///
 /// Ensures that the only entry for key in the metadata is set to value.
 /// This function maintains the existing position of (the first instance of)
 /// key if present in the data.
-NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderSet(
-    struct ArrowBuffer* buffer, struct ArrowStringView key, struct ArrowStringView value);
+ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
+                                       struct ArrowStringView key,
+                                       struct ArrowStringView value);
 
 /// \brief Remove a key from a buffer containing serialized metadata
-NANOARROW_CHECK_RETURN ArrowErrorCode
-ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer, struct ArrowStringView key);
+ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
+                                          struct ArrowStringView key);
 
 /// @}
 
@@ -1138,6 +1131,12 @@ ArrowErrorCode ArrowBasicArrayStreamValidate(const struct ArrowArrayStream* arra
                                              struct ArrowError* error);
 
 /// @}
+
+// Undefine ArrowErrorCode, which may have been defined to annotate functions that return
+// it to warn for an unsused result.
+#if defined(ArrowErrorCode)
+#undef ArrowErrorCode
+#endif
 
 // Inline function definitions
 #include "array_inline.h"

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -382,33 +382,37 @@ ArrowSchemaDeepCopy(const struct ArrowSchema* schema, struct ArrowSchema* schema
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema, const char* format);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetFormat(struct ArrowSchema* schema,
+                                                           const char* format);
 
 /// \brief Copy name into schema->name
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema, const char* name);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetName(struct ArrowSchema* schema,
+                                                         const char* name);
 
 /// \brief Copy metadata into schema->metadata
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy.
-ArrowErrorCode ArrowSchemaSetMetadata(struct ArrowSchema* schema, const char* metadata);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetMetadata(struct ArrowSchema* schema,
+                                                             const char* metadata);
 
 /// \brief Allocate the schema->children array
 ///
 /// Includes the memory for each child struct ArrowSchema.
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaAllocateChildren(struct ArrowSchema* schema,
-                                           int64_t n_children);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowSchemaAllocateChildren(struct ArrowSchema* schema, int64_t n_children);
 
 /// \brief Allocate the schema->dictionary member
 ///
 /// schema must have been allocated using ArrowSchemaInitFromType() or
 /// ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowSchemaAllocateDictionary(struct ArrowSchema* schema);
 
 /// @}
 
@@ -432,13 +436,13 @@ struct ArrowMetadataReader {
 };
 
 /// \brief Initialize an ArrowMetadataReader
-ArrowErrorCode ArrowMetadataReaderInit(struct ArrowMetadataReader* reader,
-                                       const char* metadata);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowMetadataReaderInit(struct ArrowMetadataReader* reader, const char* metadata);
 
 /// \brief Read the next key/value pair from an ArrowMetadataReader
-ArrowErrorCode ArrowMetadataReaderRead(struct ArrowMetadataReader* reader,
-                                       struct ArrowStringView* key_out,
-                                       struct ArrowStringView* value_out);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataReaderRead(
+    struct ArrowMetadataReader* reader, struct ArrowStringView* key_out,
+    struct ArrowStringView* value_out);
 
 /// \brief The number of bytes in in a key/value metadata string
 int64_t ArrowMetadataSizeOf(const char* metadata);
@@ -449,32 +453,31 @@ char ArrowMetadataHasKey(const char* metadata, struct ArrowStringView key);
 /// \brief Extract a value from schema metadata
 ///
 /// If key does not exist in metadata, value_out is unmodified
-ArrowErrorCode ArrowMetadataGetValue(const char* metadata, struct ArrowStringView key,
-                                     struct ArrowStringView* value_out);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataGetValue(
+    const char* metadata, struct ArrowStringView key, struct ArrowStringView* value_out);
 
 /// \brief Initialize a builder for schema metadata from key/value pairs
 ///
 /// metadata can be an existing metadata string or NULL to initialize
 /// an empty metadata string.
-ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer, const char* metadata);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderInit(struct ArrowBuffer* buffer,
+                                                               const char* metadata);
 
 /// \brief Append a key/value pair to a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderAppend(struct ArrowBuffer* buffer,
-                                          struct ArrowStringView key,
-                                          struct ArrowStringView value);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderAppend(
+    struct ArrowBuffer* buffer, struct ArrowStringView key, struct ArrowStringView value);
 
 /// \brief Set a key/value pair to a buffer containing serialized metadata
 ///
 /// Ensures that the only entry for key in the metadata is set to value.
 /// This function maintains the existing position of (the first instance of)
 /// key if present in the data.
-ArrowErrorCode ArrowMetadataBuilderSet(struct ArrowBuffer* buffer,
-                                       struct ArrowStringView key,
-                                       struct ArrowStringView value);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowMetadataBuilderSet(
+    struct ArrowBuffer* buffer, struct ArrowStringView key, struct ArrowStringView value);
 
 /// \brief Remove a key from a buffer containing serialized metadata
-ArrowErrorCode ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer,
-                                          struct ArrowStringView key);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowMetadataBuilderRemove(struct ArrowBuffer* buffer, struct ArrowStringView key);
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -301,7 +301,8 @@ void ArrowSchemaInit(struct ArrowSchema* schema);
 /// ArrowSchemaSetType() for the common case of constructing an
 /// unparameterized type. The caller is responsible for calling the schema->release
 /// callback if NANOARROW_OK is returned.
-ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema, enum ArrowType type);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaInitFromType(struct ArrowSchema* schema,
+                                                              enum ArrowType type);
 
 /// \brief Get a human-readable summary of a Schema
 ///
@@ -320,14 +321,16 @@ int64_t ArrowSchemaToString(const struct ArrowSchema* schema, char* out, int64_t
 /// allocated, initialized, and named; however, the caller must
 /// ArrowSchemaSetType() on the preinitialized children. Schema must have been initialized
 /// using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetType(struct ArrowSchema* schema, enum ArrowType type);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetType(struct ArrowSchema* schema,
+                                                         enum ArrowType type);
 
 /// \brief Set the format field and initialize children of a struct schema
 ///
 /// The specified number of children are initialized; however, the caller is responsible
 /// for calling ArrowSchemaSetType() and ArrowSchemaSetName() on each child.
 /// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchema* schema, int64_t n_children);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchema* schema,
+                                                               int64_t n_children);
 
 /// \brief Set the format field of a fixed-size schema
 ///
@@ -337,17 +340,17 @@ ArrowErrorCode ArrowSchemaSetTypeStruct(struct ArrowSchema* schema, int64_t n_ch
 /// allocated, initialized, and named; however, the caller must
 /// ArrowSchemaSetType() the first child. Schema must have been initialized using
 /// ArrowSchemaInit() or ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetTypeFixedSize(struct ArrowSchema* schema,
-                                           enum ArrowType type, int32_t fixed_size);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeFixedSize(
+    struct ArrowSchema* schema, enum ArrowType type, int32_t fixed_size);
 
 /// \brief Set the format field of a decimal schema
 ///
 /// Returns EINVAL for scale <= 0 or for type that is not
 /// NANOARROW_TYPE_DECIMAL128 or NANOARROW_TYPE_DECIMAL256. Schema must have been
 /// initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
-                                         int32_t decimal_precision,
-                                         int32_t decimal_scale);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
+                          int32_t decimal_precision, int32_t decimal_scale);
 
 /// \brief Set the format field of a time, timestamp, or duration schema
 ///
@@ -356,23 +359,24 @@ ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowT
 /// NANOARROW_TYPE_TIMESTAMP, or NANOARROW_TYPE_DURATION. The
 /// timezone parameter must be NULL for a non-timestamp type. Schema must have been
 /// initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-ArrowErrorCode ArrowSchemaSetTypeDateTime(struct ArrowSchema* schema, enum ArrowType type,
-                                          enum ArrowTimeUnit time_unit,
-                                          const char* timezone);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowSchemaSetTypeDateTime(struct ArrowSchema* schema, enum ArrowType type,
+                           enum ArrowTimeUnit time_unit, const char* timezone);
 
 /// \brief Seet the format field of a union schema
 ///
 /// Returns EINVAL for a type that is not NANOARROW_TYPE_DENSE_UNION
 /// or NANOARROW_TYPE_SPARSE_UNION. The specified number of children are
 /// allocated, and initialized.
-ArrowErrorCode ArrowSchemaSetTypeUnion(struct ArrowSchema* schema, enum ArrowType type,
-                                       int64_t n_children);
+NANOARROW_CHECK_RETURN ArrowErrorCode ArrowSchemaSetTypeUnion(struct ArrowSchema* schema,
+                                                              enum ArrowType type,
+                                                              int64_t n_children);
 
 /// \brief Make a (recursive) copy of a schema
 ///
 /// Allocates and copies fields of schema into schema_out.
-ArrowErrorCode ArrowSchemaDeepCopy(const struct ArrowSchema* schema,
-                                   struct ArrowSchema* schema_out);
+NANOARROW_CHECK_RETURN ArrowErrorCode
+ArrowSchemaDeepCopy(const struct ArrowSchema* schema, struct ArrowSchema* schema_out);
 
 /// \brief Copy format into schema->format
 ///

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -58,7 +58,7 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueSchemaTest) {
   nanoarrow::UniqueSchema schema;
   EXPECT_EQ(schema->release, nullptr);
 
-  ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_NE(schema->release, nullptr);
   EXPECT_STREQ(schema->format, "i");
 

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -33,7 +33,7 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayTest) {
   nanoarrow::UniqueArray array;
   EXPECT_EQ(array->release, nullptr);
 
-  ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(array.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.get(), 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(array.get(), nullptr), NANOARROW_OK);
@@ -174,7 +174,7 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayViewTest) {
   // Use an ArrayView with children, since an ArrayView with no children
   // doesn't hold any resources
   ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_STRUCT);
-  ArrowArrayViewAllocateChildren(array_view.get(), 2);
+  ASSERT_EQ(ArrowArrayViewAllocateChildren(array_view.get(), 2), NANOARROW_OK);
   EXPECT_EQ(array_view->storage_type, NANOARROW_TYPE_STRUCT);
 
   // move constructor

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -197,6 +197,10 @@ struct ArrowArrayStream {
 /// \ingroup nanoarrow-errors
 typedef int ArrowErrorCode;
 
+#if defined(NANOARROW_DEBUG)
+#define ArrowErrorCode NANOARROW_CHECK_RETURN ArrowErrorCode
+#endif
+
 /// \brief Error type containing a UTF-8 encoded message.
 /// \ingroup nanoarrow-errors
 struct ArrowError {

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -169,7 +169,8 @@ struct ArrowArrayStream {
   } while (0)
 #endif
 
-// Check ArrowErrorSet() calls for valid printf format strings/arguments
+#if defined(NANOARROW_DEBUG)
+// For checking ArrowErrorSet() calls for valid printf format strings/arguments
 // If using mingw's c99-compliant printf, we need a different format-checking attribute
 #if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
 #define NANOARROW_CHECK_PRINTF_ATTRIBUTE \
@@ -180,13 +181,18 @@ struct ArrowArrayStream {
 #define NANOARROW_CHECK_PRINTF_ATTRIBUTE
 #endif
 
-// Check calls to functions that return ArrowErrorCode
+// For checking calls to functions that return ArrowErrorCode
 #if defined(__GNUC__) && (__GNUC__ >= 4)
-#define NANOARROW_CHECK_RETURN __attribute__((warn_unused_result))
+#define NANOARROW_CHECK_RETURN_ATTRIBUTE __attribute__((warn_unused_result))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1700)
-#define NANOARROW_CHECK_RETURN _Check_return_
+#define NANOARROW_CHECK_RETURN_ATTRIBUTE _Check_return_
 #else
-#define NANOARROW_CHECK_RETURN
+#define NANOARROW_CHECK_RETURN_ATTRIBUTE
+#endif
+
+#else
+#define NANOARROW_CHECK_RETURN_ATTRIBUTE
+#define NANOARROW_CHECK_PRINTF_ATTRIBUTE
 #endif
 
 /// \brief Return code for success.
@@ -198,7 +204,7 @@ struct ArrowArrayStream {
 typedef int ArrowErrorCode;
 
 #if defined(NANOARROW_DEBUG)
-#define ArrowErrorCode NANOARROW_CHECK_RETURN ArrowErrorCode
+#define ArrowErrorCode NANOARROW_CHECK_RETURN_ATTRIBUTE ArrowErrorCode
 #endif
 
 /// \brief Error type containing a UTF-8 encoded message.

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -169,6 +169,15 @@ struct ArrowArrayStream {
   } while (0)
 #endif
 
+// If using mingw's c99-compliant printf, we need a different format-checking attribute
+#if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
+#define NANOARROW_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
+#elif defined(__GNUC__)
+#define NANOARROW_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
+#else
+#define NANOARROW_CHECK_PRINTF_ATTRIBUTE
+#endif
+
 /// \brief Return code for success.
 /// \ingroup nanoarrow-errors
 #define NANOARROW_OK 0

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -169,13 +169,24 @@ struct ArrowArrayStream {
   } while (0)
 #endif
 
+// Check ArrowErrorSet() calls for valid printf format strings/arguments
 // If using mingw's c99-compliant printf, we need a different format-checking attribute
 #if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
-#define NANOARROW_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
+#define NANOARROW_CHECK_PRINTF_ATTRIBUTE \
+  __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
 #elif defined(__GNUC__)
 #define NANOARROW_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
 #else
 #define NANOARROW_CHECK_PRINTF_ATTRIBUTE
+#endif
+
+// Check calls to functions that return ArrowErrorCode
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#define NANOARROW_CHECK_RETURN __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+#define NANOARROW_CHECK_RETURN _Check_return_
+#else
+#define NANOARROW_CHECK_RETURN
 #endif
 
 /// \brief Return code for success.

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1133,8 +1133,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
   }
 
   const char* format_end_out;
-  ArrowErrorCode result =
-      ArrowSchemaViewParse(schema_view, format, &format_end_out, error);
+  int result = ArrowSchemaViewParse(schema_view, format, &format_end_out, error);
 
   if (result != NANOARROW_OK) {
     if (error != NULL) {

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -612,8 +612,7 @@ static ArrowErrorCode ArrowSchemaViewParse(struct ArrowSchemaView* schema_view,
     // decimal
     case 'd':
       if (format[1] != ':' || format[2] == '\0') {
-        ArrowErrorSet(error, "Expected ':precision,scale[,bitwidth]' following 'd'",
-                      format + 3);
+        ArrowErrorSet(error, "Expected ':precision,scale[,bitwidth]' following 'd'");
         return EINVAL;
       }
 
@@ -958,13 +957,13 @@ static ArrowErrorCode ArrowSchemaViewValidateNChildren(
   for (int64_t i = 0; i < schema_view->schema->n_children; i++) {
     child = schema_view->schema->children[i];
     if (child == NULL) {
-      ArrowErrorSet(error, "Expected valid schema at schema->children[%d] but found NULL",
-                    i);
+      ArrowErrorSet(error, "Expected valid schema at schema->children[%ld] but found NULL",
+                    (long)i);
       return EINVAL;
     } else if (child->release == NULL) {
       ArrowErrorSet(
           error,
-          "Expected valid schema at schema->children[%d] but found a released schema", i);
+          "Expected valid schema at schema->children[%ld] but found a released schema", (long)i);
       return EINVAL;
     }
   }

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -957,13 +957,15 @@ static ArrowErrorCode ArrowSchemaViewValidateNChildren(
   for (int64_t i = 0; i < schema_view->schema->n_children; i++) {
     child = schema_view->schema->children[i];
     if (child == NULL) {
-      ArrowErrorSet(error, "Expected valid schema at schema->children[%ld] but found NULL",
+      ArrowErrorSet(error,
+                    "Expected valid schema at schema->children[%ld] but found NULL",
                     (long)i);
       return EINVAL;
     } else if (child->release == NULL) {
       ArrowErrorSet(
           error,
-          "Expected valid schema at schema->children[%ld] but found a released schema", (long)i);
+          "Expected valid schema at schema->children[%ld] but found a released schema",
+          (long)i);
       return EINVAL;
     }
   }
@@ -1175,10 +1177,12 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
   schema_view->extension_name = ArrowCharView(NULL);
   schema_view->extension_metadata = ArrowCharView(NULL);
-  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:name"),
-                        &schema_view->extension_name);
-  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:metadata"),
-                        &schema_view->extension_metadata);
+  NANOARROW_RETURN_NOT_OK(ArrowMetadataGetValue(schema->metadata,
+                                                ArrowCharView("ARROW:extension:name"),
+                                                &schema_view->extension_name));
+  NANOARROW_RETURN_NOT_OK(ArrowMetadataGetValue(schema->metadata,
+                                                ArrowCharView("ARROW:extension:metadata"),
+                                                &schema_view->extension_metadata));
 
   return NANOARROW_OK;
 }
@@ -1366,7 +1370,9 @@ int64_t ArrowMetadataSizeOf(const char* metadata) {
   struct ArrowMetadataReader reader;
   struct ArrowStringView key;
   struct ArrowStringView value;
-  ArrowMetadataReaderInit(&reader, metadata);
+  if (ArrowMetadataReaderInit(&reader, metadata) != NANOARROW_OK) {
+    return 0;
+  }
 
   int64_t size = sizeof(int32_t);
   while (ArrowMetadataReaderRead(&reader, &key, &value) == NANOARROW_OK) {
@@ -1382,7 +1388,7 @@ static ArrowErrorCode ArrowMetadataGetValueInternal(const char* metadata,
   struct ArrowMetadataReader reader;
   struct ArrowStringView existing_key;
   struct ArrowStringView existing_value;
-  ArrowMetadataReaderInit(&reader, metadata);
+  NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderInit(&reader, metadata));
 
   while (ArrowMetadataReaderRead(&reader, &existing_key, &existing_value) ==
          NANOARROW_OK) {
@@ -1409,7 +1415,10 @@ ArrowErrorCode ArrowMetadataGetValue(const char* metadata, struct ArrowStringVie
 
 char ArrowMetadataHasKey(const char* metadata, struct ArrowStringView key) {
   struct ArrowStringView value = ArrowCharView(NULL);
-  ArrowMetadataGetValue(metadata, key, &value);
+  if (ArrowMetadataGetValue(metadata, key, &value) != NANOARROW_OK) {
+    return 0;
+  }
+
   return value.data != NULL;
 }
 

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -388,7 +388,7 @@ TEST(SchemaTest, SchemaInitUnion) {
 
 TEST(SchemaTest, SchemaSetFormat) {
   struct ArrowSchema schema;
-  ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED);
+  ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
 
   EXPECT_EQ(ArrowSchemaSetFormat(&schema, "i"), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "i");
@@ -401,7 +401,7 @@ TEST(SchemaTest, SchemaSetFormat) {
 
 TEST(SchemaTest, SchemaSetName) {
   struct ArrowSchema schema;
-  ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED);
+  ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
 
   EXPECT_EQ(ArrowSchemaSetName(&schema, "a_name"), NANOARROW_OK);
   EXPECT_STREQ(schema.name, "a_name");
@@ -414,7 +414,7 @@ TEST(SchemaTest, SchemaSetName) {
 
 TEST(SchemaTest, SchemaSetMetadata) {
   struct ArrowSchema schema;
-  ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED);
+  ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
 
   // Encoded metadata string for "key": "value"
   std::string simple_metadata = SimpleMetadata();
@@ -430,7 +430,7 @@ TEST(SchemaTest, SchemaSetMetadata) {
 
 TEST(SchemaTest, SchemaAllocateDictionary) {
   struct ArrowSchema schema;
-  ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED);
+  ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_UNINITIALIZED), NANOARROW_OK);
 
   EXPECT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
   EXPECT_EQ(schema.dictionary->release, nullptr);
@@ -443,7 +443,7 @@ TEST(SchemaTest, SchemaCopySimpleType) {
   ARROW_EXPECT_OK(ExportType(*int32(), &schema));
 
   struct ArrowSchema schema_copy;
-  ArrowSchemaDeepCopy(&schema, &schema_copy);
+  ASSERT_EQ(ArrowSchemaDeepCopy(&schema, &schema_copy), NANOARROW_OK);
 
   ASSERT_NE(schema_copy.release, nullptr);
   EXPECT_STREQ(schema.format, "i");
@@ -458,7 +458,7 @@ TEST(SchemaTest, SchemaCopyNestedType) {
   ARROW_EXPECT_OK(ExportType(*struct_type, &schema));
 
   struct ArrowSchema schema_copy;
-  ArrowSchemaDeepCopy(&schema, &schema_copy);
+  ASSERT_EQ(ArrowSchemaDeepCopy(&schema, &schema_copy), NANOARROW_OK);
 
   ASSERT_NE(schema_copy.release, nullptr);
   EXPECT_STREQ(schema_copy.format, "+s");
@@ -476,7 +476,7 @@ TEST(SchemaTest, SchemaCopyDictType) {
   ARROW_EXPECT_OK(ExportType(*struct_type, &schema));
 
   struct ArrowSchema schema_copy;
-  ArrowSchemaDeepCopy(&schema, &schema_copy);
+  ASSERT_EQ(ArrowSchemaDeepCopy(&schema, &schema_copy), NANOARROW_OK);
 
   ASSERT_STREQ(schema_copy.format, "i");
   ASSERT_NE(schema_copy.dictionary, nullptr);
@@ -494,7 +494,7 @@ TEST(SchemaTest, SchemaCopyFlags) {
   ASSERT_FALSE(schema.flags & ARROW_FLAG_NULLABLE);
 
   struct ArrowSchema schema_copy;
-  ArrowSchemaDeepCopy(&schema, &schema_copy);
+  ASSERT_EQ(ArrowSchemaDeepCopy(&schema, &schema_copy), NANOARROW_OK);
 
   ASSERT_NE(schema_copy.release, nullptr);
   ASSERT_EQ(schema.flags, schema_copy.flags);
@@ -513,7 +513,7 @@ TEST(SchemaTest, SchemaCopyMetadata) {
   ARROW_EXPECT_OK(ExportField(*int_field, &schema));
 
   struct ArrowSchema schema_copy;
-  ArrowSchemaDeepCopy(&schema, &schema_copy);
+  ASSERT_EQ(ArrowSchemaDeepCopy(&schema, &schema_copy), NANOARROW_OK);
 
   ASSERT_NE(schema_copy.release, nullptr);
   EXPECT_STREQ(schema_copy.name, "field_name");


### PR DESCRIPTION
As noted in https://github.com/apache/arrow-nanoarrow/issues/224, we can use a format check attribute to ensure that format strings/types match and check that `ArrowErrorCode` is always checked.

While I was in it for compiler warnings, I enabled a few more that recently caused a problem in the Arrow R package.

To minimize impact on existing usage, these are only enabled when `NANOARROW_DEBUG` is defined (as it is for all CMake debug builds and in our CI).