### PR TITLE
Suppress unused variable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ else()
                                      -Wextra
                                      -Wpedantic
                                      -Wno-type-limits
-                                     -Wno-unused-parameter
                                      -Wmaybe-uninitialized
                                      -Wunused-result
                                      -Wconversion
@@ -142,7 +141,6 @@ else()
                                      -Wextra
                                      -Wpedantic
                                      -Wdocumentation
-                                     -Wno-unused-parameter
                                      -Wconversion
                                      -Wno-sign-conversion)
     endif()

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -53,11 +53,13 @@ static inline struct ArrowBuffer* ArrowArrayBuffer(struct ArrowArray* array, int
 // is made.
 static inline int8_t _ArrowArrayUnionChildIndex(struct ArrowArray* array,
                                                 int8_t type_id) {
+  (void)array;
   return type_id;
 }
 
 static inline int8_t _ArrowArrayUnionTypeId(struct ArrowArray* array,
                                             int8_t child_index) {
+  (void)array;  
   return child_index;
 }
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -53,13 +53,13 @@ static inline struct ArrowBuffer* ArrowArrayBuffer(struct ArrowArray* array, int
 // is made.
 static inline int8_t _ArrowArrayUnionChildIndex(struct ArrowArray* array,
                                                 int8_t type_id) {
-  (void)array;
+  NANOARROW_UNUSED(array);
   return type_id;
 }
 
 static inline int8_t _ArrowArrayUnionTypeId(struct ArrowArray* array,
                                             int8_t child_index) {
-  (void)array;
+  NANOARROW_UNUSED(array);
   return child_index;
 }
 

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -59,7 +59,7 @@ static inline int8_t _ArrowArrayUnionChildIndex(struct ArrowArray* array,
 
 static inline int8_t _ArrowArrayUnionTypeId(struct ArrowArray* array,
                                             int8_t child_index) {
-  (void)array;  
+  (void)array;
   return child_index;
 }
 

--- a/src/nanoarrow/array_stream.c
+++ b/src/nanoarrow/array_stream.c
@@ -19,8 +19,6 @@
 
 #include "nanoarrow.h"
 
-#define NANOARROW_UNUSED(x) (void)(x)
-
 struct BasicArrayStreamPrivate {
   struct ArrowSchema schema;
   int64_t n_arrays;

--- a/src/nanoarrow/array_stream.c
+++ b/src/nanoarrow/array_stream.c
@@ -57,6 +57,7 @@ static int ArrowBasicArrayStreamGetNext(struct ArrowArrayStream* array_stream,
 
 static const char* ArrowBasicArrayStreamGetLastError(
     struct ArrowArrayStream* array_stream) {
+  (void)array_stream;
   return NULL;
 }
 

--- a/src/nanoarrow/array_stream.c
+++ b/src/nanoarrow/array_stream.c
@@ -19,6 +19,8 @@
 
 #include "nanoarrow.h"
 
+#define NANOARROW_UNUSED(x) (void)(x)
+
 struct BasicArrayStreamPrivate {
   struct ArrowSchema schema;
   int64_t n_arrays;
@@ -57,7 +59,7 @@ static int ArrowBasicArrayStreamGetNext(struct ArrowArrayStream* array_stream,
 
 static const char* ArrowBasicArrayStreamGetLastError(
     struct ArrowArrayStream* array_stream) {
-  (void)array_stream;
+  NANOARROW_UNUSED(array_stream);
   return NULL;
 }
 

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -195,6 +195,8 @@ struct ArrowArrayStream {
 #define NANOARROW_CHECK_PRINTF_ATTRIBUTE
 #endif
 
+#define NANOARROW_UNUSED(x) (void)(x)
+
 /// \brief Return code for success.
 /// \ingroup nanoarrow-errors
 #define NANOARROW_OK 0

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -24,6 +24,8 @@
 
 #include "nanoarrow.h"
 
+#define NANOARROW_UNUSED(x) (void)(x)
+
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 
 int ArrowNanoarrowVersionInt(void) { return NANOARROW_VERSION_INT; }
@@ -197,8 +199,8 @@ static uint8_t* ArrowBufferAllocatorMallocReallocate(
 
 static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocator,
                                            uint8_t* ptr, int64_t size) {
-  (void)allocator;
-  (void)size;
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(size);
   ArrowFree(ptr);
 }
 
@@ -212,10 +214,10 @@ struct ArrowBufferAllocator ArrowBufferAllocatorDefault(void) {
 static uint8_t* ArrowBufferAllocatorNeverReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
-  (void)allocator;
-  (void)ptr;
-  (void)old_size;
-  (void)new_size;
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(old_size);
+  NANOARROW_UNUSED(new_size);
   return NULL;
 }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -194,6 +194,8 @@ void ArrowFree(void* ptr) { free(ptr); }
 static uint8_t* ArrowBufferAllocatorMallocReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(old_size);
   return (uint8_t*)ArrowRealloc(ptr, new_size);
 }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -24,8 +24,6 @@
 
 #include "nanoarrow.h"
 
-#define NANOARROW_UNUSED(x) (void)(x)
-
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 
 int ArrowNanoarrowVersionInt(void) { return NANOARROW_VERSION_INT; }

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -197,6 +197,8 @@ static uint8_t* ArrowBufferAllocatorMallocReallocate(
 
 static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocator,
                                            uint8_t* ptr, int64_t size) {
+  (void)allocator;
+  (void)size;
   ArrowFree(ptr);
 }
 
@@ -210,6 +212,10 @@ struct ArrowBufferAllocator ArrowBufferAllocatorDefault(void) {
 static uint8_t* ArrowBufferAllocatorNeverReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
+  (void)allocator;
+  (void)ptr;
+  (void)old_size;
+  (void)new_size;
   return NULL;
 }
 


### PR DESCRIPTION
When using as a dependency and trying to use Wextra these generate warnings