### PR TITLE
fix(ci): Use cached Arrow C++ build in CI

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -30,6 +30,9 @@ on:
       - 'src/nanoarrow/**'
       - 'extensions/nanoarrow_device/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-c-device:
 

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -50,27 +50,13 @@ jobs:
       NANOARROW_ARROW_TESTING_DIR: '${{ github.workspace }}/arrow-testing'
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - name: Checkout arrow-testing
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: apache/arrow-testing
-          fetch-depth: 0
           path: arrow-testing
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt install -y -V ca-certificates lsb-release wget cmake valgrind
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get update
-          sudo apt-get install -y -V libarrow-dev
-          rm apache-arrow-apt-*.deb
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -52,11 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout arrow-testing
-        uses: actions/checkout@v4
-        with:
-          repository: apache/arrow-testing
-          path: arrow-testing
+      - name: Install memcheck dependencies
+        if: matrix.config.label == 'default-build'
+        run: |
+          sudo apt-get update && sudo apt-get install -y valgrind
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-8
+          key: arrow-${{ runner.os }}-9
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -30,6 +30,9 @@ on:
       - 'src/nanoarrow/**'
       - 'extensions/nanoarrow_ipc/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-c-ipc:
 
@@ -70,7 +73,7 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-9
+          key: arrow-${{ runner.os }}-10
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -84,9 +84,14 @@ jobs:
           cd $SUBDIR
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
+
+          ARROW_PATH="$(pwd)/arrow"
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_IPC_BUILD_TESTS=ON ${{ matrix.config.cmake_args }}
+
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_IPC_BUILD_TESTS=ON \
+            -DCMAKE_PREFIX_PATH="${ARROW_PATH}" ${{ matrix.config.cmake_args }}
+
           cmake --build .
 
       - name: Check for non-namespaced symbols in namespaced build

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -81,11 +81,11 @@ jobs:
 
       - name: Build
         run: |
+          ARROW_PATH="$(pwd)/arrow"
           cd $SUBDIR
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
 
-          ARROW_PATH="$(pwd)/arrow"
           mkdir build
           cd build
 

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -51,27 +51,33 @@ jobs:
       NANOARROW_ARROW_TESTING_DIR: '${{ github.workspace }}/arrow-testing'
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
       - name: Checkout arrow-testing
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: apache/arrow-testing
-          fetch-depth: 0
           path: arrow-testing
 
-      - name: Install dependencies
+
+      - name: Install memcheck dependencies
+        if: matrix.config.label == 'default-build'
         run: |
-          sudo apt-get update
-          sudo apt install -y -V ca-certificates lsb-release wget cmake valgrind
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get update
-          sudo apt-get install -y -V libarrow-dev
-          rm apache-arrow-apt-*.deb
+          sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Cache Arrow C++ Build
+        id: cache-arrow-build
+        uses: actions/cache@v4
+        with:
+          path: arrow
+          # Bump the number at the end of this line to force a new Arrow C++ build
+          key: arrow-${{ runner.os }}-8
+
+      - name: Build Arrow C++
+        if: steps.cache-arrow-build.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          ci/scripts/build-arrow-cpp-minimal.sh 15.0.2 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -59,9 +59,8 @@ jobs:
           repository: apache/arrow-testing
           path: arrow-testing
 
-
       - name: Install memcheck dependencies
-        if: matrix.config.label == 'default-build'
+        if: matrix.config.label == 'default-build' || matrix.config.label == 'default-noatomics'
         run: |
           sudo apt-get update && sudo apt-get install -y valgrind
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -77,8 +77,7 @@ jobs:
           cd build
 
           cmake .. -DNANOARROW_BUILD_TESTS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DCMAKE_PREFIX_PATH="${ARROW_PATH}"
-            ${{ matrix.config.cmake_args }}
+            -DCMAKE_PREFIX_PATH="${ARROW_PATH}" ${{ matrix.config.cmake_args }}
 
           cmake --build .
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -107,6 +107,11 @@ jobs:
       - name: Run tests with valgrind
         if: matrix.config.label == 'default-build'
         run: |
+          sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Run tests with valgrind
+        if: matrix.config.label == 'default-build'
+        run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
           cd build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-7
+          key: arrow-${{ runner.os }}-8
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-8
+          key: arrow-${{ runner.os }}-9
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -59,7 +59,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: arrow
-          key: arrow-${{ runner.os }}-6
+          # Bump the number at the end of this line to force a new Arrow C++ build
+          key: arrow-${{ runner.os }}-7
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,6 +29,9 @@ on:
       - '.github/workflows/build-and-test.yaml'
       - 'src/nanoarrow/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-c:
 
@@ -60,7 +63,7 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-9
+          key: arrow-${{ runner.os }}-10
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,24 +49,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Cache Arrow C++ Build
+        id: cache-arrow-build
+        uses: actions/cache@v3
+        with:
+          path: arrow
+          key: arrow-${{ runner.os }}-6
+
+      - name: Build Arrow C++
+        if: steps.cache-arrow-build.outputs.cache-hit != 'true'
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt install -y -V ca-certificates lsb-release wget cmake valgrind
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt-get update
-          sudo apt-get install -y -V libarrow-dev
-          rm apache-arrow-apt-*.deb
+          curl https://dlcdn.apache.org/arrow/arrow-15.0.2/apache-arrow-15.0.2.tar.gz | \
+            tar -zxf -
+          mkdir arrow-build && cd arrow-build
+          cmake ../apache-arrow-15.0.2/cpp -DCMAKE_INSTALL_PREFIX=../arrow
+          cmake --build .
+          cmake --install . --prefix=../arrow
 
       - name: Build nanoarrow
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
+
+          ARROW_PATH="$(pwd)/arrow"
           mkdir build
           cd build
+
           cmake .. -DNANOARROW_BUILD_TESTS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_PREFIX_PATH="${ARROW_PATH}"
             ${{ matrix.config.cmake_args }}
+
           cmake --build .
 
       - name: Check for non-namespaced symbols in namespaced build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -49,6 +49,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install memcheck dependencies
+        if: matrix.config.label == 'default-build'
+        run: |
+          sudo apt-get update && sudo apt-get install -y valgrind
+
       - name: Cache Arrow C++ Build
         id: cache-arrow-build
         uses: actions/cache@v3
@@ -103,11 +108,6 @@ jobs:
           sudo ldconfig
           cd build
           ctest -T test --output-on-failure .
-
-      - name: Run tests with valgrind
-        if: matrix.config.label == 'default-build'
-        run: |
-          sudo apt-get update && sudo apt-get install -y cmake valgrind
 
       - name: Run tests with valgrind
         if: matrix.config.label == 'default-build'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -111,7 +111,7 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
           cd build
-          ctest -T memcheck .
+          ctest -T memcheck . --parallel
 
       - name: Upload memcheck results
         if: failure() && matrix.config.label == 'default-build'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Run tests with valgrind
         if: matrix.config.label == 'default-build'
         run: |
-          sudo apt-get update && sudo apt-get install -y valgrind
+          sudo apt-get update && sudo apt-get install -y cmake valgrind
 
       - name: Run tests with valgrind
         if: matrix.config.label == 'default-build'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -66,12 +66,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl https://dlcdn.apache.org/arrow/arrow-15.0.2/apache-arrow-15.0.2.tar.gz | \
-            tar -zxf -
-          mkdir arrow-build && cd arrow-build
-          cmake ../apache-arrow-15.0.2/cpp -DCMAKE_INSTALL_PREFIX=../arrow
-          cmake --build .
-          cmake --install . --prefix=../arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 15.0.2 arrow
 
       - name: Build nanoarrow
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -111,7 +111,7 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
           sudo ldconfig
           cd build
-          ctest -T memcheck . --parallel
+          ctest -T memcheck .
 
       - name: Upload memcheck results
         if: failure() && matrix.config.label == 'default-build'

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Arrow C++ Build
         id: cache-arrow-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build

--- a/ci/scripts/build-arrow-cpp-minimal.sh
+++ b/ci/scripts/build-arrow-cpp-minimal.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Builds a minimal Arrow C++ version required for running nanoarrow tests
+
+set -e
+set -o pipefail
+
+case $# in
+  2) ARROW_CPP_VERSION="$1"
+     ARROW_CPP_INSTALL_DIR="$2"
+     ;;
+  *) echo "Usage:"
+     echo "  Build and install Arrow C++:"
+     echo "    $0 <version> <install dir>"
+     exit 1
+     ;;
+esac
+
+# Allow other cmake (e.g., cmake3 on centos7)
+if [ -z "$CMAKE_BIN" ]; then
+  CMAKE_BIN=cmake
+fi
+
+# Ensure install directory exists and is absolute
+if [ ! -d "${ARROW_CPP_INSTALL_DIR}" ]; then
+  mkdir -p "${ARROW_CPP_INSTALL_DIR}"
+fi
+
+ARROW_CPP_INSTALL_DIR="$(cd "${ARROW_CPP_INSTALL_DIR}" && pwd)"
+
+ARROW_CPP_SCRATCH_DIR="arrow-cpp-build-${ARROW_CPP_VERSION}"
+
+mkdir "${ARROW_CPP_SCRATCH_DIR}"
+pushd "${ARROW_CPP_SCRATCH_DIR}"
+
+curl https://dlcdn.apache.org/arrow/arrow-${ARROW_CPP_VERSION}/apache-arrow-${ARROW_CPP_VERSION}.tar.gz | \
+  tar -zxf -
+mkdir build && cd build
+cmake ../apache-arrow-${ARROW_CPP_VERSION}/cpp \
+  -DARROW_JEMALLOC=OFF \
+  -DARROW_SIMD_LEVEL=NONE \
+  -DARROW_FILESYSTEM=OFF \
+  -DCMAKE_INSTALL_PREFIX="${ARROW_CPP_INSTALL_DIR}"
+cmake --build . --parallel $(nproc)
+cmake --install . --prefix="${ARROW_CPP_INSTALL_DIR}"
+
+popd
+
+# On success, we can remove the build directory
+rm -rf "${ARROW_CPP_SCRATCH_DIR}"

--- a/ci/scripts/build-arrow-cpp-minimal.sh
+++ b/ci/scripts/build-arrow-cpp-minimal.sh
@@ -50,7 +50,7 @@ ARROW_CPP_SCRATCH_DIR="arrow-cpp-build-${ARROW_CPP_VERSION}"
 mkdir "${ARROW_CPP_SCRATCH_DIR}"
 pushd "${ARROW_CPP_SCRATCH_DIR}"
 
-curl "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${ARROW_CPP_VERSION}/apache-arrow-${ARROW_CPP_VERSION}.tar.gz" | \
+curl -L "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${ARROW_CPP_VERSION}/apache-arrow-${ARROW_CPP_VERSION}.tar.gz" | \
   tar -zxf -
 mkdir build && cd build
 cmake ../apache-arrow-${ARROW_CPP_VERSION}/cpp \

--- a/ci/scripts/build-arrow-cpp-minimal.sh
+++ b/ci/scripts/build-arrow-cpp-minimal.sh
@@ -50,7 +50,7 @@ ARROW_CPP_SCRATCH_DIR="arrow-cpp-build-${ARROW_CPP_VERSION}"
 mkdir "${ARROW_CPP_SCRATCH_DIR}"
 pushd "${ARROW_CPP_SCRATCH_DIR}"
 
-curl https://dlcdn.apache.org/arrow/arrow-${ARROW_CPP_VERSION}/apache-arrow-${ARROW_CPP_VERSION}.tar.gz | \
+curl "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${ARROW_CPP_VERSION}/apache-arrow-${ARROW_CPP_VERSION}.tar.gz" | \
   tar -zxf -
 mkdir build && cd build
 cmake ../apache-arrow-${ARROW_CPP_VERSION}/cpp \


### PR DESCRIPTION
This PR removes the use of the debian packages for Arrow C++ in favour of a minimal (cached) build. This is slightly faster than installing and removes the dependence on the artifactory for CI to pass (which is temporarily not available).

It also updates some of the actions, which were using old checkout/cache versions or installing Arrow C++ unnecessarily.

Closes #408.