### PR TITLE
fix: Ensure that the deallocator called by ArrowBufferDeallocator() is called exactly once

### DIFF
--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -11,3 +11,4 @@
 ^cran-comments\.md$
 ^bootstrap\.R$
 ^\.cache$
+^compile_commands\.json$

--- a/r/.gitignore
+++ b/r/.gitignore
@@ -18,3 +18,4 @@
 .Rproj.user
 .Rhistory
 docs
+compile_commands.json

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -46,6 +46,8 @@ static inline void ArrowBufferInit(struct ArrowBuffer* buffer) {
 
 static inline ArrowErrorCode ArrowBufferSetAllocator(
     struct ArrowBuffer* buffer, struct ArrowBufferAllocator allocator) {
+  // This is not a perfect test for "has a buffer already been allocated"
+  // but is likely to catch most cases.
   if (buffer->data == NULL) {
     buffer->allocator = allocator;
     return NANOARROW_OK;
@@ -55,14 +57,9 @@ static inline ArrowErrorCode ArrowBufferSetAllocator(
 }
 
 static inline void ArrowBufferReset(struct ArrowBuffer* buffer) {
-  if (buffer->data != NULL) {
-    buffer->allocator.free(&buffer->allocator, (uint8_t*)buffer->data,
-                           buffer->capacity_bytes);
-    buffer->data = NULL;
-  }
-
-  buffer->capacity_bytes = 0;
-  buffer->size_bytes = 0;
+  buffer->allocator.free(&buffer->allocator, (uint8_t*)buffer->data,
+                         buffer->capacity_bytes);
+  ArrowBufferInit(buffer);
 }
 
 static inline void ArrowBufferMove(struct ArrowBuffer* src, struct ArrowBuffer* dst) {

--- a/src/nanoarrow/buffer_inline.h
+++ b/src/nanoarrow/buffer_inline.h
@@ -65,7 +65,7 @@ static inline void ArrowBufferReset(struct ArrowBuffer* buffer) {
 static inline void ArrowBufferMove(struct ArrowBuffer* src, struct ArrowBuffer* dst) {
   memcpy(dst, src, sizeof(struct ArrowBuffer));
   src->data = NULL;
-  ArrowBufferReset(src);
+  ArrowBufferInit(src);
 }
 
 static inline ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer,

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -307,7 +307,7 @@ static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj, const vo
 /// Specifically, this uses obj.data() to set the buffer address and
 /// obj.size() * sizeof(T::value_type) to set the buffer size. This works
 /// for STL containers like std::vector, std::array, and std::string.
-/// This funciton moves obj and ensures it is deleted when ArrowBufferReset
+/// This function moves obj and ensures it is deleted when ArrowBufferReset
 /// is called.
 template <typename T>
 void BufferInitSequence(struct ArrowBuffer* buffer, T obj) {

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -290,12 +290,14 @@ using UniqueArrayView = internal::Unique<struct ArrowArrayView>;
 /// \brief Initialize a buffer wrapping an arbitrary C++ object
 ///
 /// Initializes a buffer with a release callback that deletes the moved obj
-/// when ArrowBufferReset is called. T must be movable.
+/// when ArrowBufferReset is called. This version is useful for wrapping
+/// an object whose .data() member is missing or unrelated to the buffer
+/// value that is destined for a the buffer of an ArrowArray. T must be movable.
 template <typename T>
-static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj, const void* ptr,
+static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj, const uint8_t* data,
                                      int64_t size_bytes) {
   T* obj_moved = new T(std::move(obj));
-  buffer->data = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(ptr));
+  buffer->data = const_cast<uint8_t*>(data);
   buffer->size_bytes = size_bytes;
   buffer->capacity_bytes = 0;
   buffer->allocator =

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -294,8 +294,8 @@ using UniqueArrayView = internal::Unique<struct ArrowArrayView>;
 /// an object whose .data() member is missing or unrelated to the buffer
 /// value that is destined for a the buffer of an ArrowArray. T must be movable.
 template <typename T>
-static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj, const uint8_t* data,
-                                     int64_t size_bytes) {
+static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj,
+                                     const uint8_t* data, int64_t size_bytes) {
   T* obj_moved = new T(std::move(obj));
   buffer->data = const_cast<uint8_t*>(data);
   buffer->size_bytes = size_bytes;

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -241,6 +241,13 @@ class Unique {
   T data_;
 };
 
+template <typename T>
+static inline void DeallocateWrappedBuffer(struct ArrowBufferAllocator* allocator,
+                                           uint8_t* ptr, int64_t size) {
+  auto obj = reinterpret_cast<T*>(allocator->private_data);
+  delete obj;
+}
+
 /// @}
 
 }  // namespace internal
@@ -270,6 +277,49 @@ using UniqueBitmap = internal::Unique<struct ArrowBitmap>;
 
 /// \brief Class wrapping a unique struct ArrowArrayView
 using UniqueArrayView = internal::Unique<struct ArrowArrayView>;
+
+/// @}
+
+/// \defgroup nanoarrow_hpp-buffer Buffer helpers
+///
+/// Helpers to wrap buffer-like C++ objects as ArrowBuffer objects that can
+/// be used to build ArrowArray objects.
+///
+/// @{
+
+/// \brief Initialize a buffer wrapping an arbitrary C++ object
+///
+/// Initializes a buffer with a release callback that deletes the moved obj
+/// when ArrowBufferReset is called. T must be movable.
+template <typename T>
+static inline void BufferInitWrapped(struct ArrowBuffer* buffer, T obj, const void* ptr,
+                                     int64_t size_bytes) {
+  T* obj_moved = new T(std::move(obj));
+  buffer->data = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(ptr));
+  buffer->size_bytes = size_bytes;
+  buffer->capacity_bytes = 0;
+  buffer->allocator =
+      ArrowBufferDeallocator(&internal::DeallocateWrappedBuffer<T>, obj_moved);
+}
+
+/// \brief Initialize a buffer wrapping a C++ sequence
+///
+/// Specifically, this uses obj.data() to set the buffer address and
+/// obj.size() * sizeof(T::value_type) to set the buffer size. This works
+/// for STL containers like std::vector, std::array, and std::string.
+/// This funciton moves obj and ensures it is deleted when ArrowBufferReset
+/// is called.
+template <typename T>
+void BufferInitSequence(struct ArrowBuffer* buffer, T obj) {
+  // Move before calling .data() (matters sometimes).
+  T* obj_moved = new T(std::move(obj));
+  buffer->data =
+      const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(obj_moved->data()));
+  buffer->size_bytes = obj_moved->size() * sizeof(typename T::value_type);
+  buffer->capacity_bytes = 0;
+  buffer->allocator =
+      ArrowBufferDeallocator(&internal::DeallocateWrappedBuffer<T>, obj_moved);
+}
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -167,6 +167,70 @@ TEST(NanoarrowHppTest, NanoarrowHppUniqueBitmapTest) {
   EXPECT_EQ(bitmap3->size_bits, 123);
 }
 
+struct TestWrappedObj {
+  int64_t* num_frees;
+
+  TestWrappedObj(int64_t* addr) { num_frees = addr; }
+
+  TestWrappedObj(TestWrappedObj&& obj) {
+    num_frees = obj.num_frees;
+    obj.num_frees = nullptr;
+  }
+
+  ~TestWrappedObj() {
+    if (num_frees != nullptr) {
+      *num_frees = *num_frees + 1;
+    }
+  }
+};
+
+TEST(NanoarrowHppTest, NanoarrowHppBufferInitWrappedTest) {
+  nanoarrow::UniqueBuffer buffer;
+  int64_t num_frees = 0;
+
+  TestWrappedObj obj(&num_frees);
+  nanoarrow::BufferInitWrapped(buffer.get(), std::move(obj), nullptr, 0);
+  EXPECT_EQ(obj.num_frees, nullptr);
+  EXPECT_EQ(num_frees, 0);
+  buffer.reset();
+  EXPECT_EQ(num_frees, 1);
+
+  // Ensure the destructor won't get called again when ArrowBufferReset is
+  // called on the empty buffer.
+  buffer.reset();
+  EXPECT_EQ(num_frees, 1);
+}
+
+TEST(NanoarrowHppTest, NanoarrowHppBufferInitSequenceTest) {
+  nanoarrow::UniqueBuffer buffer;
+
+  // Check templating magic with std::string
+  nanoarrow::BufferInitSequence(buffer.get(), std::string("1234"));
+  EXPECT_EQ(buffer->size_bytes, 4);
+  EXPECT_EQ(buffer->capacity_bytes, 0);
+  EXPECT_EQ(memcmp(buffer->data, "1234", 4), 0);
+
+  // Check templating magic with std::vector
+  buffer.reset();
+  nanoarrow::BufferInitSequence(buffer.get(), std::vector<uint8_t>({1, 2, 3, 4}));
+  EXPECT_EQ(buffer->size_bytes, 4);
+  EXPECT_EQ(buffer->capacity_bytes, 0);
+  EXPECT_EQ(buffer->data[0], 1);
+  EXPECT_EQ(buffer->data[1], 2);
+  EXPECT_EQ(buffer->data[2], 3);
+  EXPECT_EQ(buffer->data[3], 4);
+
+  // Check templating magic with std::vector
+  buffer.reset();
+  nanoarrow::BufferInitSequence(buffer.get(), std::array<uint8_t, 4>({1, 2, 3, 4}));
+  EXPECT_EQ(buffer->size_bytes, 4);
+  EXPECT_EQ(buffer->capacity_bytes, 0);
+  EXPECT_EQ(buffer->data[0], 1);
+  EXPECT_EQ(buffer->data[1], 2);
+  EXPECT_EQ(buffer->data[2], 3);
+  EXPECT_EQ(buffer->data[3], 4);
+}
+
 TEST(NanoarrowHppTest, NanoarrowHppUniqueArrayViewTest) {
   nanoarrow::UniqueArrayView array_view;
   EXPECT_EQ(array_view->storage_type, NANOARROW_TYPE_UNINITIALIZED);

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -220,7 +220,7 @@ TEST(NanoarrowHppTest, NanoarrowHppBufferInitSequenceTest) {
   EXPECT_EQ(buffer->data[2], 3);
   EXPECT_EQ(buffer->data[3], 4);
 
-  // Check templating magic with std::vector
+  // Check templating magic with std::array
   buffer.reset();
   nanoarrow::BufferInitSequence(buffer.get(), std::array<uint8_t, 4>({1, 2, 3, 4}));
   EXPECT_EQ(buffer->size_bytes, 4);

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -23,7 +23,6 @@
 #include <string.h>
 
 #include "nanoarrow.h"
-#include "nanoarrow/nanoarrow_types.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "nanoarrow.h"
+#include "nanoarrow/nanoarrow_types.h"
 
 const char* ArrowNanoarrowVersion(void) { return NANOARROW_VERSION; }
 
@@ -201,7 +202,9 @@ static void ArrowBufferAllocatorMallocFree(struct ArrowBufferAllocator* allocato
                                            uint8_t* ptr, int64_t size) {
   NANOARROW_UNUSED(allocator);
   NANOARROW_UNUSED(size);
-  ArrowFree(ptr);
+  if (ptr != NULL) {
+    ArrowFree(ptr);
+  }
 }
 
 static struct ArrowBufferAllocator ArrowBufferAllocatorMalloc = {
@@ -211,13 +214,24 @@ struct ArrowBufferAllocator ArrowBufferAllocatorDefault(void) {
   return ArrowBufferAllocatorMalloc;
 }
 
-static uint8_t* ArrowBufferAllocatorNeverReallocate(
-    struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
-    int64_t new_size) {
-  NANOARROW_UNUSED(allocator);
-  NANOARROW_UNUSED(ptr);
-  NANOARROW_UNUSED(old_size);
+static uint8_t* ArrowBufferDeallocatorReallocate(struct ArrowBufferAllocator* allocator,
+                                                 uint8_t* ptr, int64_t old_size,
+                                                 int64_t new_size) {
   NANOARROW_UNUSED(new_size);
+
+  // Attempting to reallocate a buffer with a custom deallocator is
+  // a programming error. In debug mode, crash here.
+#if defined(NANOARROW_DEBUG)
+  NANOARROW_PRINT_AND_DIE(ENOMEM,
+                          "It is an error to reallocate a buffer whose allocator is "
+                          "ArrowBufferDeallocator()");
+#endif
+
+  // In release mode, ensure the the deallocator is called exactly
+  // once using the pointer it was given and return NULL, which
+  // will trigger the caller to return ENOMEM.
+  allocator->free(allocator, ptr, old_size);
+  *allocator = ArrowBufferAllocatorDefault();
   return NULL;
 }
 
@@ -226,7 +240,7 @@ struct ArrowBufferAllocator ArrowBufferDeallocator(
                         int64_t size),
     void* private_data) {
   struct ArrowBufferAllocator allocator;
-  allocator.reallocate = &ArrowBufferAllocatorNeverReallocate;
+  allocator.reallocate = &ArrowBufferDeallocatorReallocate;
   allocator.free = custom_free;
   allocator.private_data = private_data;
   return allocator;


### PR DESCRIPTION
This PR makes it more predictable to work with custom allocators, including the `ArrowBufferDeallocator` that powers the R and (soon) Python "build from buffers" behaviour. It also improves testing for using custom allocators and adds a templated C++ wrapper.