### PR TITLE
feat(python): Add repr iterator

### DIFF
--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -288,6 +288,7 @@ class ItemRepr:
     def finish(self):
         out = self._out.getvalue()
         self._out.seek(0)
+        self._out.truncate()
         if len(out) > self._max_size:
             return out[: (self._max_size - 3)] + "..."
         else:

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -316,5 +316,5 @@ def test_iterator_nullable_dictionary():
 
 
 def test_iterator_repr():
-    array = na.c_array([1, 2, 3], na.int32())
-    assert list(iterrepr(array)) == ["1", "2", "3"]
+    array = na.c_array([1234567890, 12345678901, 3], na.int64())
+    assert list(iterrepr(array, max_width=10)) == ["1234567890", "1234567...", "3"]

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import pytest
-from nanoarrow.iterator import iterator, itertuples
+from nanoarrow.iterator import iterator, iterrepr, itertuples
 
 import nanoarrow as na
 
@@ -313,3 +313,8 @@ def test_iterator_nullable_dictionary():
 
     sliced = array[1:]
     assert list(iterator(sliced)) == ["cde", "ab", "def", "cde", None]
+
+
+def test_iterator_repr():
+    array = na.c_array([1, 2, 3], na.int32())
+    assert list(iterrepr(array)) == ["1", "2", "3"]


### PR DESCRIPTION
The existing iterators are optimized for completely consuming input; however, this is very bad if (e.g.) you have one element that's a few hundred MB in size. Work in progress!