### PR TITLE
ci(python): Add cibuildwheel setup for Python wheels

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -17,7 +17,7 @@
 
 name: Build Python Wheels
 
-# Build wheels only on a release branch or when requested since it's expensive
+# Build wheels only on a release branch, weekly, or when requested
 on:
   pull_request:
     branches:
@@ -25,12 +25,6 @@ on:
     paths:
       - '.github/workflows/python-wheels.yaml'
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to force on wheels"
-        required: false
-        type: string
-        default: ""
   push:
     branches:
       - 'maint-**'
@@ -45,8 +39,7 @@ jobs:
         - "ubuntu-20.04"
         - "windows-2019"
         - "macOS-11"
-        - ["self-hosted", "ubuntu-20.04", "arm64"]
-        - ["self-hosted", "macOS", "arm64"]
+        - ["self-hosted", "ubuntu-20.04", "arm"]
 
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +54,8 @@ jobs:
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse python
+        env:
+          CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
+        with:
+          package-dir: python
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
           # Optional (test suite will pass if these are not available)

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -87,10 +87,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
-        with:
-          package-dir: python
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse python
         env:
           # Optional (test suite will pass if these are not available)
           # Commenting this for now because not all the tests pass yet (fixes in another PR)

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -86,7 +86,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
     - name: Check that cmake is installed
       run: |
         cmake --version

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -17,7 +17,7 @@
 
 name: Build Python Wheels
 
-# Build wheels weekly or when requested
+# Build wheels weekly, on commit to main, or when requested
 on:
   pull_request:
     branches:
@@ -28,6 +28,9 @@ on:
       - 'python/pyproject.toml'
       - 'python/bootstrap.py'
       - 'python/MANIFEST.in'
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '6 0 * * 0'

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -42,9 +42,9 @@ jobs:
       run: |
         cmake --version
 
-    - name: Install build
+    - name: Install packaging tools
       run: |
-        pip install build
+        pip install build twine
 
     - name: Build sdist
       run: |
@@ -58,6 +58,10 @@ jobs:
     - name: Test import
       run: |
         python -c "import nanoarrow; print(nanoarrow.__version__)"
+
+    - name: Run twine check
+      run: |
+        twine check --strict python/dist/*
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -82,7 +82,6 @@ jobs:
           - {os: "windows-2019", label: "windows"}
           - {os: "macOS-11", label: "macOS"}
           - {os: ["self-hosted", "arm"], label: "linux/arm64"}
-          - {os: ["self-hosted", "macOS", "arm64"], label: "macOS/arm64"}
 
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +96,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse python
         env:
+          CIBW_ARCHS_MACOS: x86_64 arm64
           # Optional (test suite will pass if these are not available)
           # Commenting this for now because not all the tests pass yet (fixes in another PR)
           # CIBW_BEFORE_TEST: pip install --only-binary ":all:" pyarrow numpy || pip install --only-binary ":all:" numpy || true

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -60,11 +60,16 @@ jobs:
         path: ./python/dist/nanoarrow-*.tar.gz
 
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    needs: ["build_sdist"]
+    name: Build wheels on ${{ matrix.config.label }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "windows-2019", "macOS-11"]
+        config:
+          - {os: "ubuntu-20.04", label: "linux"}
+          - {os: "windows-2019", label: "windows"}
+          - {os: "macOS-11", label: "macOS"}
+          - {os: ["self-hosted", "arm", "linux"], label: "linux/arm64"}
 
     steps:
       - uses: actions/checkout@v4
@@ -87,24 +92,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
-
-  build_wheels_linux_arm:
-    name: Build wheels (linux/arm64)
-    runs-on: ["self-hosted", "arm", "linux"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v3
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
-
-      - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse python
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: wheels-arm
           path: ./wheelhouse/*.whl

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -59,7 +59,7 @@ jobs:
       run: |
         python -c "import nanoarrow; print(nanoarrow.__version__)"
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: sdist
         path: ./python/dist/nanoarrow-*.tar.gz

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -17,7 +17,7 @@
 
 name: Build Python Wheels
 
-# Build wheels only on a release branch, weekly, or when requested
+# Build wheels weekly or when requested
 on:
   pull_request:
     branches:
@@ -25,21 +25,41 @@ on:
     paths:
       - '.github/workflows/python-wheels.yaml'
   workflow_dispatch:
-  push:
-    branches:
-      - 'maint-**'
+  schedule:
+    - cron: '6 0 * * 0'
 
 jobs:
+  build_sdist:
+    runs-on: "ubuntu-20.04"
+    steps:
+    - uses: actions/setup-python@v3
+    - name: Check that cmake is installed
+      run: |
+        cmake --version
+
+    - name: Install build
+      run: |
+        pip install build
+
+    - name: Build sdist
+      run: |
+        cd python
+        python -m build --sdist
+
+    - name: Check install from sdist
+      run: |
+        pip install python/dist/nanoarrow-*.tar.gz
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./python/dist/nanoarrow-*.tar.gz
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-        - "ubuntu-20.04"
-        - "windows-2019"
-        - "macOS-11"
-        - ["self-hosted", "arm"]
+        os: ["ubuntu-20.04", "windows-2019", "macOS-11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +76,28 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse python
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheels_linux_arm:
+    name: Build wheels (linux/arm64)
+    runs-on: ["self-hosted", "arm"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse python
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -51,6 +51,10 @@ jobs:
       run: |
         pip install python/dist/nanoarrow-*.tar.gz
 
+    - name: Test import
+      run: |
+        python -c "import nanoarrow; print(nanoarrow.__version__)"
+
     - uses: actions/upload-artifact@v3
       with:
         path: ./python/dist/nanoarrow-*.tar.gz
@@ -74,6 +78,10 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse python
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
+          # Optional (test suite will pass if these are not available)
+          CIBW_BEFORE_TEST: pip install --only-binary ":all:" pyarrow numpy || pip install --only-binary ":all:" numpy || true
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {package}/tests
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -79,7 +79,8 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
           # Optional (test suite will pass if these are not available)
-          CIBW_BEFORE_TEST: pip install --only-binary ":all:" pyarrow numpy || pip install --only-binary ":all:" numpy || true
+          # Commenting this for now because not all the tests pass yet (fixes in another PR)
+          # CIBW_BEFORE_TEST: pip install --only-binary ":all:" pyarrow numpy || pip install --only-binary ":all:" numpy || true
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        if: matrix.config.label != 'linux/arm64'
+        if: matrix.config.label != 'linux-arm64'
         with:
           python-version: "3.11"
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -88,6 +88,8 @@ jobs:
 
       - uses: actions/setup-python@v5
         if: matrix.config.label != 'linux/arm64'
+        with:
+          python-version: "3.11"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -87,6 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        if: matrix.config.label != 'linux/arm64'
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -71,7 +71,7 @@ jobs:
           - {os: "macOS-11", label: "macOS"}
           # Doesn't seem to work yet. Ref:
           # https://github.com/apache/arrow/blob/main/.github/workflows/go.yml#L46-L66
-          # - {os: ["self-hosted", "arm", "linux"], label: "linux/arm64"}
+          - {os: ["self-hosted", "arm"], label: "linux/arm64"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -77,17 +77,15 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wheels
           path: ./wheelhouse/*.whl
 
   build_wheels_linux_arm:
     name: Build wheels (linux/arm64)
-    runs-on: ["self-hosted", "Linux", "arm64"]
+    runs-on: ["self-hosted", "arm", "linux"]
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-
       - uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
@@ -99,4 +97,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wheels-arm
           path: ./wheelhouse/*.whl

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -81,12 +81,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
-
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse python
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
           # Optional (test suite will pass if these are not available)

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Build Python Wheels
+
+# Build wheels only on a release branch or when requested since it's expensive
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/python-wheels.yaml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to force on wheels"
+        required: false
+        type: string
+        default: ""
+  push:
+    branches:
+      - 'maint-**'
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+        - "ubuntu-20.04"
+        - "windows-2019"
+        - "macOS-11"
+        - ["self-hosted", "ubuntu-20.04", "arm64"]
+        - ["self-hosted", "macOS", "arm64"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse python
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -39,7 +39,7 @@ jobs:
         - "ubuntu-20.04"
         - "windows-2019"
         - "macOS-11"
-        - ["self-hosted", "ubuntu-20.04", "arm"]
+        - ["self-hosted", "arm"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -24,6 +24,10 @@ on:
       - main
     paths:
       - '.github/workflows/python-wheels.yaml'
+      - 'python/setup.py'
+      - 'python/pyproject.toml'
+      - 'python/bootstrap.py'
+      - 'python/MANIFEST.in'
   workflow_dispatch:
   schedule:
     - cron: '6 0 * * 0'

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -32,6 +32,7 @@ jobs:
   build_sdist:
     runs-on: "ubuntu-20.04"
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v3
     - name: Check that cmake is installed
       run: |
@@ -63,9 +64,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-
       - uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
@@ -83,7 +81,7 @@ jobs:
 
   build_wheels_linux_arm:
     name: Build wheels (linux/arm64)
-    runs-on: ["self-hosted", "arm"]
+    runs-on: ["self-hosted", "Linux", "arm64"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -92,7 +92,6 @@ jobs:
         with:
           package-dir: python
         env:
-          CIBW_ARCHS_MACOS: x86_64 arm64
           # Optional (test suite will pass if these are not available)
           # Commenting this for now because not all the tests pass yet (fixes in another PR)
           # CIBW_BEFORE_TEST: pip install --only-binary ":all:" pyarrow numpy || pip install --only-binary ":all:" numpy || true

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -81,8 +81,8 @@ jobs:
           - {os: "ubuntu-20.04", label: "linux"}
           - {os: "windows-2019", label: "windows"}
           - {os: "macOS-11", label: "macOS"}
-          # Uncomment when apache/arrow-nanoarrow is added to the arrow runner group
-          # - {os: ["self-hosted", "arm"], label: "linux/arm64"}
+          - {os: ["self-hosted", "arm"], label: "linux/arm64"}
+          - {os: ["self-hosted", "macOS", "arm64"], label: "macOS/arm64"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -57,6 +57,7 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
+        name: sdist
         path: ./python/dist/nanoarrow-*.tar.gz
 
   build_wheels:
@@ -69,9 +70,8 @@ jobs:
           - {os: "ubuntu-20.04", label: "linux"}
           - {os: "windows-2019", label: "windows"}
           - {os: "macOS-11", label: "macOS"}
-          # Doesn't seem to work yet. Ref:
-          # https://github.com/apache/arrow/blob/main/.github/workflows/go.yml#L46-L66
-          - {os: ["self-hosted", "arm"], label: "linux/arm64"}
+          # Uncomment when apache/arrow-nanoarrow is added to the arrow runner group
+          # - {os: ["self-hosted", "arm"], label: "linux/arm64"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -69,7 +69,9 @@ jobs:
           - {os: "ubuntu-20.04", label: "linux"}
           - {os: "windows-2019", label: "windows"}
           - {os: "macOS-11", label: "macOS"}
-          - {os: ["self-hosted", "arm", "linux"], label: "linux/arm64"}
+          # Doesn't seem to work yet. Ref:
+          # https://github.com/apache/arrow/blob/main/.github/workflows/go.yml#L46-L66
+          # - {os: ["self-hosted", "arm", "linux"], label: "linux/arm64"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -81,7 +81,7 @@ jobs:
           - {os: "ubuntu-20.04", label: "linux"}
           - {os: "windows-2019", label: "windows"}
           - {os: "macOS-11", label: "macOS"}
-          - {os: ["self-hosted", "arm"], label: "linux/arm64"}
+          - {os: ["self-hosted", "arm"], label: "linux-arm64"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -91,7 +91,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ matrix.config.label }}
           path: ./wheelhouse/*.whl

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -26,11 +26,13 @@ update_versions() {
     release)
       local version=${base_version}
       local docs_version=${base_version}
+      local python_version=${base_version}
       local r_version=${base_version}
       ;;
     snapshot)
       local version=${next_version}-SNAPSHOT
       local docs_version="${next_version} (dev)"
+      local python_version="${next_version}dev"
       local r_version="${base_version}.9000"
       ;;
   esac
@@ -45,6 +47,12 @@ update_versions() {
   pushd "${NANOARROW_DIR}/r"
   Rscript -e "desc::desc_set(Version = '${r_version}')"
   git add DESCRIPTION
+  popd
+
+  pushd "${NANOARROW_DIR}/python/src/nanoarrow"
+  sed -i.bak -E "s/version = \".+\"/version = \"${python_version}\"/" _static_version.py
+  rm _static_version.py.bak
+  git add _static_version.py
   popd
 }
 

--- a/python/.gitattributes
+++ b/python/.gitattributes
@@ -1,0 +1,1 @@
+src/nanoarrow/_static_version.py export-subst

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -18,6 +18,7 @@
 exclude bootstrap.py
 include src/nanoarrow/nanoarrow.c
 include src/nanoarrow/nanoarrow.h
+include src/nanoarrow/nanoarrow_c.pxd
 include src/nanoarrow/nanoarrow_device.c
 include src/nanoarrow/nanoarrow_device.h
-include src/nanoarrow/nanoarrow_c.pxd
+include src/nanoarrow/nanoarrow_device_c.pxd

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -18,4 +18,6 @@
 exclude bootstrap.py
 include src/nanoarrow/nanoarrow.c
 include src/nanoarrow/nanoarrow.h
+include src/nanoarrow/nanoarrow_device.c
+include src/nanoarrow/nanoarrow_device.h
 include src/nanoarrow/nanoarrow_c.pxd

--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -16,8 +16,11 @@
 # under the License.
 
 import os
+import subprocess
 import re
 import shutil
+import tempfile
+import warnings
 
 
 # Generate the nanoarrow_c.pxd file used by the Cython extension
@@ -185,42 +188,49 @@ def copy_or_generate_nanoarrow_c():
         os.path.join(source_dir, "src", "nanoarrow")
     )
     has_cmake = os.system("cmake --version") == 0
-    build_dir = os.path.join(this_dir, "_cmake")
 
-    if is_in_nanoarrow_repo:
-        device_ext_src = os.path.join(
-            source_dir, "extensions/nanoarrow_device/src/nanoarrow"
-        )
-        shutil.copyfile(
-            os.path.join(device_ext_src, "nanoarrow_device.h"), maybe_nanoarrow_device_h
-        )
-        shutil.copyfile(
-            os.path.join(device_ext_src, "nanoarrow_device.c"), maybe_nanoarrow_device_c
-        )
-
-    if has_cmake and is_cmake_dir and is_in_nanoarrow_repo:
-        try:
-            os.mkdir(build_dir)
-            os.chdir(build_dir)
-            os.system(
-                "cmake ../.. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=PythonPkg"
+    with tempfile.TemporaryDirectory() as build_dir:
+        if is_in_nanoarrow_repo:
+            device_ext_src = os.path.join(
+                source_dir, "extensions/nanoarrow_device/src/nanoarrow"
             )
-            os.system("cmake --install . --prefix=../src/nanoarrow")
-        finally:
-            if os.path.exists(build_dir):
-                # Can fail on Windows with permission issues
-                try:
-                    shutil.rmtree(build_dir)
-                except Exception as e:
-                    print(f"Failed to remove _cmake temp directory: {str(e)}")
-            os.chdir(this_wd)
+            shutil.copyfile(
+                os.path.join(device_ext_src, "nanoarrow_device.h"),
+                maybe_nanoarrow_device_h,
+            )
+            shutil.copyfile(
+                os.path.join(device_ext_src, "nanoarrow_device.c"),
+                maybe_nanoarrow_device_c,
+            )
 
-    elif is_in_nanoarrow_repo:
-        shutil.copyfile()
-    else:
-        raise ValueError(
-            "Attempt to build source distribution outside the nanoarrow repo"
-        )
+        if has_cmake and is_cmake_dir and is_in_nanoarrow_repo:
+            try:
+                subprocess.run(
+                    [
+                        "cmake",
+                        "-B",
+                        build_dir,
+                        "-S",
+                        source_dir,
+                        "-DNANOARROW_BUNDLE=ON",
+                        "-DNANOARROW_NAMESPACE=PythonPkg",
+                    ]
+                )
+                subprocess.run(
+                    [
+                        "cmake",
+                        "--install",
+                        build_dir,
+                        "--prefix",
+                        os.path.join(this_dir, "src", "nanoarrow"),
+                    ]
+                )
+            except Exception as e:
+                warnings.warn(f"cmake call failed: {e}")
+        else:
+            raise ValueError(
+                "Attempt to build source distribution outside the nanoarrow repo"
+            )
 
     if not os.path.exists(os.path.join(this_dir, "src/nanoarrow/nanoarrow.h")):
         raise ValueError("Attempt to vendor nanoarrow.c/h failed")

--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -16,9 +16,9 @@
 # under the License.
 
 import os
-import subprocess
 import re
 import shutil
+import subprocess
 import tempfile
 import warnings
 
@@ -161,7 +161,6 @@ class NanoarrowPxdGenerator:
 # any changes from nanoarrow C library sources in the checkout but is not
 # strictly necessary for things like installing from GitHub.
 def copy_or_generate_nanoarrow_c():
-    this_wd = os.getcwd()
     this_dir = os.path.abspath(os.path.dirname(__file__))
     source_dir = os.path.dirname(this_dir)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,7 +34,6 @@ repository = "https://github.com/apache/arrow-nanoarrow"
 [build-system]
 requires = [
     "setuptools >= 61.0.0",
-    "versioneer[toml]==0.29",
     "Cython"
 ]
 build-backend = "setuptools.build_meta"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,7 @@
 
 [project]
 name = "nanoarrow"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 description = "Python bindings to the nanoarrow C library"
 authors = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
 license = {text = "Apache-2.0"}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,7 +18,8 @@
 
 [project]
 name = "nanoarrow"
-dynamic = ["version", "readme"]
+dynamic = ["version"]
+readme = "README.md"
 description = "Python bindings to the nanoarrow C library"
 authors = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
 license = {text = "Apache-2.0"}

--- a/python/setup.py
+++ b/python/setup.py
@@ -66,13 +66,6 @@ else:
     extra_define_macros = []
 
 
-# README content
-readme_dir = os.path.dirname(__file__)
-readme_path = os.path.join(readme_dir, "README.md")
-with open(readme_path) as readme:
-    long_description = readme.read()
-
-
 setup(
     ext_modules=[
         Extension(
@@ -90,6 +83,4 @@ setup(
         )
     ],
     version=version,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,6 +65,14 @@ else:
     extra_link_args = []
     extra_define_macros = []
 
+
+# README content
+readme_dir = os.path.dirname(__file__)
+readme_path = os.path.join(readme_dir, "README.md")
+with open(readme_path) as readme:
+    long_description = readme.read()
+
+
 setup(
     ext_modules=[
         Extension(
@@ -82,4 +90,6 @@ setup(
         )
     ],
     version=version,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -23,6 +23,24 @@ import sys
 
 from setuptools import Extension, setup
 
+
+# https://github.com/jbweston/miniver
+def get_version(pkg_path):
+    """
+    Load version.py module without importing the whole package.
+
+    Template code from miniver.
+    """
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location("version", os.path.join(pkg_path, "_version.py"))
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.__version__
+
+version = get_version("src/nanoarrow")
+
+
 # Run bootstrap.py to run cmake generating a fresh bundle based on this
 # checkout or copy from ../dist if the caller doesn't have cmake available.
 # Note that bootstrap.py won't exist if building from sdist.
@@ -61,5 +79,6 @@ setup(
             extra_link_args=extra_link_args,
             define_macros=extra_define_macros,
         )
-    ]
+    ],
+    version=version,
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,6 +38,7 @@ def get_version(pkg_path):
     spec.loader.exec_module(module)
     return module.__version__
 
+
 version = get_version("src/nanoarrow")
 
 

--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -17,3 +17,4 @@
 
 from ._lib import Array, ArrayStream, ArrayView, Schema, c_version  # noqa: F401
 from .lib import array, array_stream, schema, array_view  # noqa: F401
+from ._version import __version__  # noqa: F401

--- a/python/src/nanoarrow/_static_version.py
+++ b/python/src/nanoarrow/_static_version.py
@@ -1,4 +1,3 @@
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,26 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+# This file is part of 'miniver': https://github.com/jbweston/miniver
 
-[project]
-name = "nanoarrow"
-dynamic = ["version"]
-description = "Python bindings to the nanoarrow C library"
-authors = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
-license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+# Replaced by version-bumping scripts at release time
+version = "0.4.0dev"
 
-[project.optional-dependencies]
-test = ["pyarrow", "pytest", "numpy"]
-
-[project.urls]
-homepage = "https://arrow.apache.org"
-repository = "https://github.com/apache/arrow-nanoarrow"
-
-[build-system]
-requires = [
-    "setuptools >= 61.0.0",
-    "versioneer[toml]==0.29",
-    "Cython"
-]
-build-backend = "setuptools.build_meta"
+# These values are only set if the distribution was created with 'git archive'
+refnames = "$Format:%D$"
+git_hash = "$Format:%h$"

--- a/python/src/nanoarrow/_version.py
+++ b/python/src/nanoarrow/_version.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file is part of 'miniver': https://github.com/jbweston/miniver
+
+import os
+
+# No public API
+__all__ = []
+
+package_root = os.path.dirname(os.path.realpath(__file__))
+package_name = os.path.basename(package_root)
+
+STATIC_VERSION_FILE = "_static_version.py"
+
+
+def get_version(version_file=STATIC_VERSION_FILE):
+    override = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION")
+    if override is not None and override != "":
+        return override
+    version_info = get_static_version_info(version_file)
+    version = version_info["version"]
+    return version
+
+
+def get_static_version_info(version_file=STATIC_VERSION_FILE):
+    version_info = {}
+    with open(os.path.join(package_root, version_file), "rb") as f:
+        exec(f.read(), {}, version_info)
+    return version_info
+
+
+__version__ = get_version()
+
+if __name__ == "__main__":
+    print("Version: ", get_version())

--- a/python/tests/test_capsules.py
+++ b/python/tests/test_capsules.py
@@ -14,10 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pyarrow as pa
+
 import pytest
 
 import nanoarrow as na
+
+pa = pytest.importorskip("pyarrow")
 
 
 class SchemaWrapper:

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -15,9 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pyarrow as pa
+import pytest
 
 from nanoarrow import device
+
+pa = pytest.importorskip("pyarrow")
 
 
 def test_cpu_device():

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -15,19 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
 import sys
 
-import numpy as np
-import pyarrow as pa
 import pytest
 
 import nanoarrow as na
 
-
-def test_c_version():
-    re_version = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$")
-    assert re_version.match(na.c_version()) is not None
+np = pytest.importorskip("numpy")
+pa = pytest.importorskip("pyarrow")
 
 
 def test_schema_helper():

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -14,12 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# This file is part of 'miniver': https://github.com/jbweston/miniver
 
-# Replaced by version-bumping scripts at release time
-version = "0.4.0dev0"
+import re
+import nanoarrow as na
 
-# These values are only set if the distribution was created with 'git archive'
-refnames = "$Format:%D$"
-git_hash = "$Format:%h$"
+
+def test_version():
+    re_py_version = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(dev[0-9+])?$")
+    assert re_py_version.match(na.__version__) is not None
+
+
+def test_c_version():
+    re_version = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$")
+    assert re_version.match(na.c_version()) is not None

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import re
+
 import nanoarrow as na
 
 


### PR DESCRIPTION
This PR adds a weekly/workflow dispatch job for building and testing Python wheels. This required a few housekeeping items:

- Versioning the python package. I used the approach from ADBC, which is a modified 'miniver'. Basically, just set the version as a string using a regex replace when needed.
- The bootstrap.py logic was updated to use a proper temporary directory
- Tests were updated to skip instead of fail when pyarrow/numpy are not available (because I can never remember which platforms they will or won't install on and the default cibuildwheel grid is large).
- I hadn't tested install from sdist, so a few files were missing from the manifest.

Two outstanding issues that don't necessarily need to be solved in this PR:

- The linux arm self-hosted runner not is not picking up the job? (config copied from https://github.com/apache/arrow/blob/main/.github/workflows/go.yml#L46-L66 ). It's not the end of the world to not have linux/arm64 wheels but if we already have the runner set up it seems like a good time to make sure it works.
- At least one test doesn't pass on 32-bit Windows (already fixed in #340). For now I just enabled the version tests to make sure everything built/linked properly.