### PR TITLE
chore(ci): Fix container build action

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,7 +23,7 @@ on:
   pull_request:
     paths:
       - 'ci/docker/*'
-      - '.github/workflow/docker-build.yaml'
+      - '.github/workflows/docker-build.yaml'
       - 'docker-compose.yaml'
 
 permissions:
@@ -51,6 +51,10 @@ jobs:
 
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x" }
 
+    env:
+      DOCKER_CLIENT_TIMEOUT: 360
+      COMPOSE_HTTP_TIMEOUT: 360
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,9 +76,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DOCKER_CLIENT_TIMEOUT: 360
-          COMPOSE_HTTP_TIMEOUT: 360
 
       - name: Set up QEMU
         if: matrix.config.arch == 's390x'
@@ -94,8 +95,6 @@ jobs:
           NANOARROW_ARCH: ${{ matrix.config.arch }}
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
-          DOCKER_CLIENT_TIMEOUT: 360
-          COMPOSE_HTTP_TIMEOUT: 360
         run: |
           docker-compose push verify
 

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -51,6 +51,10 @@ jobs:
 
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x" }
 
+    env:
+      DOCKER_CLIENT_TIMEOUT: 360
+      COMPOSE_HTTP_TIMEOUT: 360
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -51,10 +51,6 @@ jobs:
 
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x" }
 
-    env:
-      DOCKER_CLIENT_TIMEOUT: 360
-      COMPOSE_HTTP_TIMEOUT: 360
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,6 +72,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          DOCKER_CLIENT_TIMEOUT: 360
+          COMPOSE_HTTP_TIMEOUT: 360
 
       - name: Set up QEMU
         if: matrix.config.arch == 's390x'
@@ -95,6 +94,8 @@ jobs:
           NANOARROW_ARCH: ${{ matrix.config.arch }}
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
+          DOCKER_CLIENT_TIMEOUT: 360
+          COMPOSE_HTTP_TIMEOUT: 360
         run: |
           docker-compose push verify
 


### PR DESCRIPTION
This is an attempt to fix the Build Docker Images workflow (which runs once a week).

For the last few weeks we've had errors with HTTP timeouts like:

```
Error: Error response from daemon: Get "https://ghcr.io/v2/": Get "https://ghcr.io/token?account=paleolimbot&client_id=docker&offline_token=true&service=ghcr.io": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers) (Client.Timeout exceeded while awaiting headers)
```

Or

```
Pushing verify (ghcr.io/apache/arrow-nanoarrow:archlinux-amd64)...
The push refers to repository [ghcr.io/apache/arrow-nanoarrow]
[12125] Failed to execute script docker-compose
Traceback (most recent call last):
  File "urllib3/response.py", line 436, in _error_catcher
  File "urllib3/response.py", line 518, in read
  File "http/client.py", line 461, in read
  File "http/client.py", line 495, in readinto
  File "http/client.py", line 590, in _readinto_chunked
  File "http/client.py", line 558, in _get_chunk_left
  File "http/client.py", line 518, in _read_next_chunk_size
  File "socket.py", line 589, in readinto
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 81, in main
  File "compose/cli/main.py", line 203, in perform_command
  File "compose/metrics/decorator.py", line 18, in wrapper
  File "compose/cli/main.py", line 864, in push
  File "compose/project.py", line 828, in push
  File "compose/service.py", line 1264, in push
  File "compose/progress_stream.py", line 109, in get_digest_from_push
  File "compose/progress_stream.py", line 22, in stream_output
  File "compose/utils.py", line 50, in split_buffer
  File "compose/utils.py", line 26, in stream_as_text
  File "docker/api/client.py", line 350, in _stream_helper
  File "urllib3/response.py", line 540, in read
  File "contextlib.py", line 130, in __exit__
  File "urllib3/response.py", line 441, in _error_catcher
urllib3.exceptions.ReadTimeoutError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.
```