### PR TITLE
Correct a few 'nanoarow' typos

### DIFF
--- a/r/R/buffer.R
+++ b/r/R/buffer.R
@@ -183,7 +183,7 @@ convert_buffer <- function(buffer, to = NULL) {
 #' @export
 as_nanoarrow_array.nanoarrow_buffer <- function(x, ..., schema = NULL) {
   if (!is.null(schema)) {
-    stop("as_nanoarrow_array(<nanoarow_buffer>) with non-NULL schema is not supported")
+    stop("as_nanoarrow_array(<nanoarrow_buffer>) with non-NULL schema is not supported")
   }
 
   info <- nanoarrow_buffer_info(x)

--- a/r/R/type.R
+++ b/r/R/type.R
@@ -17,7 +17,7 @@
 
 #' Create type objects
 #'
-#' In nanoarow, types, fields, and schemas are all represented by a
+#' In nanoarrow, types, fields, and schemas are all represented by a
 #' [nanoarrow_schema][as_nanoarrow_schema]. These functions are convenience
 #' constructors to create these objects in a readable way. Use [na_type()] to
 #' construct types based on the constructor name, which is also the name that

--- a/r/inst/include/nanoarrow/r.h
+++ b/r/inst/include/nanoarrow/r.h
@@ -171,7 +171,7 @@ static inline SEXP nanoarrow_array_owning_xptr(void);
 /// Allocate an external pointer to an uninitialized ArrowArrayStream with a finalizer
 /// that ensures that any non-null release callback in a pointed-to structure will be
 /// called when the external pointer is garbage collected.
-static inline SEXP nanoarow_array_stream_owning_xptr(void);
+static inline SEXP nanoarrow_array_stream_owning_xptr(void);
 
 /// \brief Ensure an input SEXP points to an initialized ArrowSchema
 ///
@@ -304,7 +304,7 @@ static inline SEXP nanoarrow_array_owning_xptr(void) {
   return array_xptr;
 }
 
-static inline SEXP nanoarow_array_stream_owning_xptr(void) {
+static inline SEXP nanoarrow_array_stream_owning_xptr(void) {
   struct ArrowArrayStream* array_stream =
       (struct ArrowArrayStream*)malloc(sizeof(struct ArrowArrayStream));
   array_stream->release = NULL;

--- a/r/man/na_type.Rd
+++ b/r/man/na_type.Rd
@@ -193,7 +193,7 @@ null values.}
 A \link[=as_nanoarrow_schema]{nanoarrow_schema}
 }
 \description{
-In nanoarow, types, fields, and schemas are all represented by a
+In nanoarrow, types, fields, and schemas are all represented by a
 \link[=as_nanoarrow_schema]{nanoarrow_schema}. These functions are convenience
 constructors to create these objects in a readable way. Use \code{\link[=na_type]{na_type()}} to
 construct types based on the constructor name, which is also the name that

--- a/r/src/array_stream.c
+++ b/r/src/array_stream.c
@@ -96,7 +96,7 @@ SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
   struct ArrowSchema* schema_copy = nanoarrow_output_schema_from_xptr(schema_copy_xptr);
   schema_export(schema_xptr, schema_copy);
 
-  SEXP array_stream_xptr = PROTECT(nanoarow_array_stream_owning_xptr());
+  SEXP array_stream_xptr = PROTECT(nanoarrow_array_stream_owning_xptr());
   struct ArrowArrayStream* array_stream =
       nanoarrow_output_array_stream_from_xptr(array_stream_xptr);
 
@@ -198,7 +198,7 @@ void array_stream_export(SEXP parent_array_stream_xptr,
 
   // Allocate a new external pointer for an array stream (for consistency:
   // we always move an array stream when exporting)
-  SEXP parent_array_stream_xptr_new = PROTECT(nanoarow_array_stream_owning_xptr());
+  SEXP parent_array_stream_xptr_new = PROTECT(nanoarrow_array_stream_owning_xptr());
   struct ArrowArrayStream* parent_array_stream_new =
       (struct ArrowArrayStream*)R_ExternalPtrAddr(parent_array_stream_xptr_new);
   ArrowArrayStreamMove(parent_array_stream, parent_array_stream_new);

--- a/r/src/pointers.c
+++ b/r/src/pointers.c
@@ -31,7 +31,7 @@ SEXP nanoarrow_c_allocate_schema(void) { return nanoarrow_schema_owning_xptr(); 
 SEXP nanoarrow_c_allocate_array(void) { return nanoarrow_array_owning_xptr(); }
 
 SEXP nanoarrow_c_allocate_array_stream(void) {
-  return nanoarow_array_stream_owning_xptr();
+  return nanoarrow_array_stream_owning_xptr();
 }
 
 SEXP nanoarrow_c_pointer(SEXP obj_sexp) {

--- a/r/tests/testthat/_snaps/array-stream.md
+++ b/r/tests/testthat/_snaps/array-stream.md
@@ -1,8 +1,8 @@
-# as_nanoarrow_array_stream() works for nanoarow_array_stream
+# as_nanoarrow_array_stream() works for nanoarrow_array_stream
 
     is.null(schema) is not TRUE
 
-# as_nanoarrow_array_stream() works for nanoarow_array
+# as_nanoarrow_array_stream() works for nanoarrow_array
 
     is.null(schema) is not TRUE
 

--- a/r/tests/testthat/test-array-stream.R
+++ b/r/tests/testthat/test-array-stream.R
@@ -82,7 +82,7 @@ test_that("released nanoarrow_array_stream format, print, and str methods work",
   expect_output(expect_identical(print(array_stream), array_stream), "nanoarrow_array_stream")
 })
 
-test_that("as_nanoarrow_array_stream() works for nanoarow_array_stream", {
+test_that("as_nanoarrow_array_stream() works for nanoarrow_array_stream", {
   stream <- as_nanoarrow_array_stream(data.frame(x = 1:5))
   expect_identical(as_nanoarrow_array_stream(stream), stream)
 
@@ -98,7 +98,7 @@ test_that("as_nanoarrow_array_stream() works for nanoarow_array_stream", {
   )
 })
 
-test_that("as_nanoarrow_array_stream() works for nanoarow_array", {
+test_that("as_nanoarrow_array_stream() works for nanoarrow_array", {
   array <- as_nanoarrow_array(data.frame(x = 1:5))
 
   stream <- as_nanoarrow_array_stream(array)


### PR DESCRIPTION
After coming across a misspelling in one of the headers, a quick run of [`ag`](https://github.com/ggreer/the_silver_searcher) found a few more I corrected as well.   

This _should_ match in both code and tests but let's see what CI has to say.