### PR TITLE
fix: Relax comparison strictness such that integration tests pass

### DIFF
--- a/src/nanoarrow/integration/c_data_integration.cc
+++ b/src/nanoarrow/integration/c_data_integration.cc
@@ -54,6 +54,13 @@ static ArrowBufferAllocator IntegrationTestAllocator() {
   return allocator;
 }
 
+static void SetComparisonOptions(nanoarrow::testing::TestingJSONComparison* comparison) {
+  comparison->set_compare_batch_flags(false);
+  comparison->set_compare_float_precision(3);
+  comparison->set_compare_metadata_order(false);
+  comparison->set_metadata_null_equals_metadata_empty(true);
+}
+
 static ArrowErrorCode ReadFileString(std::ostream& out, const std::string& file_path) {
   std::ifstream infile(file_path, std::ios::in | std::ios::binary);
   char buf[8096];
@@ -141,6 +148,8 @@ static ArrowErrorCode ImportSchemaAndCompareToJson(const char* json_path,
       error));
 
   nanoarrow::testing::TestingJSONComparison comparison;
+  SetComparisonOptions(&comparison);
+
   NANOARROW_RETURN_NOT_OK(
       comparison.CompareSchema(actual.get(), data.schema.get(), error));
   if (comparison.num_differences() > 0) {
@@ -171,6 +180,8 @@ static ArrowErrorCode ImportBatchAndCompareToJson(const char* json_path, int num
   NANOARROW_RETURN_NOT_OK(MaterializeJsonFilePath(json_path, &data, num_batch, error));
 
   nanoarrow::testing::TestingJSONComparison comparison;
+  SetComparisonOptions(&comparison);
+
   NANOARROW_RETURN_NOT_OK(comparison.SetSchema(data.schema.get(), error));
   NANOARROW_RETURN_NOT_OK(
       comparison.CompareBatch(actual.get(), data.arrays[0].get(), error));

--- a/src/nanoarrow/integration/c_data_integration.cc
+++ b/src/nanoarrow/integration/c_data_integration.cc
@@ -58,7 +58,6 @@ static void SetComparisonOptions(nanoarrow::testing::TestingJSONComparison* comp
   comparison->set_compare_batch_flags(false);
   comparison->set_compare_float_precision(3);
   comparison->set_compare_metadata_order(false);
-  comparison->set_metadata_null_equals_metadata_empty(true);
 }
 
 static ArrowErrorCode ReadFileString(std::ostream& out, const std::string& file_path) {

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2187,6 +2187,10 @@ class TestingJSONReader {
     NANOARROW_RETURN_NOT_OK(
         Check(value.is_array(), error, "bitmap buffer must be array"));
 
+    // Reserving with the exact length ensures that the last bits are always zeroed.
+    // This is currently an assumption made by the C# implementation.
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapReserve(bitmap, value.size()), error);
+
     for (const auto& item : value) {
       // Some example files write bitmaps as [true, false, true] but the documentation
       // says [1, 0, 1]. Accept both for simplicity.

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2758,7 +2758,6 @@ class TestingJSONComparison {
   // Comparison options
   bool compare_batch_flags_;
   bool compare_metadata_order_;
-  bool metadata_null_equals_metadata_empty_;
 
   ArrowErrorCode CompareField(ArrowSchema* actual, ArrowSchema* expected,
                               ArrowError* error, const std::string& path = "") {

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2037,6 +2037,11 @@ class TestingJSONReader {
       }
     }
 
+    // The null type doesn't have any buffers but we can set the null_count
+    if (array_view->storage_type == NANOARROW_TYPE_NA) {
+      array_view->null_count = array_view->length;
+    }
+
     // If there is a dictionary associated with schema, parse its value into dictionary
     if (schema->dictionary != nullptr) {
       NANOARROW_RETURN_NOT_OK(Check(

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2055,6 +2055,18 @@ class TestingJSONReader {
           array->dictionary, error, error_prefix + "-> <dictionary> "));
     }
 
+    // csharp needs all non-validity buffer values to be non-null?
+    for (int i = 0; i < NANOARROW_MAX_FIXED_BUFFERS; i++) {
+      if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY) {
+        continue;
+      }
+
+      ArrowBuffer* buffer = ArrowArrayBuffer(array, i);
+      if (buffer->data == nullptr) {
+        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendUInt8(buffer, 0));
+      }
+    }
+
     // Validate the array view
     NANOARROW_RETURN_NOT_OK(PrefixError(
         ArrowArrayViewValidate(array_view, NANOARROW_VALIDATION_LEVEL_FULL, error), error,

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -148,6 +148,9 @@ class TestingJSONWriter {
   /// avoid serialization issues.
   void set_float_precision(int value) { float_precision_ = value; }
 
+  /// \brief Set whether metadata should be included in the output of a schema or field
+  ///
+  /// Use false to skip writing schema/field metadata in the output.
   void set_include_metadata(bool value) { include_metadata_ = value; }
 
   void ResetDictionaries() { dictionaries_.clear(); }

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2028,21 +2028,12 @@ class TestingJSONReader {
       buffer_view->data.as_uint8 = buffer->data;
       buffer_view->size_bytes = buffer->size_bytes;
 
-      // If this is a validity buffer with a big enough size, set the array_view's
-      // null_count
+      // If this is a validity buffer, set the null_count
       if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY &&
           _ArrowBytesForBits(array_view->length) <= buffer_view->size_bytes) {
         array_view->null_count =
             array_view->length -
             ArrowBitCountSet(buffer_view->data.as_uint8, 0, array_view->length);
-      }
-
-      // If there are no nulls, drop the validity bitmap entirely. This is more
-      // consistent with how other integration testing JSON readers represent a
-      // validity bitmap.
-      if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY &&
-          array_view->null_count == 0) {
-        ArrowBufferReset(buffer);
       }
     }
 

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2058,6 +2058,14 @@ class TestingJSONReader {
             array_view->length -
             ArrowBitCountSet(buffer_view->data.as_uint8, 0, array_view->length);
       }
+
+      // If there are no nulls, drop the validity bitmap entirely. This is more
+      // consistent with how other integration testing JSON readers represent a
+      // validity bitmap.
+      if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY &&
+          array_view->null_count == 0) {
+        ArrowBufferReset(buffer);
+      }
     }
 
     // If there is a dictionary associated with schema, parse its value into dictionary

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -1386,10 +1386,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchemaComparison) {
 
   AssertSchemasCompareUnequal(actual.get(), expected.get(), /*num_differences*/ 1,
                               /*differences*/
-                              "Path: "
+                              "Path: .metadata"
                               R"(
-- .metadata: [{"key": "key", "value": "value"}]
-+ .metadata: null
+- [{"key": "key", "value": "value"}]
++ null
 
 )");
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), nullptr), NANOARROW_OK);

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -459,6 +459,17 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
       [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], )"
       R"("metadata": [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]})");
+
+  // Ensure we can turn off metadata
+  TestWriteJSON(
+      [](ArrowSchema* schema) {
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetMetadata(schema, "\0\0\0\0"));
+        return NANOARROW_OK;
+      },
+      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": []})",
+      [](TestingJSONWriter& writer) { writer.set_include_metadata(false); });
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {


### PR DESCRIPTION
These changes are the changes required such that https://github.com/apache/arrow/pull/39302 results in passing integration tests for nanoarrow. The changes are mostly related to comparison:

- We needed an option to allow metadata to be compared on a key/value basis without considering order (for Java, which seems to reorder metadata on read)
- We needed the ability to treat NULL metadata and zero-size metadata as equivalent (for Go, which always exports zero-length metadata)
- We needed an option to ignore flags for top-level batches (for C#, which exports nullable structs)
- We needed to ensure that the last few bits of the validity buffer were zeroed (for C#, although this is now fixed in C# on Arrow main)
- We needed to ensure that no buffers were NULL (For C#, which leaks the top-level array if it encounters one, at least in the integration tests. This should really be fixed in C#).