### PR TITLE
feat: Check flags field of ArrowSchema on ArrowSchemaViewInit

### DIFF
--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -280,9 +280,10 @@ test_that("schema modify can modify name", {
 
 test_that("schema modify can modify flags", {
   schema <- na_int32()
+  expect_identical(schema$flags, 2L)
 
-  schema2 <- nanoarrow_schema_modify(schema, list(flags = 1))
-  expect_identical(schema2$flags, 1L)
+  schema2 <- nanoarrow_schema_modify(schema, list(flags = 0))
+  expect_identical(schema2$flags, 0L)
   expect_identical(schema2$format, schema$format)
   expect_identical(schema2$name, schema$name)
 

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -1370,9 +1370,9 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchemaComparison) {
   AssertSchemasCompareEqual(actual.get(), expected.get());
 
   // With different top-level flags
-  actual->flags = ARROW_FLAG_MAP_KEYS_SORTED;
+  actual->flags = 0;
   AssertSchemasCompareUnequal(actual.get(), expected.get(), /*num_differences*/ 1,
-                              "Path: \n- .flags: 4\n+ .flags: 2\n\n");
+                              "Path: \n- .flags: 0\n+ .flags: 2\n\n");
   actual->flags = expected->flags;
 
   // With different top-level metadata

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -209,6 +209,11 @@ typedef int ArrowErrorCode;
 #define ArrowErrorCode NANOARROW_CHECK_RETURN_ATTRIBUTE ArrowErrorCode
 #endif
 
+/// \brief Flags supported by ArrowSchemaViewInit()
+/// \ingroup nanoarrow-schema-view
+#define NANOARROW_FLAG_ALL_SUPPORTED \
+  (ARROW_FLAG_DICTIONARY_ORDERED | ARROW_FLAG_NULLABLE | ARROW_FLAG_MAP_KEYS_SORTED)
+
 /// \brief Error type containing a UTF-8 encoded message.
 /// \ingroup nanoarrow-errors
 struct ArrowError {

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1186,8 +1186,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
         ArrowSchemaViewValidate(schema_view, schema_view->type, error));
   }
 
-  int64_t unknown_flags = schema->flags & ~ARROW_FLAG_DICTIONARY_ORDERED &
-                          ~ARROW_FLAG_NULLABLE & ~ARROW_FLAG_MAP_KEYS_SORTED;
+  int64_t unknown_flags = schema->flags & ~NANOARROW_FLAG_ALL_SUPPORTED;
   if (unknown_flags != 0) {
     ArrowErrorSet(error, "Unknown ArrowSchema flag");
     return EINVAL;

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -588,7 +588,7 @@ TEST(SchemaViewTest, SchemaViewInitErrors) {
                "ARROW_FLAG_MAP_KEYS_SORTED is only relevant for a map type");
 
   schema.flags = 0;
-  schema.flags |= (ARROW_FLAG_MAP_KEYS_SORTED << 1);
+  schema.flags |= ~NANOARROW_FLAG_ALL_SUPPORTED;
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Unknown ArrowSchema flag");
 

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -574,6 +574,24 @@ TEST(SchemaViewTest, SchemaViewInitErrors) {
   EXPECT_STREQ(ArrowErrorMessage(&error),
                "Error parsing schema->format 'n*': parsed 1/2 characters");
 
+  ASSERT_EQ(ArrowSchemaSetFormat(&schema, "n"), NANOARROW_OK);
+  schema.flags = 0;
+  schema.flags |= ARROW_FLAG_DICTIONARY_ORDERED;
+  EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error),
+               "ARROW_FLAG_DICTIONARY_ORDERED is only relevant for dictionaries");
+
+  schema.flags = 0;
+  schema.flags |= ARROW_FLAG_MAP_KEYS_SORTED;
+  EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error),
+               "ARROW_FLAG_MAP_KEYS_SORTED is only relevant for a map type");
+
+  schema.flags = 0;
+  schema.flags |= (ARROW_FLAG_MAP_KEYS_SORTED << 1);
+  EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Unknown ArrowSchema flag");
+
   ArrowSchemaRelease(&schema);
 }
 


### PR DESCRIPTION
Closes #312.

`ArrowSchemaViewInit()` is called every time a schema is about to be interpreted (or an array corresponding to that schema is about to be interpreted), and so checking the flags is a must to ensure some future unsupported flag that affects the interpretation of an array will cause an error.

The `ArrowSchemaView` should arguably also keep track of `flags` (or perhaps each flag individually), but I will leave that to another PR.