### PR TITLE
feat(python): Add Arrow->Python datetime support

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,8 +27,8 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow", "pytest", "numpy"]
-verify = ["pytest", "numpy"]
+test = ["pyarrow", "dateutil", "pytest", "numpy"]
+verify = ["dateutil", "pytest", "numpy"]
 
 [project.urls]
 Homepage = "https://arrow.apache.org"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 test = ["pyarrow", "python-dateutil", "pytest", "numpy"]
-verify = ["dateutil", "pytest", "numpy"]
+verify = ["python-dateutil", "pytest", "numpy"]
 
 [project.urls]
 Homepage = "https://arrow.apache.org"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow", "dateutil", "pytest", "numpy"]
+test = ["pyarrow", "python-dateutil", "pytest", "numpy"]
 verify = ["dateutil", "pytest", "numpy"]
 
 [project.urls]

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -245,7 +245,7 @@ class PyIterator(ArrayViewIterator):
                 yield bytes(data[start:end])
 
     def _timestamp_iter(self, offset, length):
-        from datetime import UTC, datetime
+        from datetime import datetime
 
         fromtimestamp = datetime.fromtimestamp
 
@@ -267,7 +267,7 @@ class PyIterator(ArrayViewIterator):
             tz_fromtimestamp = tz
         else:
             tz = None
-            tz_fromtimestamp = UTC
+            tz_fromtimestamp = _get_tzinfo("UTC")
 
         for parent in self._primitive_iter(offset, length):
             if parent is None:

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -311,11 +311,12 @@ class PyIterator(ArrayViewIterator):
                 else:
                     yield (epoch + item).astimezone(tz)
         else:
+            epoch = epoch.replace(tzinfo=None)
             for item in parent:
                 if item is None:
                     yield None
                 else:
-                    yield (epoch + item).replace(tzinfo=None)
+                    yield epoch + item
 
     def _duration_iter(self, offset, length):
         from datetime import timedelta
@@ -421,7 +422,7 @@ def _get_tzinfo(tz_string, strategy=None):
     from datetime import timedelta, timezone
 
     # We can handle UTC without any imports
-    if re.search(r"^utc$", tz_string, re.IGNORECASE):
+    if tz_string.upper() == "UTC":
         return timezone.utc
 
     # Arrow also allows fixed-offset in the from +HH:MM

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -322,7 +322,7 @@ def _get_tzinfo(tz_string, strategy=None):
 
             return UTC
         except ImportError:
-            from datetime import timezone, timedelta
+            from datetime import timedelta, timezone
 
             return timezone(timedelta(0), "UTC")
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -450,7 +450,7 @@ def _get_tzinfo(tz_string, strategy=None):
             pass
 
     raise RuntimeError(
-        "zoneinfo (Python 3.9+), pytz, or dateutil is required to resolve timezone"
+        "zoneinfo (Python 3.9+) or dateutil is required to resolve timezone"
     )
 
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -316,9 +316,15 @@ class RowTupleIterator(PyIterator):
 def _get_tzinfo(tz_string, strategy=None):
     # We can handle UTC without any imports
     if tz_string.upper() == "UTC":
-        from datetime import UTC
+        try:
+            # Added in Python 3.11
+            from datetime import UTC
 
-        return UTC
+            return UTC
+        except ImportError:
+            from datetime import timezone, timedelta
+
+            return timezone(timedelta(0), "UTC")
 
     # Try zoneinfo.ZoneInfo() (Python 3.9+)
     if strategy is None or "zoneinfo" in strategy:

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -246,7 +246,6 @@ class PyIterator(ArrayViewIterator):
 
     def _timestamp_iter(self, offset, length):
         from datetime import datetime
-        import dateutil
 
         unit = self._schema_view.time_unit
         if unit == "s":
@@ -262,6 +261,8 @@ class PyIterator(ArrayViewIterator):
 
         tz = self._schema_view.timezone
         if tz:
+            import dateutil
+
             tz = dateutil.tz.gettz(tz)
         else:
             tz = None

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -244,6 +244,25 @@ class PyIterator(ArrayViewIterator):
             for start, end in zip(starts, ends):
                 yield bytes(data[start:end])
 
+    def _date_iter(self, offset, length):
+        from datetime import date, timedelta
+
+        storage = self._primitive_iter(offset, length)
+        epoch = date(1970, 1, 1)
+
+        if self._schema_view.type_id == CArrowType.DATE32:
+            for item in storage:
+                if item is None:
+                    yield item
+                else:
+                    yield epoch + timedelta(item)
+        else:
+            for item in storage:
+                if item is None:
+                    yield item
+                else:
+                    yield epoch + timedelta(milliseconds=item)
+
     def _timestamp_iter(self, offset, length):
         from datetime import datetime
 
@@ -367,6 +386,8 @@ _ITEMS_ITER_LOOKUP = {
     CArrowType.LARGE_LIST: "_list_iter",
     CArrowType.FIXED_SIZE_LIST: "_fixed_size_list_iter",
     CArrowType.DICTIONARY: "_dictionary_iter",
+     CArrowType.DATE32: "_date_iter",
+    CArrowType.DATE64: "_date_iter",
     CArrowType.TIMESTAMP: "_timestamp_iter",
 }
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -110,7 +110,7 @@ class ArrayViewIterator:
             map(self._make_child, self._schema.children, self._array_view.children)
         )
 
-        if schema.dictionary is None:
+        if self._schema.dictionary is None:
             self._dictionary = None
         else:
             self._dictionary = self._make_child(

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -386,7 +386,7 @@ _ITEMS_ITER_LOOKUP = {
     CArrowType.LARGE_LIST: "_list_iter",
     CArrowType.FIXED_SIZE_LIST: "_fixed_size_list_iter",
     CArrowType.DICTIONARY: "_dictionary_iter",
-     CArrowType.DATE32: "_date_iter",
+    CArrowType.DATE32: "_date_iter",
     CArrowType.DATE64: "_date_iter",
     CArrowType.TIMESTAMP: "_timestamp_iter",
 }

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -266,21 +266,20 @@ class PyIterator(ArrayViewIterator):
             import dateutil
 
             tz = dateutil.tz.gettz(tz)
-            for parent in self._primitive_iter(offset, length):
-                if parent is None:
-                    yield None
-                else:
-                    s = parent // scale
-                    us = parent % scale * (1_000_000 // scale)
-                    yield fromtimestamp(s, tz).replace(microsecond=us)
+            tz_fromtimestamp = tz
         else:
-            for parent in self._primitive_iter(offset, length):
-                if parent is None:
-                    yield None
-                else:
-                    s = parent // scale
-                    us = parent % scale * (1_000_000 // scale)
-                    yield fromtimestamp(s, UTC).replace(microsecond=us, tzinfo=None)
+            tz = None
+            tz_fromtimestamp = UTC
+
+        for parent in self._primitive_iter(offset, length):
+            if parent is None:
+                yield None
+            else:
+                s = parent // scale
+                us = parent % scale * (1_000_000 // scale)
+                yield fromtimestamp(s, tz_fromtimestamp).replace(
+                    microsecond=us, tzinfo=tz
+                )
 
     def _primitive_iter(self, offset, length):
         view = self._array_view

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -245,7 +245,7 @@ class PyIterator(ArrayViewIterator):
                 yield bytes(data[start:end])
 
     def _timestamp_iter(self, offset, length):
-        from datetime import datetime, UTC
+        from datetime import UTC, datetime
 
         fromtimestamp = datetime.fromtimestamp
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -285,7 +285,7 @@ class PyIterator(ArrayViewIterator):
     def _time_iter(self, offset, length):
         from datetime import time
 
-        for item in self._iter_datetime_components(offset, length):
+        for item in self._iter_time_components(offset, length):
             if item is None:
                 yield None
             else:
@@ -339,7 +339,7 @@ class PyIterator(ArrayViewIterator):
             else:
                 yield timedelta(microseconds=item * to_us)
 
-    def _iter_datetime_components(self, offset, length):
+    def _iter_time_components(self, offset, length):
         storage = self._primitive_iter(offset, length)
 
         unit = self._schema_view.time_unit

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -19,11 +19,11 @@ import datetime
 
 import pytest
 from nanoarrow.iterator import (
+    ArrayViewIterator,
+    InvalidArrayWarning,
+    LossyConversionWarning,
     iter_py,
     iter_tuples,
-    ArrayViewIterator,
-    LossyConversionWarning,
-    InvalidArrayWarning,
 )
 
 import nanoarrow as na

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -326,6 +326,9 @@ def test_iterator_timestamp():
         datetime.datetime(2022, 1, 1, 23, 59, 1, 0),
     ]
 
+    array = pa.array(items, pa.timestamp("ns"))
+    assert list(iter_py(array)) == items
+
     array = pa.array(items, pa.timestamp("us"))
     assert list(iter_py(array)) == items
 
@@ -349,6 +352,9 @@ def test_iterator_timestamp_tz():
         None,
         datetime.datetime(2022, 1, 1, 23, 59, 1, 0, tzinfo=tz),
     ]
+
+    array = pa.array(items, pa.timestamp("ns", "America/Halifax"))
+    assert list(iter_py(array)) == items
 
     array = pa.array(items, pa.timestamp("us", "America/Halifax"))
     assert list(iter_py(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pytest
 import datetime
+
+import pytest
 from nanoarrow.iterator import iter_py, iter_tuples
 
 import nanoarrow as na

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -317,7 +317,7 @@ def test_iterator_nullable_dictionary():
     assert list(iter_py(sliced)) == ["cde", "ab", "def", "cde", None]
 
 
-def test_iterator_date32():
+def test_iterator_date():
     pa = pytest.importorskip("pyarrow")
 
     items = [
@@ -329,17 +329,31 @@ def test_iterator_date32():
     array = pa.array(items, pa.date32())
     assert list(iter_py(array)) == items
 
+    array = pa.array(items, pa.date64())
+    assert list(iter_py(array)) == items
 
-def test_iterator_date64():
+
+def test_iterator_time():
     pa = pytest.importorskip("pyarrow")
 
     items = [
-        datetime.date(1970, 1, 2),
+        datetime.time(15, 45, 21, 12345),
         None,
-        datetime.date(2024, 4, 8),
+        datetime.time(1, 23, 45),
     ]
 
-    array = pa.array(items, pa.date64())
+    array = pa.array(items, pa.time64("ns"))
+    assert list(iter_py(array)) == items
+
+    array = pa.array(items, pa.time64("us"))
+    assert list(iter_py(array)) == items
+
+    items[0] = datetime.time(15, 45, 21, 123000)
+    array = pa.array(items, pa.time32("ms"))
+    assert list(iter_py(array)) == items
+
+    items[0] = datetime.time(15, 45, 21)
+    array = pa.array(items, pa.time32("s"))
     assert list(iter_py(array)) == items
 
 
@@ -404,7 +418,6 @@ def test_get_tzinfo():
     assert dt.replace(tzinfo=_get_tzinfo("utc")).utcoffset() == datetime.timedelta(0)
 
     pytest.importorskip("zoneinfo")
-    pytest.importorskip("pytz")
     pytest.importorskip("dateutil")
 
     tz_zoneinfo = _get_tzinfo("America/Halifax", strategy=["zoneinfo"])
@@ -415,3 +428,27 @@ def test_get_tzinfo():
 
     with pytest.raises(RuntimeError):
         _get_tzinfo("America/Halifax", strategy=[])
+
+
+def test_iterator_duration():
+    pa = pytest.importorskip("pyarrow")
+
+    items = [
+        datetime.timedelta(days=12, seconds=345, microseconds=6789),
+        None,
+        datetime.timedelta(days=12345, seconds=67890),
+    ]
+
+    array = pa.array(items, pa.duration("ns"))
+    assert list(iter_py(array)) == items
+
+    array = pa.array(items, pa.duration("us"))
+    assert list(iter_py(array)) == items
+
+    items[0] = datetime.timedelta(days=12, seconds=345, microseconds=678000)
+    array = pa.array(items, pa.duration("ms"))
+    assert list(iter_py(array)) == items
+
+    items[0] = datetime.timedelta(days=12, seconds=345)
+    array = pa.array(items, pa.duration("s"))
+    assert list(iter_py(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -365,14 +365,14 @@ def test_iterator_timestamp_tz():
 def test_get_tzinfo():
     from nanoarrow.iterator import _get_tzinfo
 
-    assert _get_tzinfo("UTC") is datetime.UTC
-    assert _get_tzinfo("utc") is datetime.UTC
+    dt = datetime.datetime(2020, 1, 2, 3, 4, 5)
+
+    assert dt.replace(tzinfo=_get_tzinfo("UTC")).utcoffset() == datetime.timedelta(0)
+    assert dt.replace(tzinfo=_get_tzinfo("utc")).utcoffset() == datetime.timedelta(0)
 
     pytest.importorskip("zoneinfo")
     pytest.importorskip("pytz")
     pytest.importorskip("dateutil")
-
-    dt = datetime.datetime(2020, 1, 2, 3, 4, 5)
 
     tz_zoneinfo = _get_tzinfo("America/Halifax", strategy=["zoneinfo"])
     tz_dateutil = _get_tzinfo("America/Halifax", strategy=["dateutil"])

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -317,6 +317,32 @@ def test_iterator_nullable_dictionary():
     assert list(iter_py(sliced)) == ["cde", "ab", "def", "cde", None]
 
 
+def test_iterator_date32():
+    pa = pytest.importorskip("pyarrow")
+
+    items = [
+        datetime.date(1970, 1, 2),
+        None,
+        datetime.date(2024, 4, 8),
+    ]
+
+    array = pa.array(items, pa.date32())
+    assert list(iter_py(array)) == items
+
+
+def test_iterator_date64():
+    pa = pytest.importorskip("pyarrow")
+
+    items = [
+        datetime.date(1970, 1, 2),
+        None,
+        datetime.date(2024, 4, 8),
+    ]
+
+    array = pa.array(items, pa.date64())
+    assert list(iter_py(array)) == items
+
+
 def test_iterator_timestamp():
     pa = pytest.importorskip("pyarrow")
 
@@ -342,10 +368,11 @@ def test_iterator_timestamp():
 
 
 def test_iterator_timestamp_tz():
-    pa = pytest.importorskip("pyarrow")
-    dateutil = pytest.importorskip("dateutil")
+    from nanoarrow.iterator import _get_tzinfo
 
-    tz = dateutil.tz.gettz("America/Halifax")
+    pa = pytest.importorskip("pyarrow")
+
+    tz = _get_tzinfo("America/Halifax")
 
     items = [
         datetime.datetime(2021, 1, 1, 11, 59, 1, 1234, tzinfo=tz),

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -361,9 +361,9 @@ def test_iterator_timestamp():
     pa = pytest.importorskip("pyarrow")
 
     items = [
-        datetime.datetime(2021, 1, 1, 11, 59, 1, 123),
+        datetime.datetime(1900, 1, 1, 11, 59, 1, 123),
         None,
-        datetime.datetime(2022, 1, 1, 23, 59, 1, 0),
+        datetime.datetime(2050, 1, 1, 23, 59, 1, 0),
     ]
 
     array = pa.array(items, pa.timestamp("ns"))
@@ -389,9 +389,9 @@ def test_iterator_timestamp_tz():
     tz = _get_tzinfo("America/Halifax")
 
     items = [
-        datetime.datetime(2021, 1, 1, 11, 59, 1, 1234, tzinfo=tz),
+        datetime.datetime(1900, 1, 1, 11, 59, 1, 1234, tzinfo=tz),
         None,
-        datetime.datetime(2022, 1, 1, 23, 59, 1, 0, tzinfo=tz),
+        datetime.datetime(2050, 1, 1, 23, 59, 1, 0, tzinfo=tz),
     ]
 
     array = pa.array(items, pa.timestamp("ns", "America/Halifax"))
@@ -434,7 +434,7 @@ def test_iterator_duration():
     pa = pytest.importorskip("pyarrow")
 
     items = [
-        datetime.timedelta(days=12, seconds=345, microseconds=6789),
+        datetime.timedelta(days=-12, seconds=-345, microseconds=-6789),
         None,
         datetime.timedelta(days=12345, seconds=67890),
     ]
@@ -445,10 +445,10 @@ def test_iterator_duration():
     array = pa.array(items, pa.duration("us"))
     assert list(iter_py(array)) == items
 
-    items[0] = datetime.timedelta(days=12, seconds=345, microseconds=678000)
+    items[0] = datetime.timedelta(days=-12, seconds=-345, microseconds=-678000)
     array = pa.array(items, pa.duration("ms"))
     assert list(iter_py(array)) == items
 
-    items[0] = datetime.timedelta(days=12, seconds=345)
+    items[0] = datetime.timedelta(days=-12, seconds=-345)
     array = pa.array(items, pa.duration("s"))
     assert list(iter_py(array)) == items

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -417,6 +417,14 @@ def test_get_tzinfo():
     assert dt.replace(tzinfo=_get_tzinfo("UTC")).utcoffset() == datetime.timedelta(0)
     assert dt.replace(tzinfo=_get_tzinfo("utc")).utcoffset() == datetime.timedelta(0)
 
+    assert dt.replace(tzinfo=_get_tzinfo("+03:30")).utcoffset() == datetime.timedelta(
+        hours=3, minutes=30
+    )
+
+    assert dt.replace(tzinfo=_get_tzinfo("-03:30")).utcoffset() == datetime.timedelta(
+        hours=-3, minutes=-30
+    )
+
     pytest.importorskip("zoneinfo")
     pytest.importorskip("dateutil")
 


### PR DESCRIPTION
This PR adds support for converting Arrow date, time, timestamp, and duration arrays to Python objects. 

```python
import pyarrow as pa
import datetime
import zoneinfo
import nanoarrow as na

dt = datetime.datetime.now()
list(na.Array(pa.array([dt])).iter_py())
#> [datetime.datetime(2024, 4, 8, 16, 25, 41, 216438)]

dt_tz = datetime.datetime.now(zoneinfo.ZoneInfo("America/Halifax"))
list(na.Array(pa.array([dt_tz])).iter_py())
#> [datetime.datetime(2024, 4, 8, 16, 29, 7, 226832, tzinfo=zoneinfo.ZoneInfo(key='America/Halifax'))]

tdelta = datetime.timedelta(123, 456, 678)
list(na.Array(pa.array([tdelta])).iter_py())
#> [datetime.timedelta(days=123, seconds=456, microseconds=678)]

just_time = datetime.time(15, 27, 43, 12)
list(na.Array(pa.array([just_time])).iter_py())
#> [datetime.time(15, 27, 43, 12)]
```

It is probably faster to use the DateTime C API, but the timings seem reasonable:

```python
import pyarrow as pa
import datetime
import zoneinfo
import nanoarrow as na

n = int(1e6)

dt = datetime.datetime.now()
dt_array = pa.array([dt + datetime.timedelta(i) for i in range(n)])
%timeit dt_array.to_pylist()
%timeit list(na.Array(dt_array).iter_py())
#> 805 ms ± 21.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
#> 804 ms ± 1.79 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

tdelta_array = pa.array([datetime.timedelta(123 + i, 456, 678) for i in range(n)])
%timeit tdelta_array.to_pylist()
#> 574 ms ± 3.78 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit list(na.Array(tdelta_array).iter_py())
#> 399 ms ± 612 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

just_time_array = pa.array([datetime.time(15, 27, 43, i) for i in range(n)])
%timeit just_time_array.to_pylist()
#> 831 ms ± 6.59 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit list(na.Array(just_time_array).iter_py())
#> 399 ms ± 856 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```