### PR TITLE
refactor(r): Refactor how arrays are shallow copied

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -276,7 +276,7 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
   # children are modifiable; however, it's a shallow copy in the sense that
   # none of the buffers are copied.
   schema <- .Call(nanoarrow_c_infer_schema_array, array)
-  array_copy <- array_shallow_copy(array, schema, validate = validate)
+  array_copy <- array_shallow_copy2(array, schema, validate = validate)
 
   for (i in seq_along(new_values)) {
     nm <- new_names[i]
@@ -293,7 +293,7 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
       },
       children = {
         value <- lapply(value, as_nanoarrow_array)
-        value_copy <- lapply(value, array_shallow_copy, validate = validate)
+        value_copy <- lapply(value, array_shallow_copy2, validate = validate)
         .Call(nanoarrow_c_array_set_children, array_copy, value_copy)
 
         if (!is.null(schema)) {
@@ -307,7 +307,7 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
       dictionary = {
         if (!is.null(value)) {
           value <- as_nanoarrow_array(value)
-          value_copy <- array_shallow_copy(value, validate = validate)
+          value_copy <- array_shallow_copy2(value, validate = validate)
         } else {
           value_copy <- NULL
         }
@@ -340,6 +340,12 @@ nanoarrow_array_modify <- function(array, new_values, validate = TRUE) {
     nanoarrow_array_set_schema(array_copy, schema, validate = validate)
   }
 
+  array_copy
+}
+
+array_shallow_copy2 <- function(array, schema = NULL, validate = TRUE) {
+  array_copy <- .Call(nanoarrow_c_array_editable_copy, array)
+  schema <- schema %||% .Call(nanoarrow_c_infer_schema_array, array)
   array_copy
 }
 

--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -34,7 +34,11 @@ void finalize_buffer_xptr(SEXP buffer_xptr) {
 
 void nanoarrow_sexp_deallocator(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                                 int64_t size) {
+  if (allocator->private_data == NULL) {
+    Rprintf("Deallocator called more than once");
+  }
   nanoarrow_release_sexp((SEXP)allocator->private_data);
+  allocator->private_data = NULL;
 }
 
 SEXP nanoarrow_c_as_buffer_default(SEXP x_sexp) {

--- a/r/src/buffer.h
+++ b/r/src/buffer.h
@@ -51,7 +51,8 @@ static inline void buffer_borrowed(struct ArrowBuffer* buffer, const void* addr,
     return;
   }
 
-  int result = ArrowBufferSetAllocator(buffer, ArrowBufferDeallocator(&nanoarrow_sexp_deallocator, shelter));
+  int result = ArrowBufferSetAllocator(
+      buffer, ArrowBufferDeallocator(&nanoarrow_sexp_deallocator, shelter));
   if (result != NANOARROW_OK) {
     Rf_error("Failed to set buffer deallocator");
   }

--- a/r/src/init.c
+++ b/r/src/init.c
@@ -34,6 +34,7 @@ extern SEXP nanoarrow_c_basic_array_stream(SEXP batches_sexp, SEXP schema_xptr,
 extern SEXP nanoarrow_c_array_list_total_length(SEXP list_of_array_xptr);
 extern SEXP nanoarrow_c_array_view(SEXP array_xptr, SEXP schema_xptr);
 extern SEXP nanoarrow_c_array_init(SEXP schema_xptr);
+extern SEXP nanoarrow_c_array_editable_copy(SEXP array_xptr);
 extern SEXP nanoarrow_c_array_set_length(SEXP array_xptr, SEXP length_sexp);
 extern SEXP nanoarrow_c_array_set_null_count(SEXP array_xptr, SEXP null_count_sexp);
 extern SEXP nanoarrow_c_array_set_offset(SEXP array_xptr, SEXP offset_sexp);
@@ -46,7 +47,7 @@ extern SEXP nanoarrow_c_array_set_schema(SEXP array_xptr, SEXP schema_xptr,
 extern SEXP nanoarrow_c_infer_schema_array(SEXP array_xptr);
 extern SEXP nanoarrow_c_array_proxy(SEXP array_xptr, SEXP array_view_xptr,
                                     SEXP recursive_sexp);
-extern SEXP nanoarrow_c_as_array_default(SEXP x_sexp, SEXP schema_sexp);
+extern SEXP nanoarrow_c_as_array_default(SEXP x_sexp, SEXP schema_xptr);
 extern SEXP nanoarrow_c_as_buffer_default(SEXP x_sexp);
 extern SEXP nanoarrow_c_buffer_append(SEXP buffer_xptr, SEXP new_buffer_xptr);
 extern SEXP nanoarrow_c_buffer_info(SEXP buffer_xptr);
@@ -107,6 +108,7 @@ static const R_CallMethodDef CallEntries[] = {
      1},
     {"nanoarrow_c_array_view", (DL_FUNC)&nanoarrow_c_array_view, 2},
     {"nanoarrow_c_array_init", (DL_FUNC)&nanoarrow_c_array_init, 1},
+    {"nanoarrow_c_array_editable_copy", (DL_FUNC)&nanoarrow_c_array_editable_copy, 1},
     {"nanoarrow_c_array_set_length", (DL_FUNC)&nanoarrow_c_array_set_length, 2},
     {"nanoarrow_c_array_set_null_count", (DL_FUNC)&nanoarrow_c_array_set_null_count, 2},
     {"nanoarrow_c_array_set_offset", (DL_FUNC)&nanoarrow_c_array_set_offset, 2},

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -413,11 +413,14 @@ static ArrowErrorCode ArrowArrayFinalizeBuffers(struct ArrowArray* array) {
     case NANOARROW_TYPE_BINARY:
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_LARGE_BINARY:
-    case NANOARROW_TYPE_LARGE_STRING:
-      if (ArrowArrayBuffer(array, 2)->data == NULL) {
-        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt8(ArrowArrayBuffer(array, 2), 0));
+    case NANOARROW_TYPE_LARGE_STRING: {
+      struct ArrowBuffer* data_buffer = ArrowArrayBuffer(array, 2);
+      if (data_buffer->data == NULL) {
+        ArrowBufferReset(data_buffer);
+        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt8(data_buffer, 0));
       }
       break;
+    }
     default:
       break;
   }

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -46,6 +46,8 @@ static inline void ArrowBufferInit(struct ArrowBuffer* buffer) {
 
 static inline ArrowErrorCode ArrowBufferSetAllocator(
     struct ArrowBuffer* buffer, struct ArrowBufferAllocator allocator) {
+  // This is not a perfect test for "has a buffer already been allocated"
+  // but is likely to catch most cases.
   if (buffer->data == NULL) {
     buffer->allocator = allocator;
     return NANOARROW_OK;
@@ -55,14 +57,9 @@ static inline ArrowErrorCode ArrowBufferSetAllocator(
 }
 
 static inline void ArrowBufferReset(struct ArrowBuffer* buffer) {
-  if (buffer->data != NULL) {
-    buffer->allocator.free(&buffer->allocator, (uint8_t*)buffer->data,
-                           buffer->capacity_bytes);
-    buffer->data = NULL;
-  }
-
-  buffer->capacity_bytes = 0;
-  buffer->size_bytes = 0;
+  buffer->allocator.free(&buffer->allocator, (uint8_t*)buffer->data,
+                         buffer->capacity_bytes);
+  ArrowBufferInit(buffer);
 }
 
 static inline void ArrowBufferMove(struct ArrowBuffer* src, struct ArrowBuffer* dst) {

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include "nanoarrow.h"
-#include "nanoarrow/nanoarrow_types.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "nanoarrow.h"
+#include "nanoarrow/nanoarrow_types.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "nanoarrow.h"
+#include "nanoarrow/nanoarrow_types.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 
@@ -201,7 +202,9 @@ static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocato
                                            uint8_t* ptr, int64_t size) {
   NANOARROW_UNUSED(allocator);
   NANOARROW_UNUSED(size);
-  ArrowFree(ptr);
+  if (ptr != NULL) {
+    ArrowFree(ptr);
+  }
 }
 
 static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
@@ -211,13 +214,24 @@ struct ArrowBufferAllocator ArrowBufferAllocatorDefault(void) {
   return ArrowBufferAllocatorMalloc;
 }
 
-static uint8_t* ArrowBufferAllocatorNeverReallocate(
-    struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
-    int64_t new_size) {
-  NANOARROW_UNUSED(allocator);
-  NANOARROW_UNUSED(ptr);
-  NANOARROW_UNUSED(old_size);
+static uint8_t* ArrowBufferDeallocatorReallocate(struct ArrowBufferAllocator* allocator,
+                                                 uint8_t* ptr, int64_t old_size,
+                                                 int64_t new_size) {
   NANOARROW_UNUSED(new_size);
+
+  // Attempting to reallocate a buffer with a custom deallocator is
+  // a programming error. In debug mode, crash here.
+#if defined(NANOARROW_DEBUG)
+  NANOARROW_PRINT_AND_DIE(ENOMEM,
+                          "It is an error to reallocate a buffer whose allocator is "
+                          "ArrowBufferDeallocator()");
+#endif
+
+  // In release mode, ensure the the deallocator is called exactly
+  // once using the pointer it was given and return NULL, which
+  // will trigger the caller to return ENOMEM.
+  allocator->free(allocator, ptr, old_size);
+  *allocator = ArrowBufferAllocatorDefault();
   return NULL;
 }
 
@@ -226,7 +240,7 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
                         int64_t size),
     void* private_data) {
   struct ArrowBufferAllocator allocator;
-  allocator.reallocate = &ArrowBufferAllocatorNeverReallocate;
+  allocator.reallocate = &ArrowBufferDeallocatorReallocate;
   allocator.free = custom_free;
   allocator.private_data = private_data;
   return allocator;


### PR DESCRIPTION
WIP...I think the C half of this is fine, but it seems to have exposed an inconsistency of how I was handling stuff in the R bindings that was long overdue for some simplification.