### PR TITLE
chore(python): Restructure buffer packing to support nulls and improve performance

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -52,7 +52,6 @@ from nanoarrow_c cimport *
 from nanoarrow_device_c cimport *
 
 from enum import Enum
-from array import array as py_array
 from sys import byteorder as sys_byteorder
 from struct import unpack_from, iter_unpack, calcsize, Struct
 from nanoarrow import _repr_utils
@@ -1903,6 +1902,14 @@ cdef class CBufferBuilder:
         self._assert_unlocked()
         cdef int code = ArrowBufferReserve(self._buffer._ptr, additional_bytes)
         Error.raise_error_not_ok("ArrowBufferReserve()", code)
+        return self
+
+    def advance(self, int64_t additional_bytes):
+        cdef int64_t new_size = self._buffer._ptr.size_bytes + additional_bytes
+        if new_size < 0 or new_size > self._buffer._ptr.capacity_bytes:
+            raise IndexError(f"Can't advance {additional_bytes} from {self.size_bytes}")
+
+        self._buffer._ptr.size_bytes = new_size
         return self
 
     def write(self, content):

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2069,7 +2069,7 @@ cdef class NoneAwareWrapperIterator:
             return (0, 0, 0)
         elif type_id == NANOARROW_TYPE_BOOL:
             return False
-        elif type_id  == NANOARROW_TYPE_BINARY:
+        elif type_id  in (NANOARROW_TYPE_BINARY, NANOARROW_TYPE_FIXED_SIZE_BINARY):
             return b"\x00" * item_size_bytes
         elif type_id in (NANOARROW_TYPE_HALF_FLOAT, NANOARROW_TYPE_FLOAT, NANOARROW_TYPE_DOUBLE):
             return 0.0

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -52,7 +52,6 @@ from nanoarrow_c cimport *
 from nanoarrow_device_c cimport *
 
 from enum import Enum
-from itertools import repeat
 from sys import byteorder as sys_byteorder
 from struct import unpack_from, iter_unpack, calcsize, Struct
 from nanoarrow import _repr_utils

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1887,6 +1887,10 @@ cdef class CBufferBuilder:
         self._locked = False
 
     @property
+    def format(self):
+        return self._buffer._format.decode()
+
+    @property
     def size_bytes(self):
         return self._buffer.size_bytes
 

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -365,8 +365,8 @@ def c_array_stream(obj=None, schema=None) -> CArrayStream:
         return CArrayStream.from_array_list([array], array.schema, validate=False)
     except Exception as e:
         raise TypeError(
-            f"Can't convert object of type {type(obj).__name__} "
-            "to nanoarrow.c_array_stream or nanoarrow.c_array"
+            f"An error occurred whilst converting {type(obj).__name__} "
+            f"to nanoarrow.c_array_stream or nanoarrow.c_array: \n {e}"
         ) from e
 
 

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -25,8 +25,6 @@ in Cython and their scope is limited to lifecycle management and member access a
 Python objects.
 """
 
-import array
-
 from typing import Any, Iterable, Literal
 
 from nanoarrow._lib import (
@@ -629,6 +627,8 @@ def _c_array_from_iterable(obj, schema=None):
 
 
 def _c_buffer_from_iterable(obj, schema=None) -> CBuffer:
+    import array
+
     if schema is None:
         raise ValueError("CBuffer from iterable requires schema")
 

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -481,8 +481,8 @@ def c_buffer(obj, schema=None) -> CBuffer:
         return CBuffer.from_pybuffer(obj)
 
     if _obj_is_iterable(obj):
-        buf, _ = _c_buffer_from_iterable(obj, schema)
-        return buf
+        buffer, _ = _c_buffer_from_iterable(obj, schema)
+        return buffer
 
     raise TypeError(
         f"Can't convert object of type {type(obj).__name__} to nanoarrow.c_buffer"

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -633,6 +633,9 @@ def _c_array_from_iterable(obj, schema=None) -> CArray:
         obj, schema_view.storage_type_id, schema_view.fixed_size
     )
 
+    if obj_len > 0:
+        obj_wrapper.reserve(obj_len)
+
     # Use buffer create for crude support of array from iterable
     data = _c_buffer_from_iterable(obj_wrapper, schema_view)
     n_values, null_count, validity = obj_wrapper.finish()

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -225,7 +225,18 @@ def test_c_array_from_iterable_non_empty():
     assert c_array.null_count == 0
 
     view = na.c_array_view(c_array)
+    assert list(view.buffer(0)) == []
     assert list(view.buffer(1)) == [1, 2, 3]
+
+
+def test_c_array_from_iterable_non_empty_nullable():
+    c_array = na.c_array([1, None, 3], na.int32())
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1)) == [1, 0, 3]
 
 
 def test_c_array_from_iterable_error():

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -219,7 +219,7 @@ def test_c_array_from_iterable_empty():
     assert len(array_view.buffer(2)) == 0
 
 
-def test_c_array_from_iterable_non_empty():
+def test_c_array_from_iterable_non_empty_nullable_without_nulls():
     c_array = na.c_array([1, 2, 3], na.int32())
     assert c_array.length == 3
     assert c_array.null_count == 0
@@ -229,7 +229,17 @@ def test_c_array_from_iterable_non_empty():
     assert list(view.buffer(1)) == [1, 2, 3]
 
 
-def test_c_array_from_iterable_non_empty_nullable():
+def test_c_array_from_iterable_non_empty_non_nullable():
+    c_array = na.c_array([1, 2, 3], na.int32(nullable=False))
+    assert c_array.length == 3
+    assert c_array.null_count == 0
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0)) == []
+    assert list(view.buffer(1)) == [1, 2, 3]
+
+
+def test_c_array_from_iterable_non_empty_nullable_with_nulls():
     c_array = na.c_array([1, None, 3], na.int32())
     assert c_array.length == 3
     assert c_array.null_count == 1

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -239,7 +239,7 @@ def test_c_array_from_iterable_non_empty_non_nullable():
     assert list(view.buffer(1)) == [1, 2, 3]
 
 
-def test_c_array_from_iterable_non_empty_nullable_with_nulls():
+def test_c_array_from_iterable_int_with_nulls():
     c_array = na.c_array([1, None, 3], na.int32())
     assert c_array.length == 3
     assert c_array.null_count == 1
@@ -247,6 +247,56 @@ def test_c_array_from_iterable_non_empty_nullable_with_nulls():
     view = na.c_array_view(c_array)
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [1, 0, 3]
+
+
+def test_c_array_from_iterable_float_with_nulls():
+    c_array = na.c_array([1, None, 3], na.float64())
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1)) == [1.0, 0.0, 3.0]
+
+
+def test_c_array_from_iterable_bool_with_nulls():
+    c_array = na.c_array([True, None, False], na.bool())
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1).elements()) == [True, False, False] + [False] * 5
+
+
+def test_c_array_from_iterable_fixed_size_binary_with_nulls():
+    c_array = na.c_array([b"1234", None, b"5678"], na.fixed_size_binary(4))
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1)) == [b"1234", b"\x00\x00\x00\x00", b"5678"]
+
+
+def test_c_array_from_iterable_day_time_interval_with_nulls():
+    c_array = na.c_array([(1, 2), None, (3, 4)], na.interval_day_time())
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1)) == [(1, 2), (0, 0), (3, 4)]
+
+
+def test_c_array_from_iterable_month_day_nano_interval_with_nulls():
+    c_array = na.c_array([(1, 2, 3), None, (4, 5, 6)], na.interval_month_day_nano())
+    assert c_array.length == 3
+    assert c_array.null_count == 1
+
+    view = na.c_array_view(c_array)
+    assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
+    assert list(view.buffer(1)) == [(1, 2, 3), (0, 0, 0), (4, 5, 6)]
 
 
 def test_c_array_from_iterable_error():

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -214,6 +214,14 @@ def test_c_buffer_builder():
     assert builder.size_bytes == 10
     assert builder.capacity_bytes == 123
 
+    mv = memoryview(builder)
+    with pytest.raises(BufferError, match="CBufferBuilder is locked"):
+        memoryview(builder)
+
+    with pytest.raises(BufferError, match="CBufferBuilder is locked"):
+        assert bytes(builder.finish()) == b"abcdefghij"
+
+    del mv
     assert bytes(builder.finish()) == b"abcdefghij"
 
 

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -248,7 +248,7 @@ def test_c_buffer_from_iterable():
 
     # An Arrow type whose storage type is not the same as its top-level
     # type will error.
-    with pytest.raises(ValueError, match="Can't create buffer from type"):
+    with pytest.raises(ValueError, match="Can't create buffer"):
         na.c_buffer([1, 2, 3], na.date32())
 
 

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -214,6 +214,12 @@ def test_c_buffer_builder():
     assert builder.size_bytes == 10
     assert builder.capacity_bytes == 123
 
+    with pytest.raises(IndexError):
+        builder.advance(-11)
+
+    with pytest.raises(IndexError):
+        builder.advance(114)
+
     mv = memoryview(builder)
     with pytest.raises(BufferError, match="CBufferBuilder is locked"):
         memoryview(builder)
@@ -221,8 +227,11 @@ def test_c_buffer_builder():
     with pytest.raises(BufferError, match="CBufferBuilder is locked"):
         assert bytes(builder.finish()) == b"abcdefghij"
 
+    mv[builder.size_bytes] = ord("k")
+    builder.advance(1)
+
     del mv
-    assert bytes(builder.finish()) == b"abcdefghij"
+    assert bytes(builder.finish()) == b"abcdefghijk"
 
 
 def test_c_buffer_from_iterable():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -49,14 +49,7 @@ def test_iterator_primitive():
 
 
 def test_iterator_nullable_primitive():
-    array = na.c_array_from_buffers(
-        na.int32(),
-        4,
-        buffers=[
-            na.c_buffer([1, 1, 1, 0], na.bool()),
-            na.c_buffer([1, 2, 3, 0], na.int32()),
-        ],
-    )
+    array = na.c_array([1, 2, 3, None], na.int32())
     assert list(iter_py(array)) == [1, 2, 3, None]
 
     sliced = array[1:]


### PR DESCRIPTION
First, this PR fixes the rather uninformative error that occurs on any error while building an Array (closes #423). The error is now:

```python
import nanoarrow as na
na.Array([1, 2, 3])
#> ValueError
#> ...
#> An error occurred whilst converting object of type list to nanoarrow.c_array_stream or nanoarrow.c_array: 
#> schema is required for CArray import from iterable
```

Second, this PR adds support for `None` in iterables. This makes it much more convenient to create arrays with nulls (closes #424).

```python
import nanoarrow as na
na.Array([1, 2, None, 4], na.int32())
#> nanoarrow.Array<int32>[4]
#> 1
#> 2
#> None
#> 4 
```

Finally, this PR tweaks the implementation of packing an iterable into a buffer to avoid the very bad performance that existed previously. The optimizations added were:

- The `CBufferBuilder` now implements the buffer protocol (so that we can use `pack_into`)
- The `__len__` attribute is checked to preallocate where possible

Those optimizations resulted in a ~2x improvement over the previous code; however, the types that can use the `array` constructor have the biggest wins (5-6x improvement).

An example with the biggest gain:

```python
import numpy as np
import nanoarrow as na
import pyarrow as pa

floats = np.random.random(int(1e6))
floats_lst = list(floats)

%timeit pa.array(floats, pa.float64())
#> 1.79 µs ± 9.27 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
%timeit pa.array(floats_lst, pa.float64())
#> 13.8 ms ± 35.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit pa.array(iter(floats_lst), pa.float64())
#> 17.9 ms ± 37.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit na.c_array(floats, na.float64())
#> 5.51 µs ± 25.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
%timeit na.c_array(floats_lst, na.float64(nullable=False))
#> 16.5 ms ± 41.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit na.c_array(iter(floats_lst), na.float64(nullable=False))
#> 29.1 ms ± 254 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(floats_lst, na.float64())
#> 43.6 ms ± 484 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(iter(floats_lst), na.float64())
#> 43 ms ± 227 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Before this PR:

```python
%timeit na.c_array(floats, na.float64())
#> 5.66 µs ± 44.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
%timeit na.c_array(floats_lst, na.float64())
#> 104 ms ± 187 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(iter(floats_lst), na.float64())
#> 107 ms ± 202 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

It should be noted that there is probably one more PR on top of this to support building variable-length string/binary arrays (and possibly move some of the building code out of `c_lib.py` since it is getting a little crowded there).