### PR TITLE
[c++] Remove one std::move avoiding 'pessimizing move' (closes #362)

### DIFF
--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -467,7 +467,7 @@ class TestingJSONWriter {
       NANOARROW_RETURN_NOT_OK(
           WriteColumn(dictionary_output, field->dictionary, value->dictionary));
       dictionaries_.RecordArray(field->dictionary, value->dictionary->length,
-                                std::move(dictionary_output.str()));
+                                dictionary_output.str());
     }
 
     return NANOARROW_OK;


### PR DESCRIPTION
As discussed in #362, we see a nag from `g++` 13.2.0 about a 'pessimizing move' from this `std::move` and the compiler itself suggests removing it.  Did so, and did not tickle a valgrind issue is casual testing.