### PR TITLE
chore: Add basic benchmark suite to C library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,9 @@ if(NANOARROW_BUILD_BENCHMARKS)
   add_subdirectory("thirdparty/benchmark")
 
   add_executable(schema_benchmark src/nanoarrow/schema_benchmark.cc)
+  add_executable(array_view_benchmark src/nanoarrow/array_view_benchmark.cc)
+
   target_link_libraries(schema_benchmark PRIVATE nanoarrow benchmark::benchmark_main)
+  target_link_libraries(array_view_benchmark PRIVATE nanoarrow benchmark::benchmark_main)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,9 +268,9 @@ if(NANOARROW_BUILD_BENCHMARKS)
   add_subdirectory("thirdparty/benchmark")
 
   add_executable(schema_benchmark src/nanoarrow/schema_benchmark.cc)
-  add_executable(array_view_benchmark src/nanoarrow/array_view_benchmark.cc)
+  add_executable(array_benchmark src/nanoarrow/array_benchmark.cc)
 
   target_link_libraries(schema_benchmark PRIVATE nanoarrow benchmark::benchmark_main)
-  target_link_libraries(array_view_benchmark PRIVATE nanoarrow benchmark::benchmark_main)
+  target_link_libraries(array_benchmark PRIVATE nanoarrow benchmark::benchmark_main)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,11 @@ if(NANOARROW_BUILD_TESTS)
 endif()
 
 if(NANOARROW_BUILD_BENCHMARKS)
+  # benchmark requires at least C++11
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+
   add_subdirectory("thirdparty/benchmark")
 
   add_executable(schema_benchmark src/nanoarrow/schema_benchmark.cc)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,10 @@
         {
             "name": "default",
             "displayName": "Default Config",
-            "cacheVariables": {}
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
         },
         {
             "name": "default-with-tests",
@@ -20,6 +23,14 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "NANOARROW_BUILD_TESTS": "ON"
+            }
+        },
+        {
+            "name": "default-with-benchmarks",
+            "displayName": "Default with benchmarks",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "NANOARROW_BUILD_BENCHMARKS": "ON"
             }
         }
     ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,9 +16,7 @@
         },
         {
             "name": "default-with-tests",
-            "inherits": [
-                "default"
-            ],
+            "inherits": ["default"],
             "displayName": "Default with tests",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
@@ -27,6 +25,7 @@
         },
         {
             "name": "default-with-benchmarks",
+            "inherits": ["default"],
             "displayName": "Default with benchmarks",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",

--- a/src/nanoarrow/array_benchmark.cc
+++ b/src/nanoarrow/array_benchmark.cc
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <algorithm>
-#include <iostream>
-
 #include <benchmark/benchmark.h>
 
 #include "nanoarrow.hpp"
@@ -45,55 +42,98 @@ ArrowErrorCode InitSchemaAndArrayPrimitive(ArrowSchema* schema, ArrowArray* arra
 }
 
 template <typename CType, ArrowType type>
-static void BaseArrayViewGetIntUnsafe(benchmark::State& state) {
+static void BaseArrayViewGetIntUnsafe(benchmark::State& state, double prop_null = 0.0) {
   nanoarrow::UniqueSchema schema;
   nanoarrow::UniqueArray array;
   nanoarrow::UniqueArrayView array_view;
 
   int64_t n_values = 1000000;
+
   std::vector<CType> values(n_values);
   for (int64_t i = 0; i < n_values; i++) {
     values[i] = i % std::numeric_limits<CType>::max();
   }
 
-  int code = InitSchemaAndArrayPrimitive<CType, type>(schema.get(), array.get(), values);
+  std::vector<int8_t> validity;
+
+  if (prop_null > 0) {
+    int64_t num_nulls = n_values * prop_null;
+    int64_t null_spacing = n_values / num_nulls;
+    validity.resize(n_values);
+    for (int64_t i = 0; i < n_values; i++) {
+      validity[i] = i % null_spacing != 0;
+    }
+  }
+
+  int code = InitSchemaAndArrayPrimitive<CType, type>(
+      schema.get(), array.get(), std::move(values), std::move(validity));
   NANOARROW_THROW_NOT_OK(code);
   NANOARROW_THROW_NOT_OK(
       ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
   NANOARROW_THROW_NOT_OK(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr));
 
   std::vector<CType> values_out(n_values);
-  for (auto _ : state) {
-    for (int64_t i = 0; i < n_values; i++) {
-      values_out[i] = ArrowArrayViewGetIntUnsafe(array_view.get(), i);
+
+  if (prop_null > 0) {
+    for (auto _ : state) {
+      for (int64_t i = 0; i < n_values; i++) {
+        if (ArrowArrayViewIsNull(array_view.get(), i)) {
+          values_out[i] = 0;
+        } else {
+          values_out[i] = ArrowArrayViewGetIntUnsafe(array_view.get(), i);
+        }
+      }
+      benchmark::DoNotOptimize(values_out);
     }
-    benchmark::DoNotOptimize(values_out);
-    benchmark::ClobberMemory();
+  } else {
+    for (auto _ : state) {
+      for (int64_t i = 0; i < n_values; i++) {
+        values_out[i] = ArrowArrayViewGetIntUnsafe(array_view.get(), i);
+      }
+      benchmark::DoNotOptimize(values_out);
+    }
   }
 
   state.SetItemsProcessed(n_values * state.iterations());
 }
 
 static void BM_ArrayViewGetIntUnsafeInt8(benchmark::State& state) {
-  BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT32>(state);
+  BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT8>(state);
 }
-
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt8);
 
 static void BM_ArrayViewGetIntUnsafeInt16(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state);
 }
 
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt16);
-
 static void BM_ArrayViewGetIntUnsafeInt32(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state);
 }
-
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt32);
 
 static void BM_ArrayViewGetIntUnsafeInt64(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state);
 }
 
+static void BM_ArrayViewGetIntUnsafeInt8CheckNull(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT8>(state, 0.2);
+}
+
+static void BM_ArrayViewGetIntUnsafeInt16CheckNull(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state, 0.2);
+}
+
+static void BM_ArrayViewGetIntUnsafeInt32CheckNull(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state, 0.2);
+}
+
+static void BM_ArrayViewGetIntUnsafeInt64CheckNull(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state, 0.2);
+}
+
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt8);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt16);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt32);
 BENCHMARK(BM_ArrayViewGetIntUnsafeInt64);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt8CheckNull);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt16CheckNull);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt32CheckNull);
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt64CheckNull);

--- a/src/nanoarrow/array_benchmark.cc
+++ b/src/nanoarrow/array_benchmark.cc
@@ -104,32 +104,32 @@ static void BaseArrayViewGetIntUnsafe(benchmark::State& state, double prop_null 
 }
 
 /// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int8 array
-static void BM_ArrayViewGetIntUnsafeInt8(benchmark::State& state) {
+static void BenchmarkArrayViewGetIntUnsafeInt8(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT8>(state);
 }
 
 /// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int16 array
-static void BM_ArrayViewGetIntUnsafeInt16(benchmark::State& state) {
+static void BenchmarkArrayViewGetIntUnsafeInt16(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state);
 }
 
 /// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int32 array
-static void BM_ArrayViewGetIntUnsafeInt32(benchmark::State& state) {
+static void BenchmarkArrayViewGetIntUnsafeInt32(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state);
 }
 
 /// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int64 array
-static void BM_ArrayViewGetIntUnsafeInt64(benchmark::State& state) {
+static void BenchmarkArrayViewGetIntUnsafeInt64(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state);
 }
 
 /// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int64 array (checking for nulls)
-static void BM_ArrayViewGetIntUnsafeInt64CheckNull(benchmark::State& state) {
+static void BenchmarkArrayViewGetIntUnsafeInt64CheckNull(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state, 0.2);
 }
 
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt8);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt16);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt32);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt64);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt64CheckNull);
+BENCHMARK(BenchmarkArrayViewGetIntUnsafeInt8);
+BENCHMARK(BenchmarkArrayViewGetIntUnsafeInt16);
+BENCHMARK(BenchmarkArrayViewGetIntUnsafeInt32);
+BENCHMARK(BenchmarkArrayViewGetIntUnsafeInt64);
+BENCHMARK(BenchmarkArrayViewGetIntUnsafeInt64CheckNull);

--- a/src/nanoarrow/array_benchmark.cc
+++ b/src/nanoarrow/array_benchmark.cc
@@ -19,7 +19,13 @@
 
 #include "nanoarrow.hpp"
 
-// Utility for making
+/// \defgroup nanoarrow-benchmark-array-view ArrowArrayView-related benchmarks
+///
+/// Benchmarks for consuming ArrowArrays using the ArrowArrayViewXXX() functions.
+///
+/// @{
+
+// Utility for building primitive arrays
 template <typename CType, ArrowType type>
 ArrowErrorCode InitSchemaAndArrayPrimitive(ArrowSchema* schema, ArrowArray* array,
                                            std::vector<CType> values,
@@ -97,34 +103,27 @@ static void BaseArrayViewGetIntUnsafe(benchmark::State& state, double prop_null 
   state.SetItemsProcessed(n_values * state.iterations());
 }
 
+/// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int8 array
 static void BM_ArrayViewGetIntUnsafeInt8(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT8>(state);
 }
 
+/// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int16 array
 static void BM_ArrayViewGetIntUnsafeInt16(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state);
 }
 
+/// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int32 array
 static void BM_ArrayViewGetIntUnsafeInt32(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state);
 }
 
+/// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int64 array
 static void BM_ArrayViewGetIntUnsafeInt64(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state);
 }
 
-static void BM_ArrayViewGetIntUnsafeInt8CheckNull(benchmark::State& state) {
-  BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT8>(state, 0.2);
-}
-
-static void BM_ArrayViewGetIntUnsafeInt16CheckNull(benchmark::State& state) {
-  BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state, 0.2);
-}
-
-static void BM_ArrayViewGetIntUnsafeInt32CheckNull(benchmark::State& state) {
-  BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state, 0.2);
-}
-
+/// \brief Use ArrowArrayViewGetIntUnsafe() to consume an int64 array (checking for nulls)
 static void BM_ArrayViewGetIntUnsafeInt64CheckNull(benchmark::State& state) {
   BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state, 0.2);
 }
@@ -133,7 +132,4 @@ BENCHMARK(BM_ArrayViewGetIntUnsafeInt8);
 BENCHMARK(BM_ArrayViewGetIntUnsafeInt16);
 BENCHMARK(BM_ArrayViewGetIntUnsafeInt32);
 BENCHMARK(BM_ArrayViewGetIntUnsafeInt64);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt8CheckNull);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt16CheckNull);
-BENCHMARK(BM_ArrayViewGetIntUnsafeInt32CheckNull);
 BENCHMARK(BM_ArrayViewGetIntUnsafeInt64CheckNull);

--- a/src/nanoarrow/array_view_benchmark.cc
+++ b/src/nanoarrow/array_view_benchmark.cc
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <iostream>
+
+#include <benchmark/benchmark.h>
+
+#include "nanoarrow.hpp"
+
+// Utility for making
+template <typename CType, ArrowType type>
+ArrowErrorCode InitSchemaAndArrayPrimitive(ArrowSchema* schema, ArrowArray* array,
+                                           std::vector<CType> values,
+                                           std::vector<int8_t> validity = {}) {
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, type));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(array, schema, nullptr));
+
+  // Set the data buffer
+  nanoarrow::BufferInitSequence(ArrowArrayBuffer(array, 1), std::move(values));
+
+  // Pack the validity bitmap
+  if (validity.size() > 0) {
+    ArrowBitmap* validity_bitmap = ArrowArrayValidityBitmap(array);
+    NANOARROW_RETURN_NOT_OK(ArrowBitmapReserve(validity_bitmap, validity.size()));
+    ArrowBitmapAppendInt8Unsafe(validity_bitmap, validity.data(), validity.size());
+  }
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuildingDefault(array, nullptr));
+  return NANOARROW_OK;
+}
+
+template <typename CType, ArrowType type>
+static void BaseArrayViewGetIntUnsafe(benchmark::State& state) {
+  nanoarrow::UniqueSchema schema;
+  nanoarrow::UniqueArray array;
+  nanoarrow::UniqueArrayView array_view;
+
+  int64_t n_values = 1000000;
+  std::vector<CType> values(n_values);
+  for (int64_t i = 0; i < n_values; i++) {
+    values[i] = i % std::numeric_limits<CType>::max();
+  }
+
+  int code = InitSchemaAndArrayPrimitive<CType, type>(schema.get(), array.get(), values);
+  NANOARROW_THROW_NOT_OK(code);
+  NANOARROW_THROW_NOT_OK(
+      ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr));
+  NANOARROW_THROW_NOT_OK(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr));
+
+  std::vector<CType> values_out(n_values);
+  for (auto _ : state) {
+    for (int64_t i = 0; i < n_values; i++) {
+      values_out[i] = ArrowArrayViewGetIntUnsafe(array_view.get(), i);
+    }
+    benchmark::DoNotOptimize(values_out);
+    benchmark::ClobberMemory();
+  }
+
+  state.SetItemsProcessed(n_values * state.iterations());
+}
+
+static void BM_ArrayViewGetIntUnsafeInt8(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int8_t, NANOARROW_TYPE_INT32>(state);
+}
+
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt8);
+
+static void BM_ArrayViewGetIntUnsafeInt16(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int16_t, NANOARROW_TYPE_INT16>(state);
+}
+
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt16);
+
+static void BM_ArrayViewGetIntUnsafeInt32(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int32_t, NANOARROW_TYPE_INT32>(state);
+}
+
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt32);
+
+static void BM_ArrayViewGetIntUnsafeInt64(benchmark::State& state) {
+  BaseArrayViewGetIntUnsafe<int64_t, NANOARROW_TYPE_INT64>(state);
+}
+
+BENCHMARK(BM_ArrayViewGetIntUnsafeInt64);

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -313,7 +313,7 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)
 #else
-#define NANOARROW_ASSERT_OK(EXPR) EXPR
+#define NANOARROW_ASSERT_OK(EXPR) (void)(EXPR)
 #define NANOARROW_DCHECK(EXPR)
 #endif
 

--- a/src/nanoarrow/schema_benchmark.cc
+++ b/src/nanoarrow/schema_benchmark.cc
@@ -19,12 +19,13 @@
 
 #include "nanoarrow.hpp"
 
-/// \brief Benchmark ArrowSchema creation for very wide tables
+/// \defgroup nanoarrow-benchmark-schema Schema-related benchmarks
 ///
-/// Simulates part of the process of creating a very wide table with a
-/// simple column type (integer).
-static void BM_SchemaInitWideStruct(benchmark::State& state);
+/// Benchmarks for producing and consuming ArrowSchema.
+///
+/// @{
 
+// Utility to initialize a wide struct schema
 static ArrowErrorCode SchemaInitStruct(struct ArrowSchema* schema, int64_t n_columns) {
   ArrowSchemaInit(schema);
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, n_columns));
@@ -34,6 +35,12 @@ static ArrowErrorCode SchemaInitStruct(struct ArrowSchema* schema, int64_t n_col
   }
   return NANOARROW_OK;
 }
+
+/// \brief Benchmark ArrowSchema creation for very wide tables
+///
+/// Simulates part of the process of creating a very wide table with a
+/// simple column type (integer).
+static void BM_SchemaInitWideStruct(benchmark::State& state);
 
 static void BM_SchemaInitWideStruct(benchmark::State& state) {
   struct ArrowSchema schema;
@@ -84,3 +91,5 @@ static void BM_SchemaViewInitWideStruct(benchmark::State& state) {
 }
 
 BENCHMARK(BM_SchemaViewInitWideStruct);
+
+/// @}

--- a/src/nanoarrow/schema_benchmark.cc
+++ b/src/nanoarrow/schema_benchmark.cc
@@ -40,9 +40,9 @@ static ArrowErrorCode SchemaInitStruct(struct ArrowSchema* schema, int64_t n_col
 ///
 /// Simulates part of the process of creating a very wide table with a
 /// simple column type (integer).
-static void BM_SchemaInitWideStruct(benchmark::State& state);
+static void BenchmarkSchemaInitWideStruct(benchmark::State& state);
 
-static void BM_SchemaInitWideStruct(benchmark::State& state) {
+static void BenchmarkSchemaInitWideStruct(benchmark::State& state) {
   struct ArrowSchema schema;
 
   int64_t n_columns = 10000;
@@ -55,14 +55,14 @@ static void BM_SchemaInitWideStruct(benchmark::State& state) {
   state.SetItemsProcessed(n_columns * state.iterations());
 }
 
-BENCHMARK(BM_SchemaInitWideStruct);
+BENCHMARK(BenchmarkSchemaInitWideStruct);
 
 /// \brief Benchmark ArrowSchema parsing for very wide tables
 ///
 /// Simulates part of the process of consuming a very wide table. Typically
 /// the ArrowSchemaViewInit() is done by ArrowArrayViewInit() but uses a
 /// similar pattern.
-static void BM_SchemaViewInitWideStruct(benchmark::State& state);
+static void BenchmarkSchemaViewInitWideStruct(benchmark::State& state);
 
 static ArrowErrorCode SchemaViewInitChildren(struct ArrowSchema* schema,
                                              struct ArrowError* error) {
@@ -75,7 +75,7 @@ static ArrowErrorCode SchemaViewInitChildren(struct ArrowSchema* schema,
   return NANOARROW_OK;
 }
 
-static void BM_SchemaViewInitWideStruct(benchmark::State& state) {
+static void BenchmarkSchemaViewInitWideStruct(benchmark::State& state) {
   struct ArrowSchema schema;
   struct ArrowError error;
 
@@ -90,6 +90,6 @@ static void BM_SchemaViewInitWideStruct(benchmark::State& state) {
   ArrowSchemaRelease(&schema);
 }
 
-BENCHMARK(BM_SchemaViewInitWideStruct);
+BENCHMARK(BenchmarkSchemaViewInitWideStruct);
 
 /// @}

--- a/src/nanoarrow/schema_benchmark.cc
+++ b/src/nanoarrow/schema_benchmark.cc
@@ -46,6 +46,13 @@ static void BM_SchemaInitStruct10000(benchmark::State& state) {
 
 BENCHMARK(BM_SchemaInitStruct10000);
 
+/// \brief Benchmark ArrowSchema parsing for very wide tables
+///
+/// Simulates part of the process of consuming a very wide table. Typically
+/// the ArrowSchemaViewInit() is done by ArrowArrayViewInit() but uses a
+/// similar pattern.
+static void BM_SchemaViewInit10000(benchmark::State& state);
+
 static ArrowErrorCode SchemaViewInitChildren(struct ArrowSchema* schema,
                                              struct ArrowError* error) {
   for (int64_t i = 0; i < schema->n_children; i++) {


### PR DESCRIPTION
This PR adds an initial set of benchmarks covering some realistic usage patterns. The general approach is to use doxygen comments to document the benchmarks, which will run against the released version and the previous version. I'm not sure exactly what the output format will be but I'd like the benchmarks to be written in such a way that there's a path to programatically generating a report (maybe using conbench, maybe just a Quarto document).

Work in progress!