### PR TITLE
chore(ci): Update dockerfiles for improved R/Arrow C++ dependency management

### DIFF
--- a/ci/docker/alpine.dockerfile
+++ b/ci/docker/alpine.dockerfile
@@ -22,16 +22,8 @@ FROM --platform=linux/${NANOARROW_ARCH} alpine:latest
 RUN apk add bash linux-headers git cmake R R-dev g++ gfortran gnupg curl py3-virtualenv python3-dev
 
 # For Arrow C++
-RUN curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-14.0.1.tar.gz | tar -zxf - && \
-    mkdir /arrow-build && \
-    cd /arrow-build && \
-    cmake ../arrow-apache-arrow-14.0.1/cpp \
-        -DARROW_JEMALLOC=OFF \
-        -DARROW_SIMD_LEVEL=NONE \
-        -DARROW_WITH_ZLIB=ON \
-        -DCMAKE_INSTALL_PREFIX=../arrow && \
-    cmake --build . && \
-    cmake --install . --prefix=../arrow
+COPY ci/scripts/build-arrow-cpp-minimal.sh /
+RUN /build-arrow-cpp-minimal.sh 15.0.2 /arrow
 
 # There's a missing define that numpy's build needs on s390x and there is no wheel
 RUN (grep -e "S390" /usr/include/bits/hwcap.h && echo "#define HWCAP_S390_VX HWCAP_S390_VXRS" >> /usr/include/bits/hwcap.h) || true

--- a/ci/docker/alpine.dockerfile
+++ b/ci/docker/alpine.dockerfile
@@ -33,7 +33,9 @@ ENV NANOARROW_PYTHON_VENV "/venv"
 
 # For R. Note that arrow is not installed (takes too long).
 RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
-RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "bit64"), repos = "https://cloud.r-project.org")'
+RUN R -e 'install.packages("desc", repos = "https://cloud.r-project.org")' && mkdir /tmp/rdeps
+COPY r/DESCRIPTION /tmp/rdeps
+RUN R -e 'install.packages(setdiff(desc::desc("/tmp/rdeps")$get_deps()$package, "arrow"), repos = "https://cloud.r-project.org")'
 RUN rm -f ~/.R/Makevars
 
 ENV NANOARROW_CMAKE_OPTIONS -DArrow_DIR=/arrow/lib/cmake/Arrow

--- a/ci/docker/archlinux.dockerfile
+++ b/ci/docker/archlinux.dockerfile
@@ -29,5 +29,7 @@ ENV NANOARROW_PYTHON_VENV "/venv"
 
 # For R
 RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
-RUN R -e 'utils::install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "bit64"), repos = "https://cloud.r-project.org")'
+RUN R -e 'install.packages("desc", repos = "https://cloud.r-project.org")' && mkdir /tmp/rdeps
+COPY r/DESCRIPTION /tmp/rdeps
+RUN R -e 'install.packages(setdiff(desc::desc("/tmp/rdeps")$get_deps()$package, "arrow"), repos = "https://cloud.r-project.org")'
 RUN rm -f ~/.R/Makevars

--- a/ci/docker/centos7.dockerfile
+++ b/ci/docker/centos7.dockerfile
@@ -46,7 +46,9 @@ ENV LC_ALL en_US.UTF-8
 
 # For R. Note that arrow is not installed (takes too long).
 RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
-RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "bit64"), repos = "https://cloud.r-project.org")'
+RUN R -e 'install.packages("desc", repos = "https://cloud.r-project.org")' && mkdir /tmp/rdeps
+COPY r/DESCRIPTION /tmp/rdeps
+RUN R -e 'install.packages(setdiff(desc::desc("/tmp/rdeps")$get_deps()$package, "arrow"), repos = "https://cloud.r-project.org")'
 RUN rm -f ~/.R/Makevars
 
 ENV NANOARROW_CMAKE_OPTIONS -DArrow_DIR=/arrow/lib/cmake/Arrow

--- a/ci/docker/fedora.dockerfile
+++ b/ci/docker/fedora.dockerfile
@@ -29,5 +29,7 @@ ENV NANOARROW_PYTHON_VENV "/venv"
 
 # For R. Note that arrow is not installed (takes too long).
 RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
-RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "bit64"), repos = "https://cloud.r-project.org")'
+RUN R -e 'install.packages("desc", repos = "https://cloud.r-project.org")' && mkdir /tmp/rdeps
+COPY r/DESCRIPTION /tmp/rdeps
+RUN R -e 'install.packages(setdiff(desc::desc("/tmp/rdeps")$get_deps()$package, "arrow"), repos = "https://cloud.r-project.org")'
 RUN rm -f ~/.R/Makevars

--- a/ci/docker/ubuntu.dockerfile
+++ b/ci/docker/ubuntu.dockerfile
@@ -40,8 +40,10 @@ ENV NANOARROW_PYTHON_VENV "/venv"
 RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
 
 # For R
-RUN mkdir ~/.R && echo "MAKEFLAGS += -j$(nproc)" > ~/.R/Makevars
-RUN R -e 'install.packages(c("blob", "hms", "tibble", "rlang", "testthat", "tibble", "vctrs", "withr", "bit64", "pkgdown", "covr", "pkgbuild"), repos = "https://cloud.r-project.org")'
+RUN mkdir ~/.R && echo "MAKEFLAGS = -j$(nproc)" > ~/.R/Makevars
+RUN R -e 'install.packages("desc", repos = "https://cloud.r-project.org")' && mkdir /tmp/rdeps
+COPY r/DESCRIPTION /tmp/rdeps
+RUN R -e 'install.packages(setdiff(desc::desc("/tmp/rdeps")$get_deps()$package, "arrow"), repos = "https://cloud.r-project.org")'
 
 # Install arrow here so that the integration tests for R run in at least one test image.
 # -fPIC required for this to work on MacOS/arm64

--- a/ci/scripts/build-arrow-cpp-minimal.sh
+++ b/ci/scripts/build-arrow-cpp-minimal.sh
@@ -33,11 +33,6 @@ case $# in
      ;;
 esac
 
-# Allow other cmake (e.g., cmake3 on centos7)
-if [ -z "$CMAKE_BIN" ]; then
-  CMAKE_BIN=cmake
-fi
-
 # Ensure install directory exists and is absolute
 if [ ! -d "${ARROW_CPP_INSTALL_DIR}" ]; then
   mkdir -p "${ARROW_CPP_INSTALL_DIR}"


### PR DESCRIPTION
Just a few quality-of-life improvements for the images to keep the R dependencies automatically up-to-date.

I also checked that `xz` is not one of the affected versions...it had been on the archlinux image at one point; however, rebuilding the image several days ago puts the version at a version considered "fixed" by archlinux ( https://security.archlinux.org/package/xz ). We don't use this image for building any binaries that we distribute or otherwise consume.