### PR TITLE
Increase CMake minimum version, move requirement

### DIFF
--- a/examples/linesplitter/CMakeLists.txt
+++ b/examples/linesplitter/CMakeLists.txt
@@ -15,10 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.14)
 project(linesplitter)
 
 set(CMAKE_CXX_STANDARD 11)
+
+# Avoids a warning about timestamps on downloaded files (prefer new policy
+# if available))
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.23")
+  cmake_policy(SET CMP0135 NEW)
+endif()
 
 include(FetchContent)
 

--- a/examples/linesplitter/CMakeLists.txt
+++ b/examples/linesplitter/CMakeLists.txt
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+cmake_minimum_required(VERSION 3.24)
 project(linesplitter)
-cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
This is a very minor 'quality of life' improvement to `linesplitter` as `cmake` nags about the minimum requirement being after (rather than before) the main project declaration, and increasing the version (which I understand you may not want to increase by as much) silences the TIMESTAMP nag.  Feel free to adjust or ignore, I just liked the quieter build.