### PR TITLE
fix(r): Fix tests for platforms where arrow dataset and/or zip is not available

### DIFF
--- a/r/tests/testthat/test-ipc.R
+++ b/r/tests/testthat/test-ipc.R
@@ -240,7 +240,7 @@ test_that("read_nanoarrow() respects lazy argument", {
 
 test_that("read_nanoarrow() from connection errors when called from another thread", {
   skip_if_not_installed("arrow")
-  skip_if_not("dataset" %in% names(arrow::arrow_info()$capabilities))
+  skip_if_not(arrow::arrow_info()$capabilities["dataset"])
   skip_if_not_installed("dplyr")
 
   tf <- tempfile()

--- a/r/tests/testthat/test-ipc.R
+++ b/r/tests/testthat/test-ipc.R
@@ -131,7 +131,10 @@ test_that("read_nanoarrow() works for compressed .zip file paths", {
     wd <- getwd()
     on.exit(setwd(wd))
     setwd(tdir)
-    zip(tf, "file.arrows", extras = "-q")
+    tryCatch(
+      zip(tf, "file.arrows", extras = "-q"),
+      error = function(...) skip("zip() not supported")
+    )
   })
 
   stream <- read_nanoarrow(tf)
@@ -166,7 +169,10 @@ test_that("read_nanoarrow() errors zip archives that contain files != 1", {
     wd <- getwd()
     on.exit(setwd(wd))
     setwd(tdir)
-    zip(tf, c("file1", "file2"), extras = "-q")
+    tryCatch(
+      zip(tf, c("file1", "file2"), extras = "-q"),
+      error = function(...) skip("zip() not supported")
+    )
   })
 
   expect_error(

--- a/r/tests/testthat/test-pkg-arrow.R
+++ b/r/tests/testthat/test-pkg-arrow.R
@@ -51,7 +51,7 @@ test_that("infer_nanoarrow_schema() works for arrow objects", {
   )
   expect_true(arrow::as_schema(tbl_schema)$Equals(tbl_schema_expected))
 
-  skip_if_not(isTRUE(arrow::arrow_info()$capabilities["dataset"]))
+  skip_if_not(arrow::arrow_info()$capabilities["dataset"])
 
   tbl_schema <- infer_nanoarrow_schema(
     arrow::InMemoryDataset$create(arrow::record_batch(x = 1L))
@@ -382,7 +382,7 @@ test_that("Table to nanoarrow_array_stream works", {
 
 test_that("Dataset to nanoarrow_array_stream works", {
   skip_if_not_installed("arrow")
-  skip_if_not(isTRUE(arrow::arrow_info()$capabilities["dataset"]))
+  skip_if_not(arrow::arrow_info()$capabilities["dataset"])
 
   dataset <- arrow::InMemoryDataset$create(arrow::arrow_table(a = 1:5, b = letters[1:5]))
   stream <- as_nanoarrow_array_stream(dataset)
@@ -397,7 +397,7 @@ test_that("Dataset to nanoarrow_array_stream works", {
 
 test_that("Scanner to nanoarrow_array_stream works", {
   skip_if_not_installed("arrow")
-  skip_if_not(isTRUE(arrow::arrow_info()$capabilities["dataset"]))
+  skip_if_not(arrow::arrow_info()$capabilities["dataset"])
 
   dataset <- arrow::InMemoryDataset$create(arrow::arrow_table(a = 1:5, b = letters[1:5]))
   scanner <- arrow::Scanner$create(dataset)


### PR DESCRIPTION
The `utils::zip()` function is not all that reliable; however, we only use it to create test data anyway. This was causing release verification to fail on alpine.

While running the tests, I also noticed that one of the IPC skips that checks for Arrow dataset does so incorrectly.