### PR TITLE
feat(python): Add CArrayView -> Python conversion

### DIFF
--- a/python/src/nanoarrow/_ipc_lib.pyx
+++ b/python/src/nanoarrow/_ipc_lib.pyx
@@ -63,6 +63,10 @@ cdef class PyInputStreamPrivate:
         self.size_bytes = 0
         self.close_stream = close_stream
 
+    # Needed for at least some implementations of readinto()
+    def __len__(self):
+        return self.size_bytes
+
     # Implement the buffer protocol so that this object can be used as
     # the argument to xxx.readinto(). This ensures that no extra copies
     # (beyond any buffering done by the upstream file-like object) are held

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1143,6 +1143,10 @@ cdef class CArrayView:
         self._device = CDEVICE_CPU
 
     @property
+    def storage_type_id(self):
+        return self._ptr.storage_type
+
+    @property
     def storage_type(self):
         cdef const char* type_str = ArrowTypeString(self._ptr.storage_type)
         if type_str != NULL:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -767,6 +767,10 @@ cdef class CSchemaView:
         self._map_keys_sorted = schema._ptr.flags & ARROW_FLAG_MAP_KEYS_SORTED
 
     @property
+    def layout(self):
+        return CLayout(self, <uintptr_t>&self._schema_view.layout)
+
+    @property
     def type_id(self):
         return self._schema_view.type
 
@@ -859,6 +863,31 @@ cdef class CSchemaView:
 
     def __repr__(self):
         return _repr_utils.schema_view_repr(self)
+
+
+cdef class CLayout:
+    cdef ArrowLayout* _layout
+    cdef object _base
+
+    def __cinit__(self, base, uintptr_t ptr):
+        self._base = base
+        self._layout = <ArrowLayout*>ptr
+
+    @property
+    def buffer_type(self):
+        return tuple(self._layout.buffer_type[i] for i in range(3))
+
+    @property
+    def buffer_data_type_id(self):
+        return tuple(self._layout.buffer_data_type[i] for i in range(3))
+
+    @property
+    def element_size_bits(self):
+        return tuple(self._layout.element_size_bits[i] for i in range(3))
+
+    @property
+    def child_size_elements(self):
+        return self._layout.child_size_elements
 
 
 cdef class CSchemaBuilder:
@@ -1151,6 +1180,10 @@ cdef class CArrayView:
         cdef const char* type_str = ArrowTypeString(self._ptr.storage_type)
         if type_str != NULL:
             return type_str.decode('UTF-8')
+
+    @property
+    def layout(self):
+        return CLayout(self, <uintptr_t>&self._ptr.layout)
 
     @property
     def length(self):

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1431,7 +1431,7 @@ cdef class CBufferView:
         if offset < 0 or length < 0 or (offset + length) > self.n_elements:
             raise IndexError(
                 f"offset {offset} and length {length} do not describe a valid slice "
-                f"of bitmap with {self.n_elements} elements"
+                f"of buffer with {self.n_elements} elements"
             )
 
         if self._data_type == NANOARROW_TYPE_BOOL:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -792,7 +792,8 @@ cdef class CSchemaView:
 
     @property
     def dictionary_ordered(self):
-        return self._dictionary_ordered != 0
+        if self._schema_view.type == NANOARROW_TYPE_DICTIONARY:
+            return self._dictionary_ordered != 0
 
     @property
     def nullable(self):
@@ -800,7 +801,8 @@ cdef class CSchemaView:
 
     @property
     def map_keys_sorted(self):
-        return self._map_keys_sorted != 0
+        if self._schema_view.type == NANOARROW_TYPE_MAP:
+            return self._map_keys_sorted != 0
 
     @property
     def fixed_size(self):
@@ -872,10 +874,6 @@ cdef class CLayout:
     def __cinit__(self, base, uintptr_t ptr):
         self._base = base
         self._layout = <ArrowLayout*>ptr
-
-    @property
-    def buffer_type(self):
-        return tuple(self._layout.buffer_type[i] for i in range(3))
 
     @property
     def buffer_data_type_id(self):

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -357,7 +357,7 @@ def c_array_stream(obj=None, schema=None) -> CArrayStream:
 
     try:
         array = c_array(obj, schema=schema)
-        return CArrayStream.from_arrays([array], array.schema, validate=False)
+        return CArrayStream.from_array_list([array], array.schema, validate=False)
     except Exception as e:
         raise TypeError(
             f"Can't convert object of type {type(obj).__name__} "

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -414,7 +414,7 @@ def c_array_view(obj, schema=None) -> CArrayView:
     if isinstance(obj, CArrayView) and schema is None:
         return obj
 
-    return CArrayView.from_cpu_array(c_array(obj, schema))
+    return CArrayView.from_array(c_array(obj, schema))
 
 
 def c_buffer(obj, schema=None) -> CBuffer:

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -347,6 +347,10 @@ def c_array_stream(obj=None, schema=None) -> CArrayStream:
 
     # Try import of bare capsule
     if _obj_is_capsule(obj, "arrow_array_stream"):
+        if schema is not None:
+            raise TypeError(
+                "Can't import c_array_stream from capsule with requested schema"
+            )
         return CArrayStream._import_from_c_capsule(obj)
 
     # Try _export_to_c for RecordBatchReader objects if pyarrow < 14.0

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -26,8 +26,8 @@ from nanoarrow.c_lib import (
 )
 
 
-def iteritems(obj, schema=None):
-    return ItemsIterator.get_iterator(obj, schema=schema)
+def iterator(obj, schema=None):
+    return RowIterator.get_iterator(obj, schema=schema)
 
 
 def itertuples(obj, schema=None):
@@ -67,7 +67,7 @@ class ArrayViewIterator:
         return self
 
 
-class ItemsIterator(ArrayViewIterator):
+class RowIterator(ArrayViewIterator):
     @classmethod
     def get_iterator(cls, obj, schema=None):
         with c_array_stream(obj, schema=schema) as stream:

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -76,7 +76,6 @@ class ItemsIterator(ArrayViewIterator):
                 iterator._set_array(array)
                 yield from iterator._iter1(0, array.length)
 
-
     def _iter1(self, offset, length):
         schema_view = self._schema_view
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -18,11 +18,11 @@
 from nanoarrow.c_lib import c_array_view, CArrowType
 
 
-def _storage_iter(array, child_factory=None):
+def storage(view, child_factory=None):
     if child_factory is None:
-        child_factory = _storage_iter
+        child_factory = storage
 
-    view = c_array_view(array)
+    view = c_array_view(view)
     if view.offset != 0:
         raise NotImplementedError("Offset != 0 not implemented")
 
@@ -35,7 +35,7 @@ def _storage_iter(array, child_factory=None):
         )
 
     factory = _LOOKUP[key]
-    return factory(view, _storage_iter)
+    return factory(view, storage)
 
 
 def _struct_iter(view, child_factory):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow.c_lib import c_array_view, CArrowType
+from nanoarrow.c_lib import CArrowType, c_array_view
 
 
 def storage(view, child_factory=None):
@@ -44,7 +44,7 @@ def _struct_iter(view, child_factory):
 
 def _nullable_struct_iter(view, child_factory):
     for is_valid, item in zip(
-        view.buffer(0).elements, _struct_iter(view, child_factory)
+        view.buffer(0).elements(), _struct_iter(view, child_factory)
     ):
         yield item if is_valid else None
 
@@ -60,7 +60,7 @@ def _nullable_string_iter(view, child_factory):
     validity, offsets, data = view.buffers
     offsets = memoryview(offsets)
     data = memoryview(data)
-    for is_valid, start, end in zip(validity.elements, offsets[:-1], offsets[1:]):
+    for is_valid, start, end in zip(validity.elements(), offsets[:-1], offsets[1:]):
         if is_valid:
             yield str(data[start:end], "UTF-8")
         else:
@@ -78,7 +78,7 @@ def _nullable_binary_iter(view, child_factory):
     validity, offsets, data = view.buffers
     offsets = memoryview(offsets)
     data = memoryview(data)
-    for is_valid, start, end in zip(validity.elements, offsets[:-1], offsets[1:]):
+    for is_valid, start, end in zip(validity.elements(), offsets[:-1], offsets[1:]):
         if is_valid:
             yield bytes(data[start:end])
         else:
@@ -86,12 +86,12 @@ def _nullable_binary_iter(view, child_factory):
 
 
 def _primitive_storage_iter(view, child_factory):
-    return iter(view.buffer(1).elements)
+    return iter(view.buffer(1).elements())
 
 
 def _nullable_primitive_storage_iter(view, child_factory):
     is_valid, data = view.buffers
-    for is_valid, item in zip(is_valid.elements, data.elements):
+    for is_valid, item in zip(is_valid.elements(), data.elements()):
         yield item if is_valid else None
 
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -18,12 +18,12 @@
 from functools import cached_property
 
 from nanoarrow.c_lib import (
-    CArrowType,
     CArrayView,
+    CArrowType,
     c_array,
+    c_array_stream,
     c_schema,
     c_schema_view,
-    c_array_stream,
 )
 
 
@@ -64,7 +64,6 @@ def _itertuples_stream(obj):
 
 
 class ArrayViewIterator:
-
     def __init__(self, schema, *, _array_view=None):
         self._schema = c_schema(schema)
         self._schema_view = c_schema_view(schema)
@@ -98,7 +97,6 @@ class ArrayViewIterator:
 
 
 class ItemsIterator(ArrayViewIterator):
-
     def _iter1(self, offset, length):
         schema_view = self._schema_view
 
@@ -231,12 +229,12 @@ class ItemsIterator(ArrayViewIterator):
 
 
 class RowTupleIterator(ItemsIterator):
-
     def __init__(self, schema, *, _array_view=None):
         super().__init__(schema, _array_view=_array_view)
         if self._schema_view.type != "struct":
             raise TypeError(
-                f"RowTupleIterator can only iterate over struct arrays (got '{self._schema_view.type}')"
+                "RowTupleIterator can only iterate over struct arrays ",
+                f"(got '{self._schema_view.type}')",
             )
 
     def _make_child(self, schema, array_view):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -233,8 +233,8 @@ class RowTupleIterator(ItemsIterator):
         super().__init__(schema, _array_view=_array_view)
         if self._schema_view.type != "struct":
             raise TypeError(
-                "RowTupleIterator can only iterate over struct arrays ",
-                f"(got '{self._schema_view.type}')",
+                "RowTupleIterator can only iterate over struct arrays "
+                f"(got '{self._schema_view.type}')"
             )
 
     def _make_child(self, schema, array_view):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -81,9 +81,8 @@ class ArrayViewIterator:
 def _struct_iter(iterator, offset, length):
     view = iterator._array_view
     offset += view.offset
-    return zip(
-        *(iterator._make_iter(child, offset, length) for child in iterator.children)
-    )
+    child_factory = iterator._make_iter
+    return zip(*(child_factory(child, offset, length) for child in iterator.children))
 
 
 def _nullable_struct_iter(iterator, offset, length):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -86,7 +86,7 @@ def _nullable_binary_iter(view, child_factory):
 
 
 def _primitive_storage_iter(view, child_factory):
-    return iter(view.buffer(1))
+    return iter(view.buffer(1).elements)
 
 
 def _nullable_primitive_storage_iter(view, child_factory):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -207,7 +207,7 @@ class RowIterator(ArrayViewIterator):
             yield item if is_valid else None
 
 
-class RowTupleIterator(ItemsIterator):
+class RowTupleIterator(RowIterator):
     def __init__(self, schema, *, _array_view=None):
         super().__init__(schema, _array_view=_array_view)
         if self._schema_view.type != "struct":
@@ -217,7 +217,7 @@ class RowTupleIterator(ItemsIterator):
             )
 
     def _make_child(self, schema, array_view):
-        return ItemsIterator(schema, _array_view=array_view)
+        return RowIterator(schema, _array_view=array_view)
 
     def _iter1(self, offset, length):
         if self._contains_nulls():

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -167,7 +167,7 @@ _LOOKUP = {
     (True, CArrowType.LARGE_LIST): _nullable_list_iter,
     (False, CArrowType.LARGE_LIST): _list_iter,
     (True, CArrowType.FIXED_SIZE_LIST): _nullable_fixed_size_list_iter,
-    (False, CArrowType.LARGE_LIST): _fixed_size_list_iter,
+    (False, CArrowType.FIXED_SIZE_LIST): _fixed_size_list_iter,
 }
 
 _PRIMITIVE = [

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -55,9 +55,9 @@ def iterator(obj, schema=None) -> Iterable:
 
 
 def itertuples(obj, schema=None) -> Iterable[Tuple]:
-    """Iterate over items in zero or more arrays
+    """Iterate over rows in zero or more struct arrays
 
-    Returns an iterator over an array stream of struct arrays (e.g.,
+    Returns an iterator over an array stream of struct arrays (i.e.,
     record batches) where each item is a tuple of the items in each
     row. This is different than :func:`iterator`, which encodes struct
     columns as dictionaries.

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -1,0 +1,135 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from nanoarrow.c_lib import c_array_view, CArrowType
+
+
+def _storage_iter(view, child_factory=None):
+    view = c_array_view(view)
+    nullable = _array_view_nullable(view)
+    if (nullable, view.storage_type_id) not in _LOOKUP:
+        raise KeyError(
+            f"Can't resolve iterator factory for storage type '{view.storage_type}'"
+        )
+
+    factory = _LOOKUP[nullable, view.storage_type_id]
+    return factory(view.buffers, view.children, _storage_iter)
+
+
+def _struct_iter(buffers, children, child_factory):
+    return zip(*(child_factory(child) for child in children))
+
+
+def _nullable_struct_iter(buffers, children, child_factory):
+    (validity,) = buffers
+    for is_valid, item in zip(
+        validity.elements, _struct_iter(None, children, child_factory)
+    ):
+        yield item if is_valid else None
+
+
+def _string_iter(buffers, children, child_factory):
+    _, offsets, data = buffers
+    offsets = memoryview(offsets)
+    data = memoryview(data)
+    for start, end in zip(offsets[:-1], offsets[1:]):
+        yield str(data[start:end], "UTF-8")
+
+
+def _nullable_string_iter(buffers, children, child_factory):
+    validity, offsets, data = buffers
+    offsets = memoryview(offsets)
+    data = memoryview(data)
+    for is_valid, start, end in zip(validity.elements, offsets[:-1], offsets[1:]):
+        if is_valid:
+            yield str(data[start:end], "UTF-8")
+        else:
+            yield None
+
+
+def _binary_iter(buffers, children, child_factory):
+    _, offsets, data = buffers
+    offsets = memoryview(offsets)
+    data = memoryview(data)
+    for start, end in zip(offsets[:-1], offsets[1:]):
+        yield bytes(data[start:end])
+
+
+def _nullable_binary_iter(buffers, children, child_factory):
+    validity, offsets, data = buffers
+    offsets = memoryview(offsets)
+    data = memoryview(data)
+    for is_valid, start, end in zip(validity.elements, offsets[:-1], offsets[1:]):
+        if is_valid:
+            yield bytes(data[start:end])
+        else:
+            yield None
+
+
+def _primitive_storage_iter(buffers, children, child_factory):
+    _, data = buffers
+    return iter(data)
+
+
+def _nullable_primitive_storage_iter(buffers, children, child_factory):
+    is_valid, data = buffers
+    for is_valid, item in zip(is_valid.elements, data.elements):
+        yield item if is_valid else None
+
+
+def _array_view_nullable(array):
+    return len(array.buffer(0)) != 0 and array.null_count != 0
+
+
+_LOOKUP = {
+    (True, CArrowType.BINARY): _nullable_binary_iter,
+    (False, CArrowType.BINARY): _binary_iter,
+    (True, CArrowType.LARGE_BINARY): _nullable_binary_iter,
+    (False, CArrowType.LARGE_BINARY): _binary_iter,
+    (True, CArrowType.STRING): _nullable_string_iter,
+    (False, CArrowType.STRING): _string_iter,
+    (True, CArrowType.LARGE_STRING): _nullable_string_iter,
+    (False, CArrowType.LARGE_STRING): _string_iter,
+    (True, CArrowType.STRUCT): _nullable_struct_iter,
+    (False, CArrowType.STRUCT): _struct_iter,
+}
+
+_PRIMITIVE = [
+    "BOOL",
+    "UINT8",
+    "INT8",
+    "UINT16",
+    "INT16",
+    "UINT32",
+    "INT32",
+    "UINT64",
+    "INT64",
+    "HALF_FLOAT",
+    "FLOAT",
+    "DOUBLE",
+    "FIXED_SIZE_BINARY",
+    "INTERVAL_MONTHS",
+    "INTERVAL_DAY_TIME",
+    "INTERVAL_MONTH_DAY_NANO",
+    "DECIMAL128",
+    "DECIMAL256",
+]
+
+for type_name in _PRIMITIVE:
+    type_id = getattr(CArrowType, type_name)
+    _LOOKUP[False, type_id] = _primitive_storage_iter
+    _LOOKUP[True, type_id] = _nullable_primitive_storage_iter

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -37,8 +37,8 @@ class ArrayViewIterator:
         else:
             self._array_view = _array_view
 
-        self._children = map(
-            self._make_child, self._schema.children, self._array_view.children
+        self._children = list(
+            map(self._make_child, self._schema.children, self._array_view.children)
         )
 
     def __iter__(self):
@@ -127,7 +127,7 @@ def _nullable_fixed_size_list_iter(iterator, offset, length):
     view = iterator._array_view
     for is_valid, item in zip(
         view.buffer(0).elements(view.offset + offset, length),
-        _fixed_size_list_iter(view, offset, length),
+        _fixed_size_list_iter(iterator, offset, length),
     ):
         yield item if is_valid else None
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -18,15 +18,19 @@
 from nanoarrow.c_lib import c_array_view, CArrowType
 
 
-def _storage_iter(view, child_factory=None):
+def _storage_iter(view):
     view = c_array_view(view)
+    if view.offset != 0:
+        raise NotImplementedError("offset != 0 is not yet supported")
+
     nullable = _array_view_nullable(view)
-    if (nullable, view.storage_type_id) not in _LOOKUP:
+    key = nullable, view.storage_type_id
+    if key not in _LOOKUP:
         raise KeyError(
             f"Can't resolve iterator factory for storage type '{view.storage_type}'"
         )
 
-    factory = _LOOKUP[nullable, view.storage_type_id]
+    factory = _LOOKUP[key]
     return factory(view.buffers, view.children, _storage_iter)
 
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -17,6 +17,7 @@
 
 from functools import cached_property
 from itertools import islice
+from typing import Iterable, Tuple
 
 from nanoarrow.c_lib import (
     CArrayView,
@@ -27,11 +28,11 @@ from nanoarrow.c_lib import (
 )
 
 
-def iterator(obj, schema=None):
+def iterator(obj, schema=None) -> Iterable:
     return RowIterator.get_iterator(obj, schema=schema)
 
 
-def itertuples(obj, schema=None):
+def itertuples(obj, schema=None) -> Iterable[Tuple]:
     return RowTupleIterator.get_iterator(obj, schema=schema)
 
 

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -103,6 +103,46 @@ def test_c_array_type_not_supported():
         na.c_array(None)
 
 
+def test_c_array_slice():
+    array = na.c_array([1, 2, 3], na.int32())
+    assert array.offset == 0
+    assert array.length == 3
+
+    array2 = array[:]
+    assert array.offset == 0
+    assert array.length == 3
+    assert array.buffers == array2.buffers
+
+    array2 = array[:2]
+    assert array2.offset == 0
+    assert array2.length == 2
+
+    array2 = array[:-1]
+    assert array2.offset == 0
+    assert array2.length == 2
+
+    array2 = array[1:]
+    assert array2.offset == 1
+    assert array2.length == 2
+
+    array2 = array[-2:]
+    assert array2.offset == 1
+    assert array2.length == 2
+
+
+def test_c_array_slice_errors():
+    array = na.c_array([1, 2, 3], na.int32())
+
+    with pytest.raises(TypeError):
+        array[0]
+    with pytest.raises(IndexError):
+        array[4:]
+    with pytest.raises(IndexError):
+        array[:4]
+    with pytest.raises(IndexError):
+        array[1:0]
+
+
 def test_c_array_from_pybuffer_uint8():
     data = b"abcdefg"
     c_array = na.c_array(data)

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -16,10 +16,10 @@
 # under the License.
 
 import pytest
+from nanoarrow._lib import NanoarrowException
+from nanoarrow.c_lib import CArrayStream
 
 import nanoarrow as na
-from nanoarrow.c_lib import CArrayStream
-from nanoarrow._lib import NanoarrowException
 
 
 def test_array_stream_from_arrays_schema():

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import nanoarrow as na
+from nanoarrow.c_lib import CArrayStream
+from nanoarrow._lib import NanoarrowException
+
+
+def test_array_stream_from_arrays_schema():
+    schema_in = na.c_schema(na.int32())
+
+    stream = CArrayStream.from_array_list([], schema_in)
+    assert schema_in.is_valid()
+    assert list(stream) == []
+    assert stream.get_schema().format == "i"
+
+    # Check move of schema
+    CArrayStream.from_array_list([], schema_in, move=True)
+    assert schema_in.is_valid() is False
+    assert stream.get_schema().format == "i"
+
+
+def test_array_stream_from_arrays():
+    schema_in = na.c_schema(na.int32())
+    array_in = na.c_array([1, 2, 3], schema_in)
+    array_in_buffers = array_in.buffers
+
+    stream = CArrayStream.from_array_list([array_in], schema_in)
+    assert array_in.is_valid()
+    arrays = list(stream)
+    assert len(arrays) == 1
+    assert arrays[0].buffers == array_in_buffers
+
+    # Check move of array
+    stream = CArrayStream.from_array_list([array_in], schema_in, move=True)
+    assert array_in.is_valid() is False
+    arrays = list(stream)
+    assert len(arrays) == 1
+    assert arrays[0].buffers == array_in_buffers
+
+
+def test_array_stream_from_arrays_validate():
+    schema_in = na.c_schema(na.null())
+    array_in = na.c_array([1, 2, 3], na.int32())
+
+    # Check that we can skip validation and proceed without error
+    stream = CArrayStream.from_array_list([array_in], schema_in, validate=False)
+    arrays = list(stream)
+    assert len(arrays) == 1
+    assert arrays[0].n_buffers == 2
+
+    # ...but that validation does happen by default
+    msg = "Expected array with 0 buffer"
+    with pytest.raises(NanoarrowException, match=msg):
+        CArrayStream.from_array_list([array_in], schema_in)

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -77,6 +77,34 @@ def test_c_array_stream_from_bare_capsule():
     from_capsule = na.c_array_stream(capsule)
     assert from_capsule.get_schema().format == "i"
 
+    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    capsule = array_stream.__arrow_c_stream__()
+
+    with pytest.raises(TypeError, "Can't import c_array_stream"):
+        na.c_array_stream(capsule, na.int32())
+
+
+def test_c_array_stream_from_c_array_fallback():
+    # Check that arrays are valid input
+    c_array = na.c_array([1, 2, 3], na.int32())
+    array_stream = na.c_array_stream(c_array)
+    assert array_stream.get_schema().format == "i"
+    arrays = list(array_stream)
+    assert len(arrays) == 1
+    assert arrays[0].buffers == c_array.buffers
+
+    # Check fallback with schema
+    array_stream = na.c_array_stream([1, 2, 3], na.int32())
+    assert array_stream.get_schema().format == "i"
+    arrays = list(array_stream)
+    assert len(arrays) == 1
+
+
+def test_c_array_stream_error():
+    msg = "Can't convert object of type NoneType"
+    with pytest.raises(TypeError, match=msg):
+        na.c_array_stream(None)
+
 
 def test_array_stream_from_arrays_schema():
     schema_in = na.c_schema(na.int32())

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -80,7 +80,7 @@ def test_c_array_stream_from_bare_capsule():
     array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
     capsule = array_stream.__arrow_c_stream__()
 
-    with pytest.raises(TypeError, "Can't import c_array_stream"):
+    with pytest.raises(TypeError, match="Can't import c_array_stream"):
         na.c_array_stream(capsule, na.int32())
 
 

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -119,7 +119,7 @@ def test_c_buffer_integer():
         assert buffer[1] == 1
         assert buffer[2] == 2
         assert list(buffer) == [0, 1, 2]
-        assert list(buffer.elements) == [0, 1, 2]
+        assert list(buffer.elements()) == [0, 1, 2]
         assert buffer.n_elements == len(buffer)
         assert [buffer.element(i) for i in range(buffer.n_elements)] == list(buffer)
 
@@ -146,7 +146,7 @@ def test_numpy_c_buffer_numeric():
         array = np.array([0, 1, 2], dtype)
         buffer = na.c_buffer(array)
         assert list(buffer) == list(array)
-        assert list(buffer.elements) == list(array)
+        assert list(buffer.elements()) == list(array)
 
         array_roundtrip = np.array(buffer, copy=False)
         np.testing.assert_array_equal(array_roundtrip, array)
@@ -294,7 +294,7 @@ def test_c_buffer_bitmap_from_iterable():
     assert buffer.data_type == "bool"
     assert buffer.item_size == 1
     assert buffer.element_size_bits == 1
-    assert list(buffer.elements) == [
+    assert list(buffer.elements()) == [
         True,
         False,
         False,
@@ -305,20 +305,20 @@ def test_c_buffer_bitmap_from_iterable():
         False,
     ]
     assert [buffer.element(i) for i in range(buffer.n_elements)] == list(
-        buffer.elements
+        buffer.elements()
     )
 
     # Check something exactly one byte
     buffer = na.c_buffer([True, False, False, True] * 2, na.bool())
     assert "10011001" in repr(buffer)
     assert buffer.size_bytes == 1
-    assert list(buffer.elements) == [True, False, False, True] * 2
+    assert list(buffer.elements()) == [True, False, False, True] * 2
 
     # Check something more than one byte
     buffer = na.c_buffer([True, False, False, True] * 3, na.bool())
     assert "1001100110010000" in repr(buffer)
     assert buffer.size_bytes == 2
-    assert list(buffer.elements) == [True, False, False, True] * 3 + [
+    assert list(buffer.elements()) == [True, False, False, True] * 3 + [
         False,
         False,
         False,

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import nanoarrow as na
+from nanoarrow.c_lib import c_array_view
+
+
+def test_buffer_view_bool():
+    bool_array_view = c_array_view([1, 0, 0, 1], na.bool())
+    view = bool_array_view.buffer(1)
+
+    assert view.element_size_bits == 1
+    assert view.size_bytes == 1
+    assert view.data_type_id == na.Type.BOOL.value
+    assert view.data_type == "bool"
+    assert view.format == "B"
+
+    # Check item interface
+    assert len(view) == 1
+    assert view[0] == 1 + 8
+    assert list(view) == [1 + 8]
+
+    # Check against buffer protocol
+    mv = memoryview(view)
+    assert len(mv) == len(view)
+    assert mv[0] == view[0]
+    assert list(mv) == list(view)
+
+    # Check element interface
+    assert view.n_elements == 8
+    assert list(view.elements()) == [True, False, False, True] + [False] * 4
+    assert [view.element(i) for i in range(8)] == list(view.elements())
+
+    # Check element slices
+    assert list(view.elements(0, 4)) == [True, False, False, True]
+    assert list(view.elements(1, 3)) == [False, False, True]
+
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(-1, None)
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(0, -1)
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(0, 9)
+
+    # Check repr
+    assert "10010000" in repr(view)
+
+
+def test_buffer_view_non_bool():
+    array_view = c_array_view([1, 2, 3, 5], na.int32())
+    view = array_view.buffer(1)
+
+    assert view.element_size_bits == 32
+    assert view.size_bytes == 4 * 4
+    assert view.data_type_id == na.Type.INT32.value
+    assert view.data_type == "int32"
+    assert view.format == "i"
+
+    # Check item interface
+    assert len(view) == 4
+    assert list(view) == [1, 2, 3, 5]
+    assert [view[i] for i in range(4)] == list(view)
+
+    # Check against buffer protocol
+    mv = memoryview(view)
+    assert len(mv) == len(view)
+    assert mv[0] == view[0]
+    assert [mv[i] for i in range(4)] == [view[i] for i in range(4)]
+
+    # Check element interface
+    assert view.n_elements == len(view)
+    assert list(view.elements()) == list(view)
+    assert [view.element(i) for i in range(4)] == list(view.elements())
+
+    # Check element slices
+    assert list(view.elements(0, 3)) == [1, 2, 3]
+    assert list(view.elements(1, 3)) == [2, 3, 5]
+
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(-1, None)
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(0, -1)
+    with pytest.raises(IndexError, match="do not describe a valid slice"):
+        view.elements(1, 4)
+
+    # Check repr
+    assert "1 2 3 5" in repr(view)

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -16,9 +16,9 @@
 # under the License.
 
 import pytest
+from nanoarrow.c_lib import c_array_view
 
 import nanoarrow as na
-from nanoarrow.c_lib import c_array_view
 
 
 def test_buffer_view_bool():
@@ -33,8 +33,8 @@ def test_buffer_view_bool():
 
     # Check item interface
     assert len(view) == 1
-    assert view[0] == 1 + 8
-    assert list(view) == [1 + 8]
+    assert view[0] == 0b1001
+    assert list(view) == [0b1001]
 
     # Check against buffer protocol
     mv = memoryview(view)
@@ -51,11 +51,12 @@ def test_buffer_view_bool():
     assert list(view.elements(0, 4)) == [True, False, False, True]
     assert list(view.elements(1, 3)) == [False, False, True]
 
-    with pytest.raises(IndexError, match="do not describe a valid slice"):
+    msg = "do not describe a valid slice"
+    with pytest.raises(IndexError, match=msg):
         view.elements(-1, None)
-    with pytest.raises(IndexError, match="do not describe a valid slice"):
+    with pytest.raises(IndexError, match=msg):
         view.elements(0, -1)
-    with pytest.raises(IndexError, match="do not describe a valid slice"):
+    with pytest.raises(IndexError, match=msg):
         view.elements(0, 9)
 
     # Check repr

--- a/python/tests/test_c_schema_view.py
+++ b/python/tests/test_c_schema_view.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import nanoarrow as na
 from nanoarrow.c_lib import c_schema_view
+
+import nanoarrow as na
 
 
 def test_schema_view_accessors_basic():

--- a/python/tests/test_c_schema_view.py
+++ b/python/tests/test_c_schema_view.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import nanoarrow as na
+from nanoarrow.c_lib import c_schema_view
+
+
+def test_schema_view_accessors_basic():
+    view = c_schema_view(na.Type.DATE32)
+    assert view.type == "date32"
+    assert view.type_id == na.Type.DATE32.value
+    assert view.storage_type == "int32"
+    assert view.storage_type_id == na.Type.INT32.value
+    assert view.nullable is True
+    assert view.map_keys_sorted is None
+    assert view.fixed_size is None
+    assert view.decimal_bitwidth is None
+    assert view.decimal_precision is None
+    assert view.decimal_scale is None
+    assert view.time_unit_id is None
+    assert view.time_unit is None
+    assert view.timezone is None
+    assert view.extension_name is None
+    assert view.extension_metadata is None
+
+    assert "date32" in repr(view)
+    assert "fixed_size" not in repr(view)
+
+
+def test_schema_view_accessors_fixed_size():
+    view = c_schema_view(na.fixed_size_binary(123))
+    assert view.fixed_size == 123
+
+
+def test_schema_view_accessors_datetime():
+    view = c_schema_view(na.timestamp("s", "America/Halifax"))
+    assert view.timezone == "America/Halifax"
+    assert view.time_unit_id == na.TimeUnit.SECOND.value
+    assert view.time_unit == "s"
+
+
+def test_schema_view_accessors_decimal():
+    view = c_schema_view(na.decimal128(10, 3))
+    assert view.decimal_bitwidth == 128
+    assert view.decimal_precision == 10
+    assert view.decimal_scale == 3
+
+
+def test_schema_view_accessors_non_nullable():
+    view = c_schema_view(na.int32(nullable=False))
+    assert view.nullable is False
+
+
+def test_schema_view_layout_accessors():
+    view = c_schema_view(na.Type.INT32)
+    assert view.layout.buffer_data_type_id[0] == na.Type.BOOL.value
+    assert view.layout.element_size_bits[0] == 1
+    assert view.layout.buffer_data_type_id[1] == na.Type.INT32.value
+    assert view.layout.element_size_bits[1] == 32
+    assert view.layout.child_size_elements == 0

--- a/python/tests/test_c_schema_view.py
+++ b/python/tests/test_c_schema_view.py
@@ -68,6 +68,7 @@ def test_schema_view_accessors_non_nullable():
 
 def test_schema_view_layout_accessors():
     view = c_schema_view(na.Type.INT32)
+    assert view.layout.n_buffers == 2
     assert view.layout.buffer_data_type_id[0] == na.Type.BOOL.value
     assert view.layout.element_size_bits[0] == 1
     assert view.layout.buffer_data_type_id[1] == na.Type.INT32.value

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -93,6 +93,20 @@ def test_storage_struct():
     assert list(storage(array)) == [(1, True), (2, False), (3, True)]
 
 
+def test_storage_nullable_struct():
+    array = na.c_array_from_buffers(
+        na.struct({"col1": na.int32(), "col2": na.bool()}),
+        length=4,
+        buffers=[na.c_buffer([True, True, True, False], na.bool())],
+        children=[
+            na.c_array([1, 2, 3, 4], na.int32()),
+            na.c_array([1, 0, 1, 0], na.bool()),
+        ],
+    )
+
+    assert list(storage(array)) == [(1, True), (2, False), (3, True), None]
+
+
 def test_storage_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0]]
@@ -110,12 +124,12 @@ def test_storage_nullable_list():
 def test_storage_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    array = pa.array(items, pa.list_(pa.int64()))
+    array = pa.array(items, pa.list_(pa.int64(), 3))
     assert list(storage(array)) == items
 
 
 def test_storage_nullable_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
-    array = pa.array(items, pa.list_(pa.int64()))
+    array = pa.array(items, pa.list_(pa.int64(), 3))
     assert list(storage(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -122,7 +122,7 @@ def test_itertuples_nullable():
 
 def test_itertuples_errors():
     with pytest.raises(TypeError, match="can only iterate over struct arrays"):
-        itertuples(na.c_array([1, 2, 3], na.int32()))
+        list(itertuples(na.c_array([1, 2, 3], na.int32())))
 
 
 def test_iteritems_struct():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -17,13 +17,13 @@
 
 import pytest
 from nanoarrow.ipc import Stream
-from nanoarrow.iterator import iteritems, itertuples
+from nanoarrow.iterator import iterator, itertuples
 
 import nanoarrow as na
 
 
-def test_iteritems_stream():
-    assert list(iteritems(Stream.example())) == [
+def test_iterator_stream():
+    assert list(iterator(Stream.example())) == [
         {"some_col": 1},
         {"some_col": 2},
         {"some_col": 3},
@@ -34,12 +34,12 @@ def test_itertuples_stream():
     assert list(itertuples(Stream.example())) == [(1,), (2,), (3,)]
 
 
-def test_iteritems_primitive():
+def test_iterator_primitive():
     array = na.c_array([1, 2, 3], na.int32())
-    assert list(iteritems(array)) == [1, 2, 3]
+    assert list(iterator(array)) == [1, 2, 3]
 
 
-def test_iteritems_nullable_primitive():
+def test_iterator_nullable_primitive():
     array = na.c_array_from_buffers(
         na.int32(),
         4,
@@ -48,18 +48,18 @@ def test_iteritems_nullable_primitive():
             na.c_buffer([1, 2, 3, 0], na.int32()),
         ],
     )
-    assert list(iteritems(array)) == [1, 2, 3, None]
+    assert list(iterator(array)) == [1, 2, 3, None]
 
 
-def test_iteritems_string():
+def test_iterator_string():
     array = na.c_array_from_buffers(
         na.string(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
     )
 
-    assert list(iteritems(array)) == ["ab", "cde"]
+    assert list(iterator(array)) == ["ab", "cde"]
 
 
-def test_iteritems_nullable_string():
+def test_iterator_nullable_string():
     array = na.c_array_from_buffers(
         na.string(),
         3,
@@ -70,18 +70,18 @@ def test_iteritems_nullable_string():
         ],
     )
 
-    assert list(iteritems(array)) == ["ab", "cde", None]
+    assert list(iterator(array)) == ["ab", "cde", None]
 
 
-def test_iteritems_binary():
+def test_iterator_binary():
     array = na.c_array_from_buffers(
         na.binary(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
     )
 
-    assert list(iteritems(array)) == [b"ab", b"cde"]
+    assert list(iterator(array)) == [b"ab", b"cde"]
 
 
-def test_iteritems_nullable_binary():
+def test_iterator_nullable_binary():
     array = na.c_array_from_buffers(
         na.binary(),
         3,
@@ -92,7 +92,7 @@ def test_iteritems_nullable_binary():
         ],
     )
 
-    assert list(iteritems(array)) == [b"ab", b"cde", None]
+    assert list(iterator(array)) == [b"ab", b"cde", None]
 
 
 def test_itertuples():
@@ -125,7 +125,7 @@ def test_itertuples_errors():
         list(itertuples(na.c_array([1, 2, 3], na.int32())))
 
 
-def test_iteritems_struct():
+def test_iterator_struct():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),
         length=3,
@@ -133,14 +133,14 @@ def test_iteritems_struct():
         children=[na.c_array([1, 2, 3], na.int32()), na.c_array([1, 0, 1], na.bool())],
     )
 
-    assert list(iteritems(array)) == [
+    assert list(iterator(array)) == [
         {"col1": 1, "col2": True},
         {"col1": 2, "col2": False},
         {"col1": 3, "col2": True},
     ]
 
 
-def test_iteritems_nullable_struct():
+def test_iterator_nullable_struct():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),
         length=4,
@@ -151,7 +151,7 @@ def test_iteritems_nullable_struct():
         ],
     )
 
-    assert list(iteritems(array)) == [
+    assert list(iterator(array)) == [
         {"col1": 1, "col2": True},
         {"col1": 2, "col2": False},
         {"col1": 3, "col2": True},
@@ -159,29 +159,29 @@ def test_iteritems_nullable_struct():
     ]
 
 
-def test_iteritems_list():
+def test_iterator_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0]]
     array = pa.array(items)
-    assert list(iteritems(array)) == items
+    assert list(iterator(array)) == items
 
 
-def test_iteritems_nullable_list():
+def test_iterator_nullable_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0], None]
     array = pa.array(items)
-    assert list(iteritems(array)) == items
+    assert list(iterator(array)) == items
 
 
-def test_iteritems_fixed_size_list():
+def test_iterator_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     array = pa.array(items, pa.list_(pa.int64(), 3))
-    assert list(iteritems(array)) == items
+    assert list(iterator(array)) == items
 
 
-def test_iteritems_nullable_fixed_size_list():
+def test_iterator_nullable_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
     array = pa.array(items, pa.list_(pa.int64(), 3))
-    assert list(iteritems(array)) == items
+    assert list(iterator(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,17 +16,22 @@
 # under the License.
 
 import pytest
-from nanoarrow.iterator import storage
+from nanoarrow.iterator import iteritems
+from nanoarrow.ipc import Stream
 
 import nanoarrow as na
 
 
-def test_storage_primitive():
+def test_iteritems_stream():
+    assert list(iteritems(Stream.example())) == [(1,), (2,), (3,)]
+
+
+def test_iteritems_primitive():
     array = na.c_array([1, 2, 3], na.int32())
-    assert list(storage(array)) == [1, 2, 3]
+    assert list(iteritems(array)) == [1, 2, 3]
 
 
-def test_storage_nullable_primitive():
+def test_iteritems_nullable_primitive():
     array = na.c_array_from_buffers(
         na.int32(),
         4,
@@ -35,18 +40,18 @@ def test_storage_nullable_primitive():
             na.c_buffer([1, 2, 3, 0], na.int32()),
         ],
     )
-    assert list(storage(array)) == [1, 2, 3, None]
+    assert list(iteritems(array)) == [1, 2, 3, None]
 
 
-def test_storage_string():
+def test_iteritems_string():
     array = na.c_array_from_buffers(
         na.string(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
     )
 
-    assert list(storage(array)) == ["ab", "cde"]
+    assert list(iteritems(array)) == ["ab", "cde"]
 
 
-def test_storage_nullable_string():
+def test_iteritems_nullable_string():
     array = na.c_array_from_buffers(
         na.string(),
         3,
@@ -57,18 +62,18 @@ def test_storage_nullable_string():
         ],
     )
 
-    assert list(storage(array)) == ["ab", "cde", None]
+    assert list(iteritems(array)) == ["ab", "cde", None]
 
 
-def test_storage_binary():
+def test_iteritems_binary():
     array = na.c_array_from_buffers(
         na.binary(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
     )
 
-    assert list(storage(array)) == [b"ab", b"cde"]
+    assert list(iteritems(array)) == [b"ab", b"cde"]
 
 
-def test_storage_nullable_binary():
+def test_iteritems_nullable_binary():
     array = na.c_array_from_buffers(
         na.binary(),
         3,
@@ -79,10 +84,10 @@ def test_storage_nullable_binary():
         ],
     )
 
-    assert list(storage(array)) == [b"ab", b"cde", None]
+    assert list(iteritems(array)) == [b"ab", b"cde", None]
 
 
-def test_storage_struct():
+def test_iteritems_struct():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),
         length=3,
@@ -90,10 +95,10 @@ def test_storage_struct():
         children=[na.c_array([1, 2, 3], na.int32()), na.c_array([1, 0, 1], na.bool())],
     )
 
-    assert list(storage(array)) == [(1, True), (2, False), (3, True)]
+    assert list(iteritems(array)) == [(1, True), (2, False), (3, True)]
 
 
-def test_storage_nullable_struct():
+def test_iteritems_nullable_struct():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),
         length=4,
@@ -104,32 +109,32 @@ def test_storage_nullable_struct():
         ],
     )
 
-    assert list(storage(array)) == [(1, True), (2, False), (3, True), None]
+    assert list(iteritems(array)) == [(1, True), (2, False), (3, True), None]
 
 
-def test_storage_list():
+def test_iteritems_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0]]
     array = pa.array(items)
-    assert list(storage(array)) == items
+    assert list(iteritems(array)) == items
 
 
-def test_storage_nullable_list():
+def test_iteritems_nullable_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0], None]
     array = pa.array(items)
-    assert list(storage(array)) == items
+    assert list(iteritems(array)) == items
 
 
-def test_storage_fixed_size_list():
+def test_iteritems_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     array = pa.array(items, pa.list_(pa.int64(), 3))
-    assert list(storage(array)) == items
+    assert list(iteritems(array)) == items
 
 
-def test_storage_nullable_fixed_size_list():
+def test_iteritems_nullable_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
     array = pa.array(items, pa.list_(pa.int64(), 3))
-    assert list(storage(array)) == items
+    assert list(iteritems(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import pytest
-from nanoarrow.iterator import iteritems
+from nanoarrow.iterator import iteritems, itertuples
 from nanoarrow.ipc import Stream
 
 import nanoarrow as na
@@ -28,6 +28,10 @@ def test_iteritems_stream():
         {"some_col": 2},
         {"some_col": 3},
     ]
+
+
+def test_itertuples_stream():
+    assert list(itertuples(Stream.example())) == [(1,), (2,), (3,)]
 
 
 def test_iteritems_primitive():
@@ -99,7 +103,7 @@ def test_itertuples():
         children=[na.c_array([1, 2, 3], na.int32()), na.c_array([1, 0, 1], na.bool())],
     )
 
-    assert list(iteritems(array)) == [(1, True), (2, False), (3, True)]
+    assert list(itertuples(array)) == [(1, True), (2, False), (3, True)]
 
 
 def test_itertuples_nullable():
@@ -113,7 +117,7 @@ def test_itertuples_nullable():
         ],
     )
 
-    assert list(iteritems(array)) == [(1, True), (2, False), (3, True), None]
+    assert list(itertuples(array)) == [(1, True), (2, False), (3, True), None]
 
 
 def test_iteritems_struct():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pytest
 from nanoarrow.iterator import storage
 
 import nanoarrow as na
@@ -90,3 +91,31 @@ def test_storage_struct():
     )
 
     assert list(storage(array)) == [(1, True), (2, False), (3, True)]
+
+
+def test_storage_list():
+    pa = pytest.importorskip("pyarrow")
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0]]
+    array = pa.array(items)
+    assert list(storage(array)) == items
+
+
+def test_storage_nullable_list():
+    pa = pytest.importorskip("pyarrow")
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0], None]
+    array = pa.array(items)
+    assert list(storage(array)) == items
+
+
+def test_storage_fixed_size_list():
+    pa = pytest.importorskip("pyarrow")
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    array = pa.array(items, pa.list_(pa.int64()))
+    assert list(storage(array)) == items
+
+
+def test_storage_nullable_fixed_size_list():
+    pa = pytest.importorskip("pyarrow")
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
+    array = pa.array(items, pa.list_(pa.int64()))
+    assert list(storage(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,8 +16,8 @@
 # under the License.
 
 import pytest
-from nanoarrow.iterator import iteritems, itertuples
 from nanoarrow.ipc import Stream
+from nanoarrow.iterator import iteritems, itertuples
 
 import nanoarrow as na
 

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import nanoarrow as na
 from nanoarrow.iterator import storage
+
+import nanoarrow as na
 
 
 def test_storage_primitive():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -23,7 +23,11 @@ import nanoarrow as na
 
 
 def test_iteritems_stream():
-    assert list(iteritems(Stream.example())) == [(1,), (2,), (3,)]
+    assert list(iteritems(Stream.example())) == [
+        {"some_col": 1},
+        {"some_col": 2},
+        {"some_col": 3},
+    ]
 
 
 def test_iteritems_primitive():
@@ -87,7 +91,7 @@ def test_iteritems_nullable_binary():
     assert list(iteritems(array)) == [b"ab", b"cde", None]
 
 
-def test_iteritems_struct():
+def test_itertuples():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),
         length=3,
@@ -96,6 +100,35 @@ def test_iteritems_struct():
     )
 
     assert list(iteritems(array)) == [(1, True), (2, False), (3, True)]
+
+
+def test_itertuples_nullable():
+    array = na.c_array_from_buffers(
+        na.struct({"col1": na.int32(), "col2": na.bool()}),
+        length=4,
+        buffers=[na.c_buffer([True, True, True, False], na.bool())],
+        children=[
+            na.c_array([1, 2, 3, 4], na.int32()),
+            na.c_array([1, 0, 1, 0], na.bool()),
+        ],
+    )
+
+    assert list(iteritems(array)) == [(1, True), (2, False), (3, True), None]
+
+
+def test_iteritems_struct():
+    array = na.c_array_from_buffers(
+        na.struct({"col1": na.int32(), "col2": na.bool()}),
+        length=3,
+        buffers=[None],
+        children=[na.c_array([1, 2, 3], na.int32()), na.c_array([1, 0, 1], na.bool())],
+    )
+
+    assert list(iteritems(array)) == [
+        {"col1": 1, "col2": True},
+        {"col1": 2, "col2": False},
+        {"col1": 3, "col2": True},
+    ]
 
 
 def test_iteritems_nullable_struct():
@@ -109,7 +142,12 @@ def test_iteritems_nullable_struct():
         ],
     )
 
-    assert list(iteritems(array)) == [(1, True), (2, False), (3, True), None]
+    assert list(iteritems(array)) == [
+        {"col1": 1, "col2": True},
+        {"col1": 2, "col2": False},
+        {"col1": 3, "col2": True},
+        None,
+    ]
 
 
 def test_iteritems_list():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -78,3 +78,14 @@ def test_storage_nullable_binary():
     )
 
     assert list(storage(array)) == [b"ab", b"cde", None]
+
+
+def test_storage_struct():
+    array = na.c_array_from_buffers(
+        na.struct({"col1": na.int32(), "col2": na.bool()}),
+        length=3,
+        buffers=[None],
+        children=[na.c_array([1, 2, 3], na.int32()), na.c_array([1, 0, 1], na.bool())],
+    )
+
+    assert list(storage(array)) == [(1, True), (2, False), (3, True)]

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import nanoarrow as na
+from nanoarrow.iterator import storage
+
+
+def test_storage_primitive():
+    array = na.c_array([1, 2, 3], na.int32())
+    assert list(storage(array)) == [1, 2, 3]
+
+
+def test_storage_nullable_primitive():
+    array = na.c_array_from_buffers(
+        na.int32(),
+        4,
+        buffers=[
+            na.c_buffer([1, 1, 1, 0], na.bool()),
+            na.c_buffer([1, 2, 3, 0], na.int32()),
+        ],
+    )
+    assert list(storage(array)) == [1, 2, 3, None]
+
+
+def test_storage_string():
+    array = na.c_array_from_buffers(
+        na.string(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
+    )
+
+    assert list(storage(array)) == ["ab", "cde"]
+
+
+def test_storage_nullable_string():
+    array = na.c_array_from_buffers(
+        na.string(),
+        3,
+        buffers=[
+            na.c_buffer([1, 1, 0], na.bool()),
+            na.c_buffer([0, 2, 5, 5], na.int32()),
+            b"abcde",
+        ],
+    )
+
+    assert list(storage(array)) == ["ab", "cde", None]
+
+
+def test_storage_binary():
+    array = na.c_array_from_buffers(
+        na.binary(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
+    )
+
+    assert list(storage(array)) == [b"ab", b"cde"]
+
+
+def test_storage_nullable_binary():
+    array = na.c_array_from_buffers(
+        na.binary(),
+        3,
+        buffers=[
+            na.c_buffer([1, 1, 0], na.bool()),
+            na.c_buffer([0, 2, 5, 5], na.int32()),
+            b"abcde",
+        ],
+    )
+
+    assert list(storage(array)) == [b"ab", b"cde", None]

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -22,14 +22,6 @@ from nanoarrow.iterator import iterator, itertuples
 import nanoarrow as na
 
 
-def test_iterator_stream():
-    assert list(iterator(Stream.example())) == [
-        {"some_col": 1},
-        {"some_col": 2},
-        {"some_col": 3},
-    ]
-
-
 def test_itertuples_stream():
     assert list(itertuples(Stream.example())) == [(1,), (2,), (3,)]
 
@@ -184,4 +176,13 @@ def test_iterator_nullable_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
     items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
     array = pa.array(items, pa.list_(pa.int64(), 3))
+    assert list(iterator(array)) == items
+
+
+def test_iterator_dictionary():
+    pa = pytest.importorskip("pyarrow")
+
+    items = ["ab", "cde", "ab", "def", "cde"]
+    array = pa.array(items).dictionary_encode()
+
     assert list(iterator(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -120,6 +120,11 @@ def test_itertuples_nullable():
     assert list(itertuples(array)) == [(1, True), (2, False), (3, True), None]
 
 
+def test_itertuples_errors():
+    with pytest.raises(TypeError, match="can only iterate over struct arrays"):
+        itertuples(na.c_array([1, 2, 3], na.int32()))
+
+
 def test_iteritems_struct():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool()}),

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,19 +16,17 @@
 # under the License.
 
 import pytest
-from nanoarrow.ipc import Stream
 from nanoarrow.iterator import iterator, itertuples
 
 import nanoarrow as na
 
 
-def test_itertuples_stream():
-    assert list(itertuples(Stream.example())) == [(1,), (2,), (3,)]
-
-
 def test_iterator_primitive():
     array = na.c_array([1, 2, 3], na.int32())
     assert list(iterator(array)) == [1, 2, 3]
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [2, 3]
 
 
 def test_iterator_nullable_primitive():
@@ -42,6 +40,9 @@ def test_iterator_nullable_primitive():
     )
     assert list(iterator(array)) == [1, 2, 3, None]
 
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [2, 3, None]
+
 
 def test_iterator_string():
     array = na.c_array_from_buffers(
@@ -49,6 +50,9 @@ def test_iterator_string():
     )
 
     assert list(iterator(array)) == ["ab", "cde"]
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == ["cde"]
 
 
 def test_iterator_nullable_string():
@@ -64,6 +68,9 @@ def test_iterator_nullable_string():
 
     assert list(iterator(array)) == ["ab", "cde", None]
 
+    sliced = array[1:]
+    assert list(iterator(sliced)) == ["cde", None]
+
 
 def test_iterator_binary():
     array = na.c_array_from_buffers(
@@ -71,6 +78,9 @@ def test_iterator_binary():
     )
 
     assert list(iterator(array)) == [b"ab", b"cde"]
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [b"cde"]
 
 
 def test_iterator_nullable_binary():
@@ -86,6 +96,9 @@ def test_iterator_nullable_binary():
 
     assert list(iterator(array)) == [b"ab", b"cde", None]
 
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [b"cde", None]
+
 
 def test_itertuples():
     array = na.c_array_from_buffers(
@@ -96,6 +109,20 @@ def test_itertuples():
     )
 
     assert list(itertuples(array)) == [(1, True), (2, False), (3, True)]
+
+    sliced = array[1:]
+    assert list(itertuples(sliced)) == [(2, False), (3, True)]
+
+    sliced_child = na.c_array_from_buffers(
+        array.schema,
+        length=2,
+        buffers=[None],
+        children=[array.child(0)[1:], array.child(1)[1:]],
+    )
+    assert list(itertuples(sliced_child)) == [(2, False), (3, True)]
+
+    nested_sliced = sliced_child[1:]
+    assert list(itertuples(nested_sliced)) == [(3, True)]
 
 
 def test_itertuples_nullable():
@@ -110,6 +137,20 @@ def test_itertuples_nullable():
     )
 
     assert list(itertuples(array)) == [(1, True), (2, False), (3, True), None]
+
+    sliced = array[1:]
+    assert list(itertuples(sliced)) == [(2, False), (3, True), None]
+
+    sliced_child = na.c_array_from_buffers(
+        array.schema,
+        length=3,
+        buffers=[na.c_buffer([True, True, False], na.bool())],
+        children=[array.child(0)[1:], array.child(1)[1:]],
+    )
+    assert list(itertuples(sliced_child)) == [(2, False), (3, True), None]
+
+    nested_sliced = sliced_child[1:]
+    assert list(itertuples(nested_sliced)) == [(3, True), None]
 
 
 def test_itertuples_errors():
@@ -127,6 +168,12 @@ def test_iterator_struct():
 
     assert list(iterator(array)) == [
         {"col1": 1, "col2": True},
+        {"col1": 2, "col2": False},
+        {"col1": 3, "col2": True},
+    ]
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [
         {"col1": 2, "col2": False},
         {"col1": 3, "col2": True},
     ]
@@ -150,33 +197,98 @@ def test_iterator_nullable_struct():
         None,
     ]
 
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [
+        {"col1": 2, "col2": False},
+        {"col1": 3, "col2": True},
+        None,
+    ]
+
 
 def test_iterator_list():
     pa = pytest.importorskip("pyarrow")
-    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0]]
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, None], [0]]
     array = pa.array(items)
     assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [[4, 5, 6], [7, 8, None], [0]]
+
+    array_sliced_child = pa.ListArray.from_arrays([0, 2, 5, 8, 9], array.values[1:])
+    assert (list(iterator(array_sliced_child))) == [
+        [2, 3],
+        [4, 5, 6],
+        [7, 8, None],
+        [0],
+    ]
+
+    nested_sliced = array_sliced_child[1:]
+    assert (list(iterator(nested_sliced))) == [
+        [4, 5, 6],
+        [7, 8, None],
+        [0],
+    ]
 
 
 def test_iterator_nullable_list():
     pa = pytest.importorskip("pyarrow")
-    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [0], None]
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, None], [0], None]
     array = pa.array(items)
     assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [[4, 5, 6], [7, 8, None], [0], None]
+
+    array_sliced_child = pa.ListArray.from_arrays(
+        [0, 2, 5, 8, 9, 9],
+        array.values[1:],
+        mask=pa.array([False, False, False, False, True]),
+    )
+    assert (list(iterator(array_sliced_child))) == [
+        [2, 3],
+        [4, 5, 6],
+        [7, 8, None],
+        [0],
+        None,
+    ]
+
+    nested_sliced = array_sliced_child[1:]
+    assert (list(iterator(nested_sliced))) == [[4, 5, 6], [7, 8, None], [0], None]
 
 
 def test_iterator_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
-    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, None]]
     array = pa.array(items, pa.list_(pa.int64(), 3))
     assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [[4, 5, 6], [7, 8, None]]
+
+    array_sliced_child = pa.FixedSizeListArray.from_arrays(array.values[3:], 3)
+    assert (list(iterator(array_sliced_child))) == [[4, 5, 6], [7, 8, None]]
+
+    nested_sliced = array_sliced_child[1:]
+    assert (list(iterator(nested_sliced))) == [[7, 8, None]]
 
 
 def test_iterator_nullable_fixed_size_list():
     pa = pytest.importorskip("pyarrow")
-    items = [[1, 2, 3], [4, 5, 6], [7, 8, 9], None]
+    items = [[1, 2, 3], [4, 5, 6], [7, 8, None], None]
     array = pa.array(items, pa.list_(pa.int64(), 3))
     assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == [[4, 5, 6], [7, 8, None], None]
+
+    # mask argument only available for pyarrow >= 15.0.0
+    array_sliced_child = pa.FixedSizeListArray.from_arrays(
+        array.values[3:], 3, mask=pa.array([False, False, True])
+    )
+    assert (list(iterator(array_sliced_child))) == [[4, 5, 6], [7, 8, None], None]
+
+    nested_sliced = array_sliced_child[1:]
+    assert (list(iterator(nested_sliced))) == [[7, 8, None], None]
 
 
 def test_iterator_dictionary():
@@ -186,3 +298,18 @@ def test_iterator_dictionary():
     array = pa.array(items).dictionary_encode()
 
     assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == ["cde", "ab", "def", "cde"]
+
+
+def test_iterator_nullable_dictionary():
+    pa = pytest.importorskip("pyarrow")
+
+    items = ["ab", "cde", "ab", "def", "cde", None]
+    array = pa.array(items).dictionary_encode()
+
+    assert list(iterator(array)) == items
+
+    sliced = array[1:]
+    assert list(iterator(sliced)) == ["cde", "ab", "def", "cde", None]

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -371,15 +371,19 @@ def test_buffers_bool():
 
     # Check via element interface
     assert data_buffer.n_elements == 8
-    assert list(data_buffer.elements) == [True] * 3 + [False] * 5
+    assert list(data_buffer.elements()) == [True] * 3 + [False] * 5
     assert [data_buffer.element(i) for i in range(data_buffer.n_elements)] == list(
-        data_buffer.elements
+        data_buffer.elements()
     )
 
     with pytest.raises(IndexError):
         data_buffer[8]
     with pytest.raises(IndexError):
         data_buffer[-1]
+    with pytest.raises(IndexError):
+        next(data_buffer.elements(-1, 4))
+    with pytest.raises(IndexError):
+        next(data_buffer.elements(7, 2))
 
     # Check repr
     assert "11100000" in repr(data_buffer)


### PR DESCRIPTION
This PR adds a framework for Python object creation from arrays and array streams with implementations for most arrow types. Notably, it includes implementations for nested types (struct, list, dictionary) to make sure that the framework won't have to be completely rewritten to accommodate them. A few types (decimal, datetime) aren't supported but should be reasonably easy to implement by wrapping existing iterator factories included in this PR.

None of these are exposed with `import nanoarrow as na` yet...I'm anticipating that the user-facing `nanoarrow.Array` and/or `nanoarrow.ArrayStream` to use the implementation here in methods.

A few changes were required at a lower level to make this work:

- It is now possible to use nanoarrow's `ArrowBasicArrayStream` implementation to create a stream from a previously-resolved list of arrays. This makes it easier to test streams since before we had no way to create them.
- The constructor for `c_array_stream()` now falls back on `c_array()` by wrapping it in a length-one stream. This makes it easier to write generic code that takes stream-like input (like the iterator).
- The `ArrowLayout` needed to be exposed to implement the fixed-size list implementation.
- I added tests for all the lower level changes, which I did in dedicated files. Some of these tests overlap with existing tests in test_nanoarrow...at some point we should go through test_nanoarrow and separate the tests (or create an integration test section since many of those early tests assumed pyarrow was available).

The implementation seems to be efficient given the constraint that assembling the iterators is currently done using Python code.

```python
import numpy as np
import pyarrow as pa
from nanoarrow import iterator

n = int(1e6)
n_cols = 10
arrays = [np.random.random(n) for _ in range(n_cols)]
batch = pa.record_batch(
    arrays,
    names=[f"col{i}" for i in range(n_cols)]
)

%timeit list(iterator.itertuples(batch))
#> 256 ms ± 4.61 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Just zipping the arrays
%timeit list(zip(*arrays))
#> 335 ms ± 1.15 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# A few ways to do this from pyarrow
%timeit list(zip(*(col.to_pylist() for col in batch.columns)))
#> 1.99 s ± 52.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit list(zip(*(col.to_numpy() for col in batch.columns)))
#> 315 ms ± 1.33 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# Works if all columns are the same type (but rows are arrays, not tuples)
%timeit list(np.array(batch))
#> 131 ms ± 484 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# Test some nested things
n = int(1e4)
n_cols = 10
big_list = [["a", "b", "c", "d", "e"]] * n

arrays = [big_list for _ in range(n_cols)]
batch = pa.record_batch(
    arrays,
    names=[f"col{i}" for i in range(n_cols)]
)

%timeit list(iterator.itertuples(batch))
#> 89.2 ms ± 756 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit list(zip(*(col.to_pylist() for col in batch.columns)))
#> 288 ms ± 748 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```