### PR TITLE
feat(python): Support Decimal types in convert to Python

### DIFF
--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -264,7 +264,7 @@ class PyIterator(ArrayViewIterator):
                 yield bytes(data[start:end])
 
     def _decimal_iter(self, offset, length):
-        from decimal import Decimal, Context
+        from decimal import Context, Decimal
         from sys import byteorder
 
         storage = self._primitive_iter(offset, length)

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -346,7 +346,7 @@ def test_iterator_decimal():
     assert list(iter_py(array)) == items
 
     # Make sure this isn't affected by user-modified context
-    with decimal.localcontext(prec=1):
+    with decimal.localcontext(decimal.Context(prec=1)):
         assert list(iter_py(array)) == items
 
 

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import datetime
+import decimal
 
 import pytest
 from nanoarrow.iterator import (
@@ -332,6 +333,21 @@ def test_iterator_nullable_dictionary():
 
     sliced = array[1:]
     assert list(iter_py(sliced)) == ["cde", "ab", "def", "cde", None]
+
+
+def test_iterator_decimal():
+    pa = pytest.importorskip("pyarrow")
+
+    items = [decimal.Decimal("12.3450"), None, decimal.Decimal("1234567.3456")]
+    array = pa.array(items, pa.decimal128(11, 4))
+    assert list(iter_py(array)) == items
+
+    array = pa.array(items, pa.decimal256(11, 4))
+    assert list(iter_py(array)) == items
+
+    # Make sure this isn't affected by user-modified context
+    with decimal.localcontext(prec=1):
+        assert list(iter_py(array)) == items
 
 
 def test_iterator_date():


### PR DESCRIPTION
I experimented with a few different methods here...I think this one has a good balance of speed and not messing with the global precision.

```python
import pyarrow as pa
import decimal
from nanoarrow.iterator import iter_py

items = [decimal.Decimal("12.3450"), None, decimal.Decimal("1234567.3456")]
array = pa.array(items, pa.decimal128(11, 4))
list(iter_py(array))
#> [Decimal('12.3450'), None, Decimal('1234567.3456')]
```

This seems to be vaguely on par with pyarrow convert:

```python
import pyarrow as pa
import decimal
import numpy as np
from nanoarrow.iterator import iter_py

floats = np.random.random(int(1e6))
items = [decimal.Decimal(item) for item in floats]
array = pa.array(items)

%timeit array.to_pylist()
#> 799 ms ± 6.24 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit list(iter_py(array))
#> 431 ms ± 8.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```