### PR TITLE
chore(ci): Fix bundler action

### DIFF
--- a/.github/workflows/bundle.yaml
+++ b/.github/workflows/bundle.yaml
@@ -31,14 +31,7 @@ jobs:
   bundle-dist:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y cmake
+      - uses: actions/checkout@v4
 
       - name: Bundle nanoarrow
         run: |


### PR DESCRIPTION
This was failing because it didn't call `apt-get update`; however, CMake is installed anyway on the runner (so no need to install it again).