### PR TITLE
chore(ci): Add Python development files to verification images and build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -33,22 +33,23 @@ permissions:
 jobs:
   build-docker:
     name: "docker-${{ matrix.config.platform }}-${{ matrix.config.arch }}"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { platform: "ubuntu", arch: "amd64" }
-          - { platform: "fedora", arch: "amd64" }
-          - { platform: "archlinux", arch: "amd64" }
-          - { platform: "alpine", arch: "amd64" }
-          - { platform: "centos7", arch: "amd64" }
+          - { runs_on: "ubuntu-latest", platform: "ubuntu", arch: "amd64" }
+          - { runs_on: "ubuntu-latest", platform: "fedora", arch: "amd64" }
+          - { runs_on: "ubuntu-latest", platform: "archlinux", arch: "amd64" }
+          - { runs_on: "ubuntu-latest", platform: "alpine", arch: "amd64" }
+          - { runs_on: "ubuntu-latest", platform: "centos7", arch: "amd64" }
 
-          - { platform: "ubuntu", arch: "arm64" }
-          - { platform: "alpine", arch: "arm64" }
-          - { platform: "centos7", arch: "arm64" }
+          - { runs_on: ["self-hosted", "arm"], platform: "ubuntu", arch: "arm64" }
+          - { runs_on: ["self-hosted", "arm"], platform: "fedora", arch: "arm64" }
+          - { runs_on: ["self-hosted", "arm"], platform: "alpine", arch: "arm64" }
+          - { runs_on: ["self-hosted", "arm"], platform: "centos7", arch: "arm64" }
 
-          - { platform: "alpine", arch: "s390x" }
+          - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -74,7 +74,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        if: matrix.config.arch != 'amd64'
+        if: matrix.config.arch == 's390x'
         uses: docker/setup-qemu-action@v2
 
       - name: Build
@@ -130,6 +130,17 @@ jobs:
           ghcr.io/apache/arrow-nanoarrow:centos7-arm64 --arch arm64
 
         docker manifest create \
+          ghcr.io/apache/arrow-nanoarrow:fedora \
+          ghcr.io/apache/arrow-nanoarrow:fedora-amd64 \
+          ghcr.io/apache/arrow-nanoarrow:fedora-arm64
+        docker manifest annotate \
+          ghcr.io/apache/arrow-nanoarrow:fedora \
+          ghcr.io/apache/arrow-nanoarrow:fedora-amd64 --arch amd64
+        docker manifest annotate \
+          ghcr.io/apache/arrow-nanoarrow:fedora \
+          ghcr.io/apache/arrow-nanoarrow:fedora-arm64 --arch arm64
+
+        docker manifest create \
           ghcr.io/apache/arrow-nanoarrow:alpine \
           ghcr.io/apache/arrow-nanoarrow:alpine-amd64 \
           ghcr.io/apache/arrow-nanoarrow:alpine-arm64 \
@@ -148,5 +159,6 @@ jobs:
       if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/arrow-nanoarrow'}}
       run: |
         docker manifest push ghcr.io/apache/arrow-nanoarrow:ubuntu
+        docker manifest push ghcr.io/apache/arrow-nanoarrow:fedora
         docker manifest push ghcr.io/apache/arrow-nanoarrow:centos7
         docker manifest push ghcr.io/apache/arrow-nanoarrow:alpine

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,13 +52,19 @@ jobs:
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x" }
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Create Docker Context for Buildx
+        run: |
+          docker context create builders
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          endpoint: builders
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -83,7 +83,7 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker compose build verify
+          docker-compose build verify
 
       - name: Push
         if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/arrow-nanoarrow'}}
@@ -92,7 +92,7 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker compose push verify
+          docker-compose push verify
 
   # Build some arch-agnostic images for non-verify docker bits
   build-docker-manifest:

--- a/ci/docker/centos7.dockerfile
+++ b/ci/docker/centos7.dockerfile
@@ -20,7 +20,7 @@ ARG NANOARROW_ARCH
 FROM --platform=linux/${NANOARROW_ARCH} centos:7
 
 RUN yum install -y epel-release
-RUN yum install -y git gnupg curl R gcc-c++ gcc-gfortran cmake3
+RUN yum install -y git gnupg curl R gcc-c++ gcc-gfortran cmake3 python3-devel
 
 # For Arrow C++. Use 9.0.0 because this version works fine with the default gcc
 RUN curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-9.0.0.tar.gz | tar -zxf - && \

--- a/ci/docker/ubuntu.dockerfile
+++ b/ci/docker/ubuntu.dockerfile
@@ -20,7 +20,7 @@ ARG NANOARROW_ARCH
 FROM --platform=linux/${NANOARROW_ARCH} ubuntu:latest
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    locales git cmake r-base gnupg curl valgrind gfortran python3-venv doxygen pandoc lcov \
+    locales git cmake r-base gnupg curl valgrind gfortran python3-venv python3-dev doxygen pandoc lcov \
     libxml2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
     libjpeg-dev libpng-dev libtiff-dev
 


### PR DESCRIPTION
...also builds arm images in the arm runner instead of using emulation. This is needed to run verification for Python (since we'll need to build a Python extension).