### PR TITLE
chore(ci): Integrate Python into more CI workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -57,4 +57,4 @@ jobs:
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2
         with:
-          files: '_coverage/coverage.info,_coverage/r_coverage.json'
+          files: '_coverage/coverage.info,_coverage/r_coverage.json,_coverage/python_coverage.xml'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -55,6 +55,6 @@ jobs:
           path: _coverage
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: '_coverage/coverage.info,_coverage/r_coverage.json,_coverage/python_coverage.xml'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -59,12 +59,12 @@ jobs:
           pytest python/tests -v -s
 
       - name: Run doctests
-        if: success() && matrix.python-version == '3.10'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pytest --pyargs nanoarrow --doctest-modules
 
       - name: Coverage
-        if: success() && matrix.python-version == '3.10'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pip uninstall --yes nanoarrow
           pip install pytest-cov Cython
@@ -79,7 +79,7 @@ jobs:
           python -m coverage xml
 
       - name: Upload coverage to codecov
-        if: success() && matrix.python-version == '3.10'
+        if: success() && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v2
         with:
           files: 'python/coverage.xml'

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -62,24 +62,3 @@ jobs:
         if: success() && matrix.python-version == '3.12'
         run: |
           pytest --pyargs nanoarrow --doctest-modules
-
-      - name: Coverage
-        if: success() && matrix.python-version == '3.12'
-        run: |
-          pip uninstall --yes nanoarrow
-          pip install pytest-cov Cython
-          pushd python
-
-          # Build with Cython + gcc coverage options
-          pip install -e .
-          NANOARROW_PYTHON_COVERAGE=1 python setup.py build_ext --inplace
-
-          # Run tests + coverage.py (generates .coverage + coverage.xml files)
-          python -m pytest --cov ./src/nanoarrow
-          python -m coverage xml
-
-      - name: Upload coverage to codecov
-        if: success() && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v2
-        with:
-          files: 'python/coverage.xml'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -138,7 +138,9 @@ jobs:
           - {
               platform: "centos7",
               arch: "amd64",
-              compose_args: "-e NANOARROW_ACCEPT_IMPORT_GPG_KEYS_ERROR=1"
+              # Currently the Python on the centos7 image is 3.6, which does not support
+              # new enough setuptools to build the Python package.
+              compose_args: "-e NANOARROW_ACCEPT_IMPORT_GPG_KEYS_ERROR=1 -e TEST_PYTHON=0"
             }
           - {
               platform: "ubuntu",

--- a/ci/scripts/coverage.sh
+++ b/ci/scripts/coverage.sh
@@ -54,8 +54,6 @@ esac
 
 maybe_activate_venv() {
   if [ ! -z "${NANOARROW_PYTHON_VENV}" ]; then
-    # TODO: Move to dockerfiles
-    apt-get install -y python3-dev
     source "${NANOARROW_PYTHON_VENV}/bin/activate"
   fi
 }

--- a/ci/scripts/coverage.sh
+++ b/ci/scripts/coverage.sh
@@ -153,8 +153,7 @@ function main() {
     TARGET_NANOARROW_PYTHON_DIR="${TARGET_NANOARROW_DIR}/python"
 
     pushd "${TARGET_NANOARROW_PYTHON_DIR}"
-    python -m pip install -e .
-    NANOARROW_COVERAGE=1 python setup.py build_ext --inplace
+    NANOARROW_PYTHON_COVERAGE=1 python -m pip install -e .
 
     # Run tests + coverage.py (generates .coverage with absolute file paths)
     python -m pytest --cov ./src/nanoarrow

--- a/ci/scripts/coverage.sh
+++ b/ci/scripts/coverage.sh
@@ -158,14 +158,23 @@ function main() {
     python -m pip install -e .
     NANOARROW_COVERAGE=1 python setup.py build_ext --inplace
 
-    # Run tests + coverage.py (generates .coverage + coverage.xml files)
+    # Run tests + coverage.py (generates .coverage with absolute file paths)
     python -m pytest --cov ./src/nanoarrow
-    python -m coverage xml
-    python -m coverage html
 
-    mv .coverage "${SANDBOX_DIR}/python_coverage.db"
-    mv coverage.xml "${SANDBOX_DIR}/python_coverage.xml"
+    # Generate HTML report (file paths not important since it's just for viewing)
+    python -m coverage html
     mv htmlcov "${SANDBOX_DIR}/python_htmlcov"
+
+    # Move .coverage to the root directory and generate coverage.xml
+    # (generates relative file paths from the root of the repo)
+    mv .coverage ..
+    cp .coveragerc ..
+    pushd ..
+    python -m coverage xml
+    mv coverage.xml "${SANDBOX_DIR}/python_coverage.xml"
+    mv .coverage "${SANDBOX_DIR}/python_coverage.db"
+    rm .coveragerc
+    popd
 
     popd
     popd

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -302,7 +302,8 @@ activate_or_create_venv() {
     show_info "Activating virtual environment at ${NANOARROW_PYTHON_VENV}"
     # TODO: Move to dockerfiles
     apt-get install -y python3-dev
-    source "${NANOARROW_PYTHON_VENV}/bin/activate"
+    # bash on Windows needs venv/Scripts/activate instead of venv/bin/activate
+    source "${NANOARROW_PYTHON_VENV}/bin/activate" || source "${NANOARROW_PYTHON_VENV}/Scripts/activate"
   else
     # Try python3 first, then try regular python (e.g., Windows)
     if [ -z "${PYTHON_BIN}" ] && python3 --version >/dev/null; then
@@ -313,7 +314,8 @@ activate_or_create_venv() {
 
     show_info "Creating temporary virtual environment using ${PYTHON_BIN}..."
     "${PYTHON_BIN}" -m venv "${NANOARROW_TMPDIR}/venv"
-    source "${NANOARROW_TMPDIR}/venv/bin/activate"
+    # bash on Windows needs venv/Scripts/activate instead of venv/bin/activate
+    source "${NANOARROW_TMPDIR}/venv/bin/activate" || source "${NANOARROW_TMPDIR}/venv/Scripts/activate"
     pip install --upgrade pip
   fi
 }

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -335,7 +335,7 @@ test_python() {
   PYTHON_SDIST_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".tar.gz")
   PYTHON_WHEEL_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".whl")
 
-  show_info "Installing from sdist"
+  show_info "Installing from source distribution"
   python -m pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[test]"
 
   show_info "Testing source distribution"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -332,8 +332,17 @@ test_python() {
   python -m build --wheel --outdir "${NANOARROW_TMPDIR}/python"
   PYTHON_WHEEL_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".whl")
 
+  # On Windows bash, pip install needs a Windows-style path
+  if uname | grep -e "_NT-" >/dev/null; then
+    pushd "${NANOARROW_TMPDIR}"
+    PYTHON_WHEEL_PATH="$(pwd -W)/python/${PYTHON_WHEEL_NAME}"
+    popd
+  else
+    PYTHON_WHEEL_PATH="${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}"
+  fi
+
   show_info "Installing Python package"
-  python -m pip install --force-reinstall "${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}[verify]"
+  python -m pip install --force-reinstall "${PYTHON_WHEEL_PATH}[verify]"
 
   show_info "Testing wheel"
   python -m pytest -vv

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -334,7 +334,7 @@ test_python() {
   PYTHON_WHEEL_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".whl")
 
   show_info "Installing from source distribution"
-  python -m pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[test]"
+  python -m pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[verify]"
 
   show_info "Testing source distribution"
   python -m pytest -vv

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -327,20 +327,13 @@ test_python() {
 
   pushd "${NANOARROW_SOURCE_DIR}/python"
 
-  show_info "Building sdist and wheel"
+  show_info "Building Python package"
   rm -rf "${NANOARROW_TMPDIR}/python"
-  python -m build --sdist --wheel --outdir "${NANOARROW_TMPDIR}/python"
-  PYTHON_SDIST_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".tar.gz")
+  python -m build --wheel --outdir "${NANOARROW_TMPDIR}/python"
   PYTHON_WHEEL_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".whl")
 
-  show_info "Installing from source distribution"
-  python -m pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[verify]"
-
-  show_info "Testing source distribution"
-  python -m pytest -vv
-
-  show_info "Installing from wheel"
-  python -m pip install --force-reinstall "${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}"
+  show_info "Installing Python package"
+  python -m pip install --force-reinstall "${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}[verify]"
 
   show_info "Testing wheel"
   python -m pytest -vv

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -300,8 +300,6 @@ test_r() {
 activate_or_create_venv() {
   if [ ! -z "${NANOARROW_PYTHON_VENV}" ]; then
     show_info "Activating virtual environment at ${NANOARROW_PYTHON_VENV}"
-    # TODO: Move to dockerfiles
-    apt-get install -y python3-dev
     # bash on Windows needs venv/Scripts/activate instead of venv/bin/activate
     source "${NANOARROW_PYTHON_VENV}/bin/activate" || source "${NANOARROW_PYTHON_VENV}/Scripts/activate"
   else

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -316,7 +316,7 @@ activate_or_create_venv() {
     "${PYTHON_BIN}" -m venv "${NANOARROW_TMPDIR}/venv"
     # bash on Windows needs venv/Scripts/activate instead of venv/bin/activate
     source "${NANOARROW_TMPDIR}/venv/bin/activate" || source "${NANOARROW_TMPDIR}/venv/Scripts/activate"
-    pip install --upgrade pip
+    python -m pip install --upgrade pip
   fi
 }
 
@@ -325,7 +325,7 @@ test_python() {
   activate_or_create_venv
 
   show_info "Installing build utilities"
-  pip install --upgrade build
+  python -m pip install --upgrade build
 
   pushd "${NANOARROW_SOURCE_DIR}/python"
 
@@ -336,13 +336,13 @@ test_python() {
   PYTHON_WHEEL_NAME=$(ls "${NANOARROW_TMPDIR}/python" | grep -e ".whl")
 
   show_info "Installing from sdist"
-  pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[test]"
+  python -m pip install "${NANOARROW_TMPDIR}/python/${PYTHON_SDIST_NAME}[test]"
 
   show_info "Testing source distribution"
   python -m pytest -vv
 
   show_info "Installing from wheel"
-  pip install --force-reinstall "${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}"
+  python -m pip install --force-reinstall "${NANOARROW_TMPDIR}/python/${PYTHON_WHEEL_NAME}"
 
   show_info "Testing wheel"
   python -m pytest -vv

--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -186,7 +186,10 @@ def copy_or_generate_nanoarrow_c():
     is_in_nanoarrow_repo = "nanoarrow.h" in os.listdir(
         os.path.join(source_dir, "src", "nanoarrow")
     )
-    has_cmake = os.system("cmake --version") == 0
+    cmake_bin = os.getenv("CMAKE_BIN")
+    if not cmake_bin:
+        cmake_bin = "cmake"
+    has_cmake = os.system(f"{cmake_bin} --version") == 0
 
     with tempfile.TemporaryDirectory() as build_dir:
         if is_in_nanoarrow_repo:
@@ -206,7 +209,7 @@ def copy_or_generate_nanoarrow_c():
             try:
                 subprocess.run(
                     [
-                        "cmake",
+                        cmake_bin,
                         "-B",
                         build_dir,
                         "-S",
@@ -217,7 +220,7 @@ def copy_or_generate_nanoarrow_c():
                 )
                 subprocess.run(
                     [
-                        "cmake",
+                        cmake_bin,
                         "--install",
                         build_dir,
                         "--prefix",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,6 +22,7 @@ dynamic = ["version"]
 readme = "README.md"
 description = "Python bindings to the nanoarrow C library"
 authors = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
+maintainers = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
@@ -30,8 +31,10 @@ test = ["pyarrow", "pytest", "numpy"]
 verify = ["pytest", "numpy"]
 
 [project.urls]
-homepage = "https://arrow.apache.org"
-repository = "https://github.com/apache/arrow-nanoarrow"
+Homepage = "https://arrow.apache.org"
+Repository = "https://github.com/apache/arrow-nanoarrow"
+Issues = "https://github.com/apache/arrow-nanoarrow/issues"
+Changelog = "https://github.com/apache/arrow-nanoarrow/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = ["pyarrow", "pytest", "numpy"]
+verify = ["pytest", "numpy"]
 
 [project.urls]
 homepage = "https://arrow.apache.org"

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,6 @@
 # under the License.
 
 import os
-import re
 import subprocess
 import sys
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,6 +20,7 @@
 import os
 import subprocess
 import sys
+import re
 
 from setuptools import Extension, setup
 
@@ -52,7 +53,7 @@ if os.path.exists(bootstrap_py):
 
 
 # Set some extra flags for compiling with coverage support
-if os.getenv("NANOARROW_COVERAGE") == "1":
+if os.getenv("NANOARROW_PYTHON_COVERAGE") == "1":
     extra_compile_args = ["--coverage"]
     extra_link_args = ["--coverage"]
     extra_define_macros = [("CYTHON_TRACE", 1)]
@@ -65,6 +66,11 @@ else:
     extra_link_args = []
     extra_define_macros = []
 
+# Setting the CFLAGS environment variable doesn't seem sufficient in all cases to add
+# extra flags (e.g., -std=c99 on very old gcc).
+more_compile_args = os.getenv("NANOARROW_PYTHON_CFLAGS")
+if more_compile_args:
+    extra_compile_args += re.split(r"\s+", more_compile_args)
 
 setup(
     ext_modules=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -66,12 +66,6 @@ else:
     extra_link_args = []
     extra_define_macros = []
 
-# Setting the CFLAGS environment variable doesn't seem sufficient in all cases to add
-# extra flags (e.g., -std=c99 on very old gcc).
-more_compile_args = os.getenv("NANOARROW_PYTHON_CFLAGS")
-if more_compile_args:
-    extra_compile_args += re.split(r"\s+", more_compile_args)
-
 setup(
     ext_modules=[
         Extension(

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,9 +18,9 @@
 # under the License.
 
 import os
+import re
 import subprocess
 import sys
-import re
 
 from setuptools import Extension, setup
 

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -915,7 +915,7 @@ cdef class CBufferView:
         if format_const != NULL:
             snprintf(self._format, sizeof(self._format), "%s", format_const)
         else:
-            snprintf(self._format, sizeof(self._format), "%ds", self._element_size_bits // 8)
+            snprintf(self._format, sizeof(self._format), "%ds", <int>self._element_size_bits // 8)
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         if self._device.device_type != ARROW_DEVICE_CPU:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -915,7 +915,7 @@ cdef class CBufferView:
         if format_const != NULL:
             snprintf(self._format, sizeof(self._format), "%s", format_const)
         else:
-            snprintf(self._format, sizeof(self._format), "%ds", <int>self._element_size_bits // 8)
+            snprintf(self._format, sizeof(self._format), "%ds", <int>(self._element_size_bits // 8))
 
     def __getbuffer__(self, Py_buffer *buffer, int flags):
         if self._device.device_type != ARROW_DEVICE_CPU:

--- a/python/src/nanoarrow/_static_version.py
+++ b/python/src/nanoarrow/_static_version.py
@@ -18,7 +18,7 @@
 # This file is part of 'miniver': https://github.com/jbweston/miniver
 
 # Replaced by version-bumping scripts at release time
-version = "0.4.0dev0"
+version = "0.4.0.dev0"
 
 # These values are only set if the distribution was created with 'git archive'
 refnames = "$Format:%D$"

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -21,7 +21,7 @@ import nanoarrow as na
 
 
 def test_version():
-    re_py_version = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(dev[0-9+])?$")
+    re_py_version = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9+])?$")
     assert re_py_version.match(na.__version__) is not None
 
 


### PR DESCRIPTION
This PR adds Python to the coverage and verify workflows (except on centos7, where the image isn't set up for a supported version of Python yet). There were also some housekeeping issues identified by various logs that I noticed in the process (e.g., fixing the Python dev version format, ensuring that CMAKE_BIN is respected in bootstrap.py).