### PR TITLE
chore: Clean up Compiler warnings

### DIFF
--- a/dev/benchmarks/c/array_benchmark.cc
+++ b/dev/benchmarks/c/array_benchmark.cc
@@ -231,7 +231,7 @@ static void BenchmarkArrayViewGetString(benchmark::State& state) {
 
   int64_t n_alphabets = n_values / alphabet.size() + 1;
   std::vector<char> data(alphabet.size() * n_alphabets);
-  for (int64_t data_pos = 0; data_pos < data.size(); data_pos += alphabet.size()) {
+  for (size_t data_pos = 0; data_pos < data.size(); data_pos += alphabet.size()) {
     memcpy(data.data() + data_pos, alphabet.data(), alphabet.size());
   }
 
@@ -262,7 +262,7 @@ static ArrowErrorCode CreateAndAppendToArrayInt(ArrowArray* array,
   NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromType(array, type));
   NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array));
 
-  for (int64_t i = 0; i < values.size(); i++) {
+  for (size_t i = 0; i < values.size(); i++) {
     NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array, values[i]));
   }
 
@@ -289,11 +289,11 @@ static ArrowErrorCode CreateAndAppendToArrayString(
 static void BenchmarkArrayAppendString(benchmark::State& state) {
   nanoarrow::UniqueArray array;
 
-  int64_t n_values = kNumItemsPrettyBig;
-  int64_t value_size = 7;
+  const int64_t n_values = kNumItemsPrettyBig;
+  const size_t value_size = 7;
 
   std::vector<std::string> values(n_values);
-  int64_t alphabet_pos = 0;
+  size_t alphabet_pos = 0;
   for (std::string& value : values) {
     if ((alphabet_pos + value_size) >= kAlphabet.size()) {
       alphabet_pos = 0;
@@ -361,7 +361,7 @@ static ArrowErrorCode CreateAndAppendIntWithNulls(ArrowArray* array,
   NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array));
   CType non_null_value = std::numeric_limits<CType>::max() / 2;
 
-  for (int64_t i = 0; i < validity.size(); i++) {
+  for (size_t i = 0; i < validity.size(); i++) {
     if (validity[i]) {
       NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(array, non_null_value));
     } else {

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -29,6 +29,7 @@
 static uint8_t* TestAllocatorReallocate(struct ArrowBufferAllocator* allocator,
                                         uint8_t* ptr, int64_t old_size,
                                         int64_t new_size) {
+  NANOARROW_UNUSED(allocator);
   uint8_t* new_ptr = reinterpret_cast<uint8_t*>(malloc(new_size));
 
   int64_t copy_size = std::min<int64_t>(old_size, new_size);
@@ -45,6 +46,8 @@ static uint8_t* TestAllocatorReallocate(struct ArrowBufferAllocator* allocator,
 
 static void TestAllocatorFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                               int64_t size) {
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(size);
   free(ptr);
 }
 
@@ -168,7 +171,7 @@ TEST(BufferTest, BufferTestError) {
   ArrowBufferInit(&buffer);
   EXPECT_EQ(ArrowBufferResize(&buffer, std::numeric_limits<int64_t>::max(), false),
             ENOMEM);
-  EXPECT_EQ(ArrowBufferAppend(&buffer, nullptr, std::numeric_limits<int64_t>::max()),
+  EXPECT_EQ(ArrowBufferAppend(nullptr, nullptr, std::numeric_limits<int64_t>::max()),
             ENOMEM);
 
   ASSERT_EQ(ArrowBufferAppend(&buffer, "abcd", 4), NANOARROW_OK);
@@ -241,7 +244,7 @@ TEST(BitmapTest, BitmapTestElement) {
   uint8_t bitmap[10];
 
   memset(bitmap, 0xff, sizeof(bitmap));
-  for (int i = 0; i < sizeof(bitmap) * 8; i++) {
+  for (size_t i = 0; i < sizeof(bitmap) * 8; i++) {
     EXPECT_EQ(ArrowBitGet(bitmap, i), 1);
   }
 
@@ -256,7 +259,7 @@ TEST(BitmapTest, BitmapTestElement) {
   EXPECT_EQ(ArrowBitGet(bitmap, 16 + 7), 1);
 
   memset(bitmap, 0x00, sizeof(bitmap));
-  for (int i = 0; i < sizeof(bitmap) * 8; i++) {
+  for (size_t i = 0; i < sizeof(bitmap) * 8; i++) {
     EXPECT_EQ(ArrowBitGet(bitmap, i), 0);
   }
 

--- a/src/nanoarrow/integration/c_data_integration.cc
+++ b/src/nanoarrow/integration/c_data_integration.cc
@@ -28,6 +28,7 @@ static int64_t kBytesAllocated = 0;
 
 static uint8_t* IntegrationTestReallocate(ArrowBufferAllocator* allocator, uint8_t* ptr,
                                           int64_t old_size, int64_t new_size) {
+  NANOARROW_UNUSED(allocator);
   ArrowBufferAllocator default_allocator = ArrowBufferAllocatorDefault();
   kBytesAllocated -= old_size;
   uint8_t* out =
@@ -41,6 +42,7 @@ static uint8_t* IntegrationTestReallocate(ArrowBufferAllocator* allocator, uint8
 
 static void IntegrationTestFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                                 int64_t size) {
+  NANOARROW_UNUSED(allocator);
   ArrowBufferAllocator default_allocator = ArrowBufferAllocatorDefault();
   kBytesAllocated -= size;
   default_allocator.free(&default_allocator, ptr, size);

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -244,6 +244,8 @@ class Unique {
 template <typename T>
 static inline void DeallocateWrappedBuffer(struct ArrowBufferAllocator* allocator,
                                            uint8_t* ptr, int64_t size) {
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(size);
   auto obj = reinterpret_cast<T*>(allocator->private_data);
   delete obj;
 }

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -1105,7 +1105,7 @@ class TestingJSONReader {
       } else if (num_batch == kNumBatchReadAll) {
         batch_ids.resize(batches.size());
         std::iota(batch_ids.begin(), batch_ids.end(), 0);
-      } else if (num_batch >= 0 && num_batch < batches.size()) {
+      } else if (num_batch >= 0 && static_cast<size_t>(num_batch) < batches.size()) {
         batch_ids.push_back(num_batch);
       } else {
         ArrowErrorSet(error, "Expected num_batch between 0 and %d but got %d",
@@ -1887,8 +1887,9 @@ class TestingJSONReader {
     const auto& columns = value["columns"];
     NANOARROW_RETURN_NOT_OK(
         Check(columns.is_array(), error, "RecordBatch columns must be array"));
-    NANOARROW_RETURN_NOT_OK(Check(columns.size() == array_view->n_children, error,
-                                  "RecordBatch children has incorrect size"));
+    NANOARROW_RETURN_NOT_OK(Check(
+        columns.size() == static_cast<decltype(columns.size())>(array_view->n_children),
+        error, "RecordBatch children has incorrect size"));
 
     for (int64_t i = 0; i < array_view->n_children; i++) {
       NANOARROW_RETURN_NOT_OK(SetArrayColumn(columns[i], schema->children[i],
@@ -1987,8 +1988,10 @@ class TestingJSONReader {
       const auto& children = value["children"];
       NANOARROW_RETURN_NOT_OK(
           Check(children.is_array(), error, error_prefix + "children must be array"));
-      NANOARROW_RETURN_NOT_OK(Check(children.size() == array_view->n_children, error,
-                                    error_prefix + "children has incorrect size"));
+      NANOARROW_RETURN_NOT_OK(
+          Check(children.size() ==
+                    static_cast<decltype(children.size())>(array_view->n_children),
+                error, error_prefix + "children has incorrect size"));
 
       for (int64_t i = 0; i < array_view->n_children; i++) {
         NANOARROW_RETURN_NOT_OK(SetArrayColumn(children[i], schema->children[i],
@@ -2272,7 +2275,8 @@ class TestingJSONReader {
     // Check offsets against values
     const T* expected_offset = reinterpret_cast<const T*>(offsets->data);
     NANOARROW_RETURN_NOT_OK(Check(
-        offsets->size_bytes == ((value.size() + 1) * sizeof(T)), error,
+        static_cast<size_t>(offsets->size_bytes) == ((value.size() + 1) * sizeof(T)),
+        error,
         "Expected offset buffer with " + std::to_string(value.size()) + " elements"));
     NANOARROW_RETURN_NOT_OK(
         Check(*expected_offset++ == 0, error, "first offset must be zero"));
@@ -2310,7 +2314,8 @@ class TestingJSONReader {
     // Check offsets against values if not fixed size
     const T* expected_offset = reinterpret_cast<const T*>(offsets->data);
     NANOARROW_RETURN_NOT_OK(Check(
-        offsets->size_bytes == ((value.size() + 1) * sizeof(T)), error,
+        static_cast<size_t>(offsets->size_bytes) == ((value.size() + 1) * sizeof(T)),
+        error,
         "Expected offset buffer with " + std::to_string(value.size()) + " elements"));
     NANOARROW_RETURN_NOT_OK(
         Check(*expected_offset++ == 0, error, "first offset must be zero"));
@@ -2355,7 +2360,7 @@ class TestingJSONReader {
         Check(item.is_string(), error, "binary data buffer item must be string"));
     auto item_str = item.get<std::string>();
 
-    int64_t item_size_bytes = item_str.size() / 2;
+    size_t item_size_bytes = item_str.size() / 2;
     NANOARROW_RETURN_NOT_OK(Check((item_size_bytes * 2) == item_str.size(), error,
                                   "binary data buffer item must have even size"));
 

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -39,16 +39,19 @@ ArrowErrorCode WriteColumnJSON(std::ostream& out, TestingJSONWriter& writer,
 
 ArrowErrorCode WriteSchemaJSON(std::ostream& out, TestingJSONWriter& writer,
                                const ArrowSchema* schema, ArrowArrayView* array_view) {
+  NANOARROW_UNUSED(array_view);
   return writer.WriteSchema(out, schema);
 }
 
 ArrowErrorCode WriteFieldJSON(std::ostream& out, TestingJSONWriter& writer,
                               const ArrowSchema* schema, ArrowArrayView* array_view) {
+  NANOARROW_UNUSED(array_view);
   return writer.WriteField(out, schema);
 }
 
 ArrowErrorCode WriteTypeJSON(std::ostream& out, TestingJSONWriter& writer,
                              const ArrowSchema* schema, ArrowArrayView* array_view) {
+  NANOARROW_UNUSED(array_view);
   return writer.WriteType(out, schema);
 }
 
@@ -82,13 +85,17 @@ void TestWriteJSON(std::function<ArrowErrorCode(ArrowSchema*)> type_expr,
   EXPECT_EQ(ss.str(), expected_json);
 }
 
+static constexpr auto append_func_stub = [](ArrowArray* array) {
+  NANOARROW_UNUSED(array);
+  return NANOARROW_OK;
+};
+
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnNull) {
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
-      R"({"name": null, "count": 0})");
+      append_func_stub, &WriteColumnJSON, R"({"name": null, "count": 0})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -96,8 +103,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnNull) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, "colname"));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
-      R"({"name": "colname", "count": 0})");
+      append_func_stub, &WriteColumnJSON, R"({"name": "colname", "count": 0})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
@@ -105,7 +111,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnInt) {
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT32);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
+      append_func_stub, &WriteColumnJSON,
       R"({"name": null, "count": 0, "VALIDITY": [], "DATA": []})");
 
   // Without a null value
@@ -304,7 +310,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnStruct) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
+      append_func_stub, &WriteColumnJSON,
       R"({"name": null, "count": 0, "VALIDITY": [], "children": []})");
 
   // Non-empty struct
@@ -320,7 +326,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnStruct) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[1], "col2"));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
+      append_func_stub, &WriteColumnJSON,
       R"({"name": null, "count": 0, "VALIDITY": [], "children": [)"
       R"({"name": "col1", "count": 0}, {"name": "col2", "count": 0}]})");
 }
@@ -334,7 +340,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnDenseUnion) {
             ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_DENSE_UNION, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteColumnJSON,
+      append_func_stub, &WriteColumnJSON,
       R"({"name": null, "count": 0, "TYPE_ID": [], "OFFSET": [], "children": []})");
 }
 
@@ -346,8 +352,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestBatch) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteBatchJSON,
-      R"({"count": 0, "columns": []})");
+      append_func_stub, &WriteBatchJSON, R"({"count": 0, "columns": []})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
@@ -358,8 +363,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteSchemaJSON,
-      R"({"fields": []})");
+      append_func_stub, &WriteSchemaJSON, R"({"fields": []})");
 
   // More than zero fields
   TestWriteJSON(
@@ -372,7 +376,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchema) {
             ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_STRING));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteSchemaJSON,
+      append_func_stub, &WriteSchemaJSON,
       R"({"fields": [)"
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": []}, )"
       R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": []}]})");
@@ -384,7 +388,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": []})");
 
   TestWriteJSON(
@@ -393,7 +397,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
         schema->flags = 0;
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": false, "type": {"name": "null"}, "children": []})");
 
   TestWriteJSON(
@@ -402,7 +406,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldBasic) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, "colname"));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": "colname", "nullable": true, "type": {"name": "null"}, "children": []})");
 }
 
@@ -415,7 +419,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldDict) {
             ArrowSchemaInitFromType(schema->dictionary, NANOARROW_TYPE_STRING));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "utf8"}, )"
       R"("dictionary": {"id": 0, "indexType": {"name": "int", "bitWidth": 16, "isSigned": true}, )"
       R"("isOrdered": false}, "children": []})");
@@ -428,7 +432,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": []})");
 
   // Non-null but zero-size metadata
@@ -438,7 +442,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetMetadata(schema, "\0\0\0\0"));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], "metadata": []})");
 
   // Non-zero size metadata
@@ -456,7 +460,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
             ArrowSchemaSetMetadata(schema, reinterpret_cast<const char*>(buffer->data)));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": [], )"
       R"("metadata": [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]})");
 }
@@ -472,7 +476,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldNested) {
             ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_STRING));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteFieldJSON,
+      append_func_stub, &WriteFieldJSON,
       R"({"name": null, "nullable": true, "type": {"name": "struct"}, "children": [)"
       R"({"name": null, "nullable": true, "type": {"name": "null"}, "children": []}, )"
       R"({"name": null, "nullable": true, "type": {"name": "utf8"}, "children": []}]})");
@@ -483,78 +487,72 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypePrimitive) {
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "null"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "null"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_BOOL);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "bool"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "bool"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_INT8);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "int", "bitWidth": 8, "isSigned": true})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_UINT8);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "int", "bitWidth": 8, "isSigned": false})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_HALF_FLOAT);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "HALF"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_FLOAT);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "SINGLE"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_DOUBLE);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "floatingpoint", "precision": "DOUBLE"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "utf8"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "utf8"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_LARGE_STRING);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "largeutf8"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "largeutf8"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_BINARY);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "binary"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "binary"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_LARGE_BINARY);
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "largebinary"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "largebinary"})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
@@ -565,7 +563,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetTypeFixedSize(schema, NANOARROW_TYPE_FIXED_SIZE_BINARY, 123));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "fixedsizebinary", "byteWidth": 123})");
 
   TestWriteJSON(
@@ -575,7 +573,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetTypeDecimal(schema, NANOARROW_TYPE_DECIMAL128, 10, 3));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "decimal", "bitWidth": 128, "precision": 10, "scale": 3})");
 
   TestWriteJSON(
@@ -584,8 +582,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
         NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "struct"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "struct"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -595,8 +592,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "list"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "list"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -608,8 +604,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetType(schema->children[0]->children[1], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "map", "keysSorted": false})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "map", "keysSorted": false})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -622,8 +617,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
         schema->flags = ARROW_FLAG_MAP_KEYS_SORTED;
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "map", "keysSorted": true})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "map", "keysSorted": true})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -633,8 +627,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "largelist"})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "largelist"})");
 
   TestWriteJSON(
       [](ArrowSchema* schema) {
@@ -645,8 +638,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeParameterized) {
             ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
-      R"({"name": "fixedsizelist", "listSize": 12})");
+      append_func_stub, &WriteTypeJSON, R"({"name": "fixedsizelist", "listSize": 12})");
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
@@ -657,7 +649,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
             ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_SPARSE_UNION, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "union", "mode": "SPARSE", "typeIds": []})");
 
   TestWriteJSON(
@@ -671,7 +663,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
             ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "union", "mode": "SPARSE", "typeIds": [0,1]})");
 
   TestWriteJSON(
@@ -681,7 +673,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
             ArrowSchemaSetTypeUnion(schema, NANOARROW_TYPE_DENSE_UNION, 0));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "union", "mode": "DENSE", "typeIds": []})");
 
   TestWriteJSON(
@@ -695,7 +687,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestTypeUnion) {
             ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_INT32));
         return NANOARROW_OK;
       },
-      [](ArrowArray* array) { return NANOARROW_OK; }, &WriteTypeJSON,
+      append_func_stub, &WriteTypeJSON,
       R"({"name": "union", "mode": "DENSE", "typeIds": [0,1]})");
 }
 

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -166,6 +166,8 @@ struct CustomFreeData {
 
 static void CustomFree(struct ArrowBufferAllocator* allocator, uint8_t* ptr,
                        int64_t size) {
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(size);
   auto data = reinterpret_cast<struct CustomFreeData*>(allocator->private_data);
   ArrowFree(data->pointer_proxy);
   data->pointer_proxy = nullptr;


### PR DESCRIPTION
When compiling with the meson configuration which sets -Wall and -Wextra I noticed a lot of warnings for unused parameters and sign comparisons

I think this is also worth enforcing in CI - any objection to updating the current CMake jobs? Or maybe we can add one for meson to run on every PR?