### PR TITLE
feat(python): Clarify interaction between the CDeviceArray, the CArrayView, and the CArray

### DIFF
--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
@@ -115,7 +115,7 @@ struct ArrowDevice* ArrowDeviceCpu(void) {
 
 void ArrowDeviceInitCpu(struct ArrowDevice* device) {
   device->device_type = ARROW_DEVICE_CPU;
-  device->device_id = 0;
+  device->device_id = -1;
   device->array_init = NULL;
   device->array_move = NULL;
   device->buffer_init = &ArrowDeviceCpuBufferInit;
@@ -135,7 +135,7 @@ struct ArrowDevice* ArrowDeviceCuda(ArrowDeviceType device_type, int64_t device_
 #endif
 
 struct ArrowDevice* ArrowDeviceResolve(ArrowDeviceType device_type, int64_t device_id) {
-  if (device_type == ARROW_DEVICE_CPU && device_id == 0) {
+  if (device_type == ARROW_DEVICE_CPU) {
     return ArrowDeviceCpu();
   }
 

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
@@ -28,7 +28,7 @@ TEST(NanoarrowDevice, CheckRuntime) {
 TEST(NanoarrowDevice, CpuDevice) {
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   EXPECT_EQ(cpu->device_type, ARROW_DEVICE_CPU);
-  EXPECT_EQ(cpu->device_id, 0);
+  EXPECT_EQ(cpu->device_id, -1);
   EXPECT_EQ(cpu, ArrowDeviceCpu());
 
   void* sync_event = nullptr;

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1151,7 +1151,7 @@ cdef class CArray:
 
         if self._device_type != ARROW_DEVICE_CPU:
             raise ValueError(
-                "Can't invoke __arrow_c_aray__ on non-CPU array "
+                "Can't invoke __arrow_c_array__ on non-CPU array "
                 f"with device_type {self._device_type}")
 
         if requested_schema is not None:
@@ -2404,8 +2404,8 @@ cdef class CDeviceArray:
 
     @property
     def array(self):
-        # TODO: We loose access to the sync_event here, so we probably need to
-        # synchronize (or propatate it, or somehow prevent data access downstream)
+        # TODO: We lose access to the sync_event here, so we probably need to
+        # synchronize (or propagate it, or somehow prevent data access downstream)
         cdef CArray array = CArray(self, <uintptr_t>&self._ptr.array, self._schema)
         array._set_device(self._ptr.device_type, self._ptr.device_id)
         return array
@@ -2428,7 +2428,7 @@ cdef class CDeviceArray:
     @staticmethod
     def _import_from_c_capsule(schema_capsule, device_array_capsule):
         """
-        Import from a ArrowSchema and ArrowArray PyCapsule tuple.
+        Import from an ArrowSchema and ArrowArray PyCapsule tuple.
 
         Parameters
         ----------

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -526,7 +526,7 @@ cdef class CArrowTimeUnit:
 
 class DeviceType(Enum):
     """
-    An enum-like wrapper providing access to the device constant values
+    An enumerator providing access to the device constant values
     defined in the Arrow C Device interface. Unlike the other enum
     accessors, this Python Enum is defined in Cython so that we can use
     the bulit-in functionality to do better printing of device identifiers

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2375,7 +2375,12 @@ cdef class CDeviceArray:
 
     @property
     def array(self):
-        return CArray(self, <uintptr_t>&self._ptr.array, self._schema)
+        cdef CArray out = CArray(self, <uintptr_t>&self._ptr.array, self._schema)
+        out._set_device(self._device_type, self._device_id)
+        return out
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return self.array.__arrow_c_array__(requested_schema=requested_schema)
 
     def __repr__(self):
         return _repr_utils.device_array_repr(self)

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2413,5 +2413,12 @@ cdef class CDeviceArray:
     def __arrow_c_array__(self, requested_schema=None):
         return self.array.__arrow_c_array__(requested_schema=requested_schema)
 
+    def __arrow_c_device_array__(self, requested_schema=None):
+        if requested_schema is not None:
+            raise NotImplementedError("requested_schema")
+
+        device_array_capsule = alloc_c_device_array_shallow_copy(self._base, self._ptr)
+        return self._schema.__arrow_c_schema__(), device_array_capsule
+
     def __repr__(self):
         return _repr_utils.device_array_repr(self)

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2404,7 +2404,7 @@ cdef class CDeviceArray:
         # TODO: We loose access to the sync_event here, so we probably need to
         # synchronize (or propatate it, or somehow prevent data access downstream)
         cdef CArray array = CArray(self, <uintptr_t>&self._ptr.array, self._schema)
-        array._set_device(self._device_type, self._device_id)
+        array._set_device(self._ptr.device_type, self._ptr.device_id)
         return array
 
     def view(self):

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2420,6 +2420,8 @@ cdef class CDeviceArray:
         if requested_schema is not None:
             raise NotImplementedError("requested_schema")
 
+        # TODO: evaluate whether we need to synchronize here or whether we should
+        # move device arrays instead of shallow-copying them
         device_array_capsule = alloc_c_device_array_shallow_copy(self._base, self._ptr)
         return self._schema.__arrow_c_schema__(), device_array_capsule
 

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -551,7 +551,7 @@ class DeviceType(Enum):
     HEXAGON = ARROW_DEVICE_HEXAGON
 
 
-cdef class CDevice:
+cdef class Device:
     """ArrowDevice wrapper
 
     The ArrowDevice structure is a nanoarrow internal struct (i.e.,
@@ -601,7 +601,7 @@ cdef class CDevice:
 
 # Cache the CPU device
 # The CPU device is statically allocated (so base is None)
-CDEVICE_CPU = CDevice(None, <uintptr_t>ArrowDeviceCpu())
+CDEVICE_CPU = Device(None, <uintptr_t>ArrowDeviceCpu())
 
 
 cdef class CSchema:
@@ -1208,7 +1208,7 @@ cdef class CArray:
             raise RuntimeError("CArray is released")
 
     def view(self):
-        device = CDevice.resolve(self._device_type, self._device_id)
+        device = Device.resolve(self._device_type, self._device_id)
         return CArrayView.from_array(self, device)
 
     @property
@@ -1301,14 +1301,14 @@ cdef class CArrayView:
     cdef object _base
     cdef object _array_base
     cdef ArrowArrayView* _ptr
-    cdef CDevice _device
+    cdef Device _device
 
     def __cinit__(self, object base, uintptr_t addr):
         self._base = base
         self._ptr = <ArrowArrayView*>addr
         self._device = CDEVICE_CPU
 
-    def _set_array(self, CArray array, CDevice device=CDEVICE_CPU):
+    def _set_array(self, CArray array, Device device=CDEVICE_CPU):
         cdef Error error = Error()
         cdef int code
 
@@ -1444,7 +1444,7 @@ cdef class CArrayView:
         return CArrayView(base, <uintptr_t>c_array_view)
 
     @staticmethod
-    def from_array(CArray array, CDevice device=CDEVICE_CPU):
+    def from_array(CArray array, Device device=CDEVICE_CPU):
         out = CArrayView.from_schema(array._schema)
         return out._set_array(array, device)
 
@@ -1491,7 +1491,7 @@ cdef class CBufferView:
     cdef object _base
     cdef ArrowBufferView _ptr
     cdef ArrowType _data_type
-    cdef CDevice _device
+    cdef Device _device
     cdef Py_ssize_t _element_size_bits
     cdef Py_ssize_t _shape
     cdef Py_ssize_t _strides
@@ -1499,7 +1499,7 @@ cdef class CBufferView:
 
     def __cinit__(self, object base, uintptr_t addr, int64_t size_bytes,
                   ArrowType data_type,
-                  Py_ssize_t element_size_bits, CDevice device):
+                  Py_ssize_t element_size_bits, Device device):
         self._base = base
         self._ptr.data.data = <void*>addr
         self._ptr.size_bytes = size_bytes
@@ -1701,7 +1701,7 @@ cdef class CBuffer:
     cdef ArrowType _data_type
     cdef int _element_size_bits
     cdef char _format[32]
-    cdef CDevice _device
+    cdef Device _device
     cdef CBufferView _view
     cdef int _get_buffer_count
 

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2437,7 +2437,7 @@ cdef class CDeviceArray:
             ArrowSchema pointer.
         device_array_capsule : PyCapsule
             A valid PyCapsule with name 'arrow_device_array' containing an
-            ArrowArray pointer.
+            ArrowDeviceArray pointer.
         """
         cdef:
             CSchema out_schema

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -50,6 +50,7 @@ from cpython.ref cimport Py_INCREF, Py_DECREF
 from nanoarrow_c cimport *
 from nanoarrow_device_c cimport *
 
+from enum import Enum
 from sys import byteorder as sys_byteorder
 from struct import unpack_from, iter_unpack, calcsize, Struct
 from nanoarrow import _repr_utils
@@ -523,6 +524,32 @@ cdef class CArrowTimeUnit:
     NANO = NANOARROW_TIME_UNIT_NANO
 
 
+class DeviceType(Enum):
+    """
+    An enum-like wrapper providing access to the device constant values
+    defined in the Arrow C Device interface. Unlike the other enum
+    accessors, this Python Enum is defined in Cython so that we can use
+    the bulit-in functionality to do better printing of device identifiers
+    for classes defined in Cython. Unlike the other enums, users don't
+    typically need to specify these (but would probably like them printed
+    nicely).
+    """
+
+    CPU = ARROW_DEVICE_CPU
+    CUDA = ARROW_DEVICE_CUDA
+    CUDA_HOST = ARROW_DEVICE_CUDA_HOST
+    OPENCL = ARROW_DEVICE_OPENCL
+    VULKAN =  ARROW_DEVICE_VULKAN
+    METAL = ARROW_DEVICE_METAL
+    VPI = ARROW_DEVICE_VPI
+    ROCM = ARROW_DEVICE_ROCM
+    ROCM_HOST = ARROW_DEVICE_ROCM_HOST
+    EXT_DEV = ARROW_DEVICE_EXT_DEV
+    CUDA_MANAGED = ARROW_DEVICE_CUDA_MANAGED
+    ONEAPI = ARROW_DEVICE_ONEAPI
+    WEBGPU = ARROW_DEVICE_WEBGPU
+    HEXAGON = ARROW_DEVICE_HEXAGON
+
 
 cdef class CDevice:
     """ArrowDevice wrapper
@@ -554,6 +581,10 @@ cdef class CDevice:
 
     @property
     def device_type(self):
+        return DeviceType(self._ptr.device_type)
+
+    @property
+    def device_type_id(self):
         return self._ptr.device_type
 
     @property
@@ -561,8 +592,8 @@ cdef class CDevice:
         return self._ptr.device_id
 
     @staticmethod
-    def resolve(ArrowDeviceType device_type, int64_t device_id):
-        if device_type == ARROW_DEVICE_CPU:
+    def resolve(device_type, int64_t device_id):
+        if int(device_type) == ARROW_DEVICE_CPU:
             return CDEVICE_CPU
         else:
             raise ValueError(f"Device not found for type {device_type}/{device_id}")
@@ -1186,6 +1217,10 @@ cdef class CArray:
 
     @property
     def device_type(self):
+        return DeviceType(self._device_type)
+
+    @property
+    def device_type_id(self):
         return self._device_type
 
     @property
@@ -2396,6 +2431,10 @@ cdef class CDeviceArray:
 
     @property
     def device_type(self):
+        return DeviceType(self._ptr.device_type)
+
+    @property
+    def device_type_id(self):
         return self._ptr.device_type
 
     @property

--- a/python/src/nanoarrow/_repr_utils.py
+++ b/python/src/nanoarrow/_repr_utils.py
@@ -169,7 +169,7 @@ def buffer_view_repr(buffer_view, max_char_width=80):
     prefix = f"{buffer_view.data_type}"
     prefix += f"[{buffer_view.size_bytes} b]"
 
-    if buffer_view.device.device_type == 1:
+    if buffer_view.device.device_type_id == 1:
         return (
             prefix
             + " "
@@ -232,7 +232,10 @@ def device_array_repr(device_array):
     class_label = make_class_label(device_array, module="nanoarrow.device")
 
     title_line = f"<{class_label}>"
-    device_type = f"- device_type: {device_array.device_type}"
+    device_type = (
+        f"- device_type: {device_array.device_type.name} "
+        f"<{device_array.device_type_id}>"
+    )
     device_id = f"- device_id: {device_array.device_id}"
     array = f"- array: {array_repr(device_array.array, indent=2)}"
     return "\n".join((title_line, device_type, device_id, array))
@@ -242,6 +245,6 @@ def device_repr(device):
     class_label = make_class_label(device, module="nanoarrow.device")
 
     title_line = f"<{class_label}>"
-    device_type = f"- device_type: {device.device_type}"
+    device_type = f"- device_type: {device.device_type.name} <{device.device_type_id}>"
     device_id = f"- device_id: {device.device_id}"
     return "\n".join([title_line, device_type, device_id])

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -190,8 +190,8 @@ class Array:
         >>> array = na.Array([1, 2, 3], na.int32())
         >>> array.device
         <nanoarrow.device.Device>
-        - device_type: 1
-        - device_id: 0
+        - device_type: CPU <1>
+        - device_id: -1
         """
         return self._device
 

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -18,13 +18,7 @@
 from functools import cached_property
 from typing import Iterable, Tuple
 
-from nanoarrow._lib import (
-    DEVICE_CPU,
-    CArray,
-    CBuffer,
-    CMaterializedArrayStream,
-    Device,
-)
+from nanoarrow._lib import DEVICE_CPU, CArray, CBuffer, CMaterializedArrayStream, Device
 from nanoarrow.c_lib import c_array, c_array_stream, c_array_view
 from nanoarrow.iterator import iter_py, iter_tuples
 from nanoarrow.schema import Schema

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -22,8 +22,8 @@ from nanoarrow._lib import (
     CDEVICE_CPU,
     CArray,
     CBuffer,
-    CDevice,
     CMaterializedArrayStream,
+    Device,
 )
 from nanoarrow.c_lib import c_array, c_array_stream, c_array_view
 from nanoarrow.iterator import iter_py, iter_tuples
@@ -65,7 +65,7 @@ class Scalar:
         self._device = None
 
     @property
-    def device(self) -> CDevice:
+    def device(self) -> Device:
         return self._device
 
     @property
@@ -121,7 +121,7 @@ class Array:
         :func:`c_array_stream`.
     schema : schema-like, optional
         An optional schema, passed to :func:`c_array_stream`.
-    device : CDevice, optional
+    device : Device, optional
         The device associated with the buffers held by this Array.
         Defaults to the CPU device.
 
@@ -139,10 +139,10 @@ class Array:
     def __init__(self, obj, schema=None, device=None) -> None:
         if device is None:
             self._device = CDEVICE_CPU
-        elif isinstance(device, CDevice):
+        elif isinstance(device, Device):
             self._device = device
         else:
-            raise TypeError("device must be CDevice")
+            raise TypeError("device must be Device")
 
         if isinstance(obj, CMaterializedArrayStream) and schema is None:
             self._data = obj
@@ -186,7 +186,7 @@ class Array:
         self._assert_one_chunk("export ArrowArray")
 
     @property
-    def device(self) -> CDevice:
+    def device(self) -> Device:
         """Get the device on which the buffers for this array are allocated.
 
         Examples
@@ -195,7 +195,7 @@ class Array:
         >>> import nanoarrow as na
         >>> array = na.Array([1, 2, 3], na.int32())
         >>> array.device
-        <nanoarrow.device.CDevice>
+        <nanoarrow.device.Device>
         - device_type: 1
         - device_id: 0
         """

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -19,7 +19,7 @@ from functools import cached_property
 from typing import Iterable, Tuple
 
 from nanoarrow._lib import (
-    CDEVICE_CPU,
+    DEVICE_CPU,
     CArray,
     CBuffer,
     CMaterializedArrayStream,
@@ -138,7 +138,7 @@ class Array:
 
     def __init__(self, obj, schema=None, device=None) -> None:
         if device is None:
-            self._device = CDEVICE_CPU
+            self._device = DEVICE_CPU
         elif isinstance(device, Device):
             self._device = device
         else:
@@ -164,7 +164,7 @@ class Array:
             raise ValueError(f"Can't {op} with non-contiguous Array")
 
     def _assert_cpu(self, op):
-        if self._device != CDEVICE_CPU:
+        if self._device != DEVICE_CPU:
             raise ValueError(f"Can't {op} with Array on non-CPU device")
 
     def __arrow_c_stream__(self, requested_schema=None):

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -427,7 +427,7 @@ def c_array_view(obj, schema=None) -> CArrayView:
     if isinstance(obj, CArrayView) and schema is None:
         return obj
 
-    return CArrayView.from_array(c_array(obj, schema))
+    return c_array(obj, schema).view()
 
 
 def c_buffer(obj, schema=None) -> CBuffer:

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray
-from nanoarrow.c_lib import c_array
+from nanoarrow.c_lib import c_array, c_schema
 
 
 def cpu():
@@ -27,11 +27,20 @@ def resolve(device_type, device_id):
     return CDevice.resolve(device_type, device_id)
 
 
-def c_device_array(obj):
-    if isinstance(obj, CDeviceArray):
+def c_device_array(obj, schema=None):
+    if schema is not None:
+        schema = c_schema(schema)
+
+    if isinstance(obj, CDeviceArray) and schema is None:
         return obj
 
-    # Only CPU for now
-    cpu_array = c_array(obj)
+    if hasattr(obj, "__arrow_c_device_array__"):
+        schema_capsule = None if schema is None else schema.__arrow_c_schema__()
+        schema_capsule, device_array_capsule = obj.__arrow_c_device_array__(
+            requested_schema=schema_capsule
+        )
+        return CDeviceArray._import_from_c_capsule(schema_capsule, device_array_capsule)
 
+    # Attempt to create a CPU array and wrap it
+    cpu_array = c_array(obj, schema=schema)
     return cpu()._array_init(cpu_array._addr(), cpu_array.schema)

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray
+from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray, CArray
 from nanoarrow.c_lib import c_array
 
 

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device, DeviceType
+from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device
 from nanoarrow.c_lib import c_array, c_schema
 
 

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray, CArray
+from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray
 from nanoarrow.c_lib import c_array
 
 

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray
+from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray, DeviceType
 from nanoarrow.c_lib import c_array, c_schema
 
 

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device, DeviceType  # noqa: F401
+from nanoarrow._lib import DEVICE_CPU, CDeviceArray, Device, DeviceType  # noqa: F401
 from nanoarrow.c_lib import c_array, c_schema
 
 
 def cpu():
-    return CDEVICE_CPU
+    return DEVICE_CPU
 
 
 def resolve(device_type, device_id):

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device
+from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device, DeviceType  # noqa: F401
 from nanoarrow.c_lib import c_array, c_schema
 
 

--- a/python/src/nanoarrow/device.py
+++ b/python/src/nanoarrow/device.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow._lib import CDEVICE_CPU, CDevice, CDeviceArray, DeviceType
+from nanoarrow._lib import CDEVICE_CPU, CDeviceArray, Device, DeviceType
 from nanoarrow.c_lib import c_array, c_schema
 
 
@@ -24,7 +24,7 @@ def cpu():
 
 
 def resolve(device_type, device_id):
-    return CDevice.resolve(device_type, device_id)
+    return Device.resolve(device_type, device_id)
 
 
 def c_device_array(obj, schema=None):

--- a/python/src/nanoarrow/nanoarrow_device_c.pxd
+++ b/python/src/nanoarrow/nanoarrow_device_c.pxd
@@ -26,7 +26,17 @@ cdef extern from "nanoarrow_device.h" nogil:
     int32_t ARROW_DEVICE_CPU
     int32_t ARROW_DEVICE_CUDA
     int32_t ARROW_DEVICE_CUDA_HOST
+    int32_t ARROW_DEVICE_OPENCL
+    int32_t ARROW_DEVICE_VULKAN
     int32_t ARROW_DEVICE_METAL
+    int32_t ARROW_DEVICE_VPI
+    int32_t ARROW_DEVICE_ROCM
+    int32_t ARROW_DEVICE_ROCM_HOST
+    int32_t ARROW_DEVICE_EXT_DEV
+    int32_t ARROW_DEVICE_CUDA_MANAGED
+    int32_t ARROW_DEVICE_ONEAPI
+    int32_t ARROW_DEVICE_WEBGPU
+    int32_t ARROW_DEVICE_HEXAGON
 
     struct ArrowDeviceArray:
         ArrowArray array

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -31,7 +31,7 @@ def test_array_construct():
     array2 = na.Array(array._data)
     assert array2._data is array._data
 
-    with pytest.raises(TypeError, match="device must be CDevice"):
+    with pytest.raises(TypeError, match="device must be Device"):
         na.Array([], na.int32(), device=1234)
 
     with pytest.raises(NotImplementedError):

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -39,6 +39,8 @@ def test_c_array_from_c_array():
     assert c_array_from_c_array.length == c_array.length
     assert c_array_from_c_array.buffers == c_array.buffers
 
+    assert list(c_array.view().buffer(1)) == [1, 2, 3]
+
 
 def test_c_array_from_capsule_protocol():
     class CArrayWrapper:
@@ -53,6 +55,8 @@ def test_c_array_from_capsule_protocol():
     c_array_from_protocol = na.c_array(c_array_wrapper)
     assert c_array_from_protocol.length == c_array.length
     assert c_array_from_protocol.buffers == c_array.buffers
+
+    assert list(c_array_from_protocol.view().buffer(1)) == [1, 2, 3]
 
 
 def test_c_array_from_old_pyarrow():
@@ -72,6 +76,8 @@ def test_c_array_from_old_pyarrow():
     c_array = na.c_array(array)
     assert c_array.length == 3
     assert c_array.schema.format == "i"
+
+    assert list(c_array.view().buffer(1)) == [1, 2, 3]
 
     # Make sure that this heuristic won't result in trying to import
     # something else that has an _export_to_c method
@@ -96,6 +102,8 @@ def test_c_array_from_bare_capsule():
     c_array_from_capsule = na.c_array(array_capsule, schema_capsule)
     assert c_array_from_capsule.length == c_array.length
     assert c_array_from_capsule.buffers == c_array.buffers
+
+    assert list(c_array_from_capsule.view().buffer(1)) == [1, 2, 3]
 
 
 def test_c_array_type_not_supported():

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -23,21 +23,23 @@ from nanoarrow import device
 
 def test_cpu_device():
     cpu = device.cpu()
-    assert cpu.device_type == 1
+    assert cpu.device_type_id == 1
+    assert cpu.device_type == device.DeviceType.CPU
     assert cpu.device_id == 0
-    assert "device_type: 1" in repr(cpu)
+    assert "device_type: CPU <1>" in repr(cpu)
 
     cpu = device.resolve(1, 0)
-    assert cpu.device_type == 1
+    assert cpu.device_type_id == 1
 
 
 def test_c_device_array():
     # Unrecognized arguments should be passed to c_array() to generate CPU array
     darray = device.c_device_array([1, 2, 3], na.int32())
 
-    assert darray.device_type == 1
+    assert darray.device_type_id == 1
+    assert darray.device_type == device.DeviceType.CPU
     assert darray.device_id == 0
-    assert "device_type: 1" in repr(darray)
+    assert "device_type: CPU <1>" in repr(darray)
 
     assert darray.schema.format == "i"
 

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -15,11 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
-
+import nanoarrow as na
 from nanoarrow import device
-
-pa = pytest.importorskip("pyarrow")
 
 
 def test_cpu_device():
@@ -31,12 +28,43 @@ def test_cpu_device():
     cpu = device.resolve(1, 0)
     assert cpu.device_type == 1
 
-    pa_array = pa.array([1, 2, 3])
 
-    darray = device.c_device_array(pa_array)
+def test_c_device_array():
+    # Unrecognized arguments should be passed to c_array() to generate  CPU array
+    darray = device.c_device_array([1, 2, 3], na.int32())
+
     assert darray.device_type == 1
     assert darray.device_id == 0
+    assert darray.schema.format == "i"
     assert darray.array.length == 3
+    assert darray.array.device_type == device.cpu().device_type
+    assert darray.array.device_id == device.cpu().device_id
     assert "device_type: 1" in repr(darray)
 
+    # A CDeviceArray should be returned as is
     assert device.c_device_array(darray) is darray
+
+    # A CPU device array should be able to export to a regular array
+    array = na.c_array(darray)
+    assert array.schema.format == "i"
+    assert array.buffers == darray.array.buffers
+
+
+# Wrapper to prevent c_device_array() from returning early when it detects the
+# input is already a CDeviceArray
+class DeviceArrayWrapper:
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __arrow_c_device_array__(self, requested_schema=None):
+        return self.obj.__arrow_c_device_array__(requested_schema=requested_schema)
+
+
+def test_c_device_array_protocol():
+    darray = device.c_device_array([1, 2, 3], na.int32())
+    wrapper = DeviceArrayWrapper(darray)
+
+    darray2 = device.c_device_array(wrapper)
+    assert darray2.schema.format == "i"
+    assert darray2.array.length == 3
+    assert darray2.array.buffers == darray.array.buffers

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -25,11 +25,11 @@ def test_cpu_device():
     cpu = device.cpu()
     assert cpu.device_type_id == 1
     assert cpu.device_type == device.DeviceType.CPU
-    assert cpu.device_id == 0
+    assert cpu.device_id == -1
     assert "device_type: CPU <1>" in repr(cpu)
 
-    cpu = device.resolve(1, 0)
-    assert cpu.device_type_id == 1
+    cpu2 = device.resolve(1, 0)
+    assert cpu2 is cpu
 
 
 def test_c_device_array():
@@ -38,7 +38,7 @@ def test_c_device_array():
 
     assert darray.device_type_id == 1
     assert darray.device_type == device.DeviceType.CPU
-    assert darray.device_id == 0
+    assert darray.device_id == -1
     assert "device_type: CPU <1>" in repr(darray)
 
     assert darray.schema.format == "i"

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -32,7 +32,7 @@ def test_cpu_device():
 
 
 def test_c_device_array():
-    # Unrecognized arguments should be passed to c_array() to generate  CPU array
+    # Unrecognized arguments should be passed to c_array() to generate CPU array
     darray = device.c_device_array([1, 2, 3], na.int32())
 
     assert darray.device_type == 1


### PR DESCRIPTION
When device support was first added, the `CArrayView` was device-aware but the `CArray` was not. This worked well until it was clear that `__arrow_c_array__` needed to error if it did not represent a CPU array (and the `CArray` had no way to check). Now, the `CArray` has a `device_type` and `device_id`. A nice side-effect of this is that we get back the `view()` method (whose removal @jorisvandenbossche had lamented!).

This also implements the device array protocol to help test https://github.com/apache/arrow/pull/40717 . This protocol isn't finalized yet and I could remove that part until it is (although it doesn't seem likely to change).

The non-cpu case is still hard to test without real-world CUDA support...this PR is just trying to get the right information in the right place as early as possible.

```python
import nanoarrow as na

array = na.c_array([1, 2, 3], na.int32())
array.device_type, array.device_id
#> (1, 0)
```
