### PR TITLE
[r] Return package version as a package_version object

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Provides an 'R' interface to the 'nanoarrow' 'C' library and the
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/apache/arrow-nanoarrow
 BugReports: https://github.com/apache/arrow-nanoarrow/issues
 Suggests:

--- a/r/R/nanoarrow-package.R
+++ b/r/R/nanoarrow-package.R
@@ -29,8 +29,8 @@ NULL
 #' @param runtime Compare TRUE and FALSE values to detect a
 #'   possible ABI mismatch.
 #'
-#' @return A string identifying the version of nanoarrow this package
-#'   was compiled against.
+#' @return An 'package_version' object identifying the version of
+#'   nanoarrow this package was compiled against.
 #' @export
 #'
 #' @examples
@@ -38,8 +38,8 @@ NULL
 #'
 nanoarrow_version <- function(runtime = TRUE) {
   if (runtime) {
-    .Call(nanoarrow_c_version_runtime)
+    as.package_version(.Call(nanoarrow_c_version_runtime))
   } else {
-    .Call(nanoarrow_c_version)
+    as.package_version(.Call(nanoarrow_c_version))
   }
 }

--- a/r/man/nanoarrow_version.Rd
+++ b/r/man/nanoarrow_version.Rd
@@ -11,8 +11,8 @@ nanoarrow_version(runtime = TRUE)
 possible ABI mismatch.}
 }
 \value{
-A string identifying the version of nanoarrow this package
-was compiled against.
+An 'package_version' object identifying the version of
+nanoarrow this package was compiled against.
 }
 \description{
 Underlying 'nanoarrow' C library build


### PR DESCRIPTION
The R package currently returns the (run-time or compile-time) package version as a string.  There is a simple 'quality of life' improvement to be had by wrapping this into `as.package_version()` as better comparison operators are available.  Default formatters exists so this should not have side-effects.

Also added a line to the documentation and re-ran `roxygenize()`.  

Please feel free to discard or close if this is any way against which package guidelines you may have here in the larger context of your organization.