### PR TITLE
fix: Ensure negative return values from snprintf() are not used as indexes

### DIFF
--- a/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -613,6 +613,11 @@ static int ArrowIpcDecoderSetTypeFixedSizeList(struct ArrowSchema* schema,
 
   char fixed_size_str[128];
   int n_chars = snprintf(fixed_size_str, 128, "+w:%d", fixed_size);
+  if (n_chars < 0) {
+    ArrowErrorSet(error, "snprintf() encoding error");
+    return ERANGE;
+  }
+
   fixed_size_str[n_chars] = '\0';
   return ArrowIpcDecoderSetTypeSimpleNested(schema, fixed_size_str, error);
 }
@@ -671,6 +676,11 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
       return EINVAL;
   }
 
+  if (n_chars < 0) {
+    ArrowErrorSet(error, "snprintf() encoding error");
+    return ERANGE;
+  }
+
   if (ns(Union_typeIds_is_present(type))) {
     flatbuffers_int32_vec_t type_ids = ns(Union_typeIds(type));
     int64_t n_type_ids = flatbuffers_int32_vec_len(type_ids);
@@ -689,11 +699,21 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
       format_cursor += n_chars;
       format_out_size -= n_chars;
 
+      if (n_chars < 0) {
+        ArrowErrorSet(error, "snprintf() encoding error");
+        return ERANGE;
+      }
+
       for (int64_t i = 1; i < n_type_ids; i++) {
         n_chars = snprintf(format_cursor, format_out_size, ",%d",
                            (int)flatbuffers_int32_vec_at(type_ids, i));
         format_cursor += n_chars;
         format_out_size -= n_chars;
+
+        if (n_chars < 0) {
+          ArrowErrorSet(error, "snprintf() encoding error");
+          return ERANGE;
+        }
       }
     }
   } else if (n_children > 0) {
@@ -701,10 +721,20 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
     format_cursor += n_chars;
     format_out_size -= n_chars;
 
+    if (n_chars < 0) {
+      ArrowErrorSet(error, "snprintf() encoding error");
+      return ERANGE;
+    }
+
     for (int64_t i = 1; i < n_children; i++) {
       n_chars = snprintf(format_cursor, format_out_size, ",%d", (int)i);
       format_cursor += n_chars;
       format_out_size -= n_chars;
+
+      if (n_chars < 0) {
+        ArrowErrorSet(error, "snprintf() encoding error");
+        return ERANGE;
+      }
     }
   }
 

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -430,6 +430,13 @@ ArrowErrorCode ArrowDecimalAppendDigitsToBuffer(const struct ArrowDecimal* decim
   // The most significant segment should have no leading zeroes
   int n_chars = snprintf((char*)buffer->data + buffer->size_bytes, 21, "%lu",
                          (unsigned long)segments[num_segments - 1]);
+
+  // Ensure that an encoding error from snprintf() does not result
+  // in an out-of-bounds access.
+  if (n_chars < 0) {
+    return ERANGE;
+  }
+
   buffer->size_bytes += n_chars;
 
   // Subsequent output needs to be left-padded with zeroes such that each segment


### PR DESCRIPTION
It is difficult, but not impossible, to get `snprintf()` to return -1, and there are a number of places where we call it on untrusted user input. This PR ensures that the return value of all `snprintf()` calls is checked.