### PR TITLE
feat(python): Create string/binary arrays from iterables

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -101,6 +101,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_SKIP: "pp38-*"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -101,7 +101,6 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_SKIP: "pp38-*"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -23,7 +23,7 @@ import tempfile
 import warnings
 
 
-# Generate the nanoarrow_c.pxd file used by the Cython extension
+# Generate the nanoarrow_c.pxd file used by the Cython extensions
 class NanoarrowPxdGenerator:
     def __init__(self):
         self._define_regexes()

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1879,9 +1879,6 @@ cdef class CBufferBuilder:
         if self._locked:
             raise BufferError("CBufferBuilder is locked")
 
-    def __buffer__(self, flags):
-        return memoryview(self)
-
     # Implement the buffer protocol so that this object can be used as
     # the argument to Struct.readinto() (or perhaps written to by
     # an independent library).

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1939,6 +1939,9 @@ cdef class CBufferBuilder:
         self._buffer._ptr.size_bytes = new_size
         return self
 
+    def read(self, *args):
+        raise NotImplementedError()
+
     def write(self, content):
         """Write bytes to this buffer
 

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1879,6 +1879,9 @@ cdef class CBufferBuilder:
         if self._locked:
             raise BufferError("CBufferBuilder is locked")
 
+    def __buffer__(self, flags):
+        return memoryview(self)
+
     # Implement the buffer protocol so that this object can be used as
     # the argument to Struct.readinto() (or perhaps written to by
     # an independent library).
@@ -1938,9 +1941,6 @@ cdef class CBufferBuilder:
 
         self._buffer._ptr.size_bytes = new_size
         return self
-
-    def read(self, *args):
-        raise NotImplementedError()
 
     def write(self, content):
         """Write bytes to this buffer

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1996,7 +1996,8 @@ cdef class CBufferBuilder:
         cdef int code
 
         struct_obj = Struct(self._buffer._format)
-        pack_into = struct_obj.pack_into
+        pack = struct_obj.pack
+        write = self.write
 
         # If an object has a length, we can avoid extra allocations
         if hasattr(obj, "__len__"):
@@ -2010,22 +2011,12 @@ cdef class CBufferBuilder:
         if self._buffer._data_type in (NANOARROW_TYPE_INTERVAL_DAY_TIME,
                                        NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO):
             for item in obj:
-                code = ArrowBufferReserve(self._buffer._ptr, bytes_per_element)
-                if code != NANOARROW_OK:
-                    Error.raise_error("ArrowBufferReserve()", code)
-
-                pack_into(self, self._buffer._ptr.size_bytes, *item)
-                self._buffer._ptr.size_bytes += bytes_per_element
+                write(pack(*item))
                 n_values += 1
 
         else:
             for item in obj:
-                code = ArrowBufferReserve(self._buffer._ptr, bytes_per_element)
-                if code != NANOARROW_OK:
-                    Error.raise_error("ArrowBufferReserve()", code)
-
-                pack_into(self, self._buffer._ptr.size_bytes, item)
-                self._buffer._ptr.size_bytes += bytes_per_element
+                write(pack(item))
                 n_values += 1
 
         return n_values

--- a/python/src/nanoarrow/c_lib.py
+++ b/python/src/nanoarrow/c_lib.py
@@ -628,6 +628,14 @@ def _c_array_from_iterable(obj, schema=None) -> CArray:
             f"Can't create array from iterable for type {schema_view.type}"
         )
 
+    # Handle variable-size binary types
+    if schema_view.type_id in (CArrowType.STRING, CArrowType.LARGE_STRING):
+        builder = CArrayBuilder.allocate()
+        builder.init_from_schema(schema)
+        builder.start_appending()
+        builder.append_strings(obj)
+        return builder.finish()
+
     # Creating a buffer from an iterable does not handle None values,
     # but we can do so here with the NoneAwareWrapperIterator() wrapper.
     # This approach is quite a bit slower, so only do it for a nullable

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -244,7 +244,7 @@ def test_c_array_from_iterable_bytes():
     assert len(array_view.buffer(1)) == 4
     assert len(array_view.buffer(2)) == 7
 
-    with pytest.raises(TypeError, match="a bytes-like object"):
+    with pytest.raises(TypeError):
         na.c_array(["1234"], na.binary())
 
     buf_not_bytes = na.c_buffer([1, 2, 3], na.int32())

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -219,6 +219,17 @@ def test_c_array_from_iterable_empty():
     assert len(array_view.buffer(2)) == 0
 
 
+def test_c_array_from_iterable_string():
+    string = na.c_array(["abc", None, "defg"], na.c_schema(na.string()))
+    assert string.length == 3
+    assert string.null_count == 1
+
+    array_view = na.c_array_view(string)
+    assert len(array_view.buffer(0)) == 1
+    assert len(array_view.buffer(1)) == 4
+    assert len(array_view.buffer(2)) == 7
+
+
 def test_c_array_from_iterable_non_empty_nullable_without_nulls():
     c_array = na.c_array([1, 2, 3], na.int32())
     assert c_array.length == 3

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -229,6 +229,10 @@ def test_c_array_from_iterable_string():
     assert len(array_view.buffer(1)) == 4
     assert len(array_view.buffer(2)) == 7
 
+    # Check an item that is not a str()
+    with pytest.raises(TypeError):
+        na.c_array([b"1234"], na.string())
+
 
 def test_c_array_from_iterable_bytes():
     string = na.c_array([b"abc", None, b"defg"], na.binary())
@@ -239,6 +243,18 @@ def test_c_array_from_iterable_bytes():
     assert len(array_view.buffer(0)) == 1
     assert len(array_view.buffer(1)) == 4
     assert len(array_view.buffer(2)) == 7
+
+    with pytest.raises(TypeError, match="a bytes-like object"):
+        na.c_array(["1234"], na.binary())
+
+    buf_not_bytes = na.c_buffer([1, 2, 3], na.int32())
+    with pytest.raises(ValueError, match="Can't append buffer with itemsize != 1"):
+        na.c_array([buf_not_bytes], na.binary())
+
+    np = pytest.importorskip("numpy")
+    buf_2d = np.ones((2, 2))
+    with pytest.raises(ValueError, match="Can't append buffer with dimensions != 1"):
+        na.c_array([buf_2d], na.binary())
 
 
 def test_c_array_from_iterable_non_empty_nullable_without_nulls():

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -207,7 +207,7 @@ def test_c_array_from_pybuffer_numpy():
 
 
 def test_c_array_from_iterable_empty():
-    empty_string = na.c_array([], na.c_schema(na.string()))
+    empty_string = na.c_array([], na.string())
     assert empty_string.length == 0
     assert empty_string.null_count == 0
     assert empty_string.offset == 0
@@ -220,7 +220,18 @@ def test_c_array_from_iterable_empty():
 
 
 def test_c_array_from_iterable_string():
-    string = na.c_array(["abc", None, "defg"], na.c_schema(na.string()))
+    string = na.c_array(["abc", None, "defg"], na.string())
+    assert string.length == 3
+    assert string.null_count == 1
+
+    array_view = na.c_array_view(string)
+    assert len(array_view.buffer(0)) == 1
+    assert len(array_view.buffer(1)) == 4
+    assert len(array_view.buffer(2)) == 7
+
+
+def test_c_array_from_iterable_bytes():
+    string = na.c_array([b"abc", None, b"defg"], na.binary())
     assert string.length == 3
     assert string.null_count == 1
 

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -229,8 +229,8 @@ def test_c_buffer_builder():
 
     mv[builder.size_bytes] = ord("k")
     builder.advance(1)
+    mv.release()
 
-    del mv
     assert bytes(builder.finish()) == b"abcdefghijk"
 
 

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -220,18 +220,31 @@ def test_c_buffer_builder():
     with pytest.raises(IndexError):
         builder.advance(114)
 
+
+def test_c_buffer_builder_buffer_protocol():
+    import platform
+
+    builder = CBufferBuilder()
+    builder.reserve_bytes(1)
+
     mv = memoryview(builder)
+    assert len(mv) == 1
+
     with pytest.raises(BufferError, match="CBufferBuilder is locked"):
         memoryview(builder)
 
     with pytest.raises(BufferError, match="CBufferBuilder is locked"):
         assert bytes(builder.finish()) == b"abcdefghij"
 
+    # On at least some versions of PyPy the call to mv.release() does not seem
+    # to deterministically call the CBufferBuilder's __releasebuffer__().
+    if platform.python_implementation() == "PyPy":
+        pytest.skip("CBufferBuilder buffer  not implemented for PyPy")
+
     mv[builder.size_bytes] = ord("k")
     builder.advance(1)
     mv.release()
-
-    assert bytes(builder.finish()) == b"abcdefghijk"
+    assert bytes(builder.finish()) == b"k"
 
 
 def test_c_buffer_from_iterable():

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -239,7 +239,7 @@ def test_c_buffer_builder_buffer_protocol():
     # On at least some versions of PyPy the call to mv.release() does not seem
     # to deterministically call the CBufferBuilder's __releasebuffer__().
     if platform.python_implementation() == "PyPy":
-        pytest.skip("CBufferBuilder buffer  not implemented for PyPy")
+        pytest.skip("CBufferBuilder buffer release is non-deterministic on PyPy")
 
     mv[builder.size_bytes] = ord("k")
     builder.advance(1)

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -58,9 +58,7 @@ def test_iterator_nullable_primitive():
 
 
 def test_iterator_string():
-    array = na.c_array_from_buffers(
-        na.string(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
-    )
+    array = na.c_array(["ab", "cde"], na.string())
 
     assert list(iter_py(array)) == ["ab", "cde"]
 
@@ -69,15 +67,7 @@ def test_iterator_string():
 
 
 def test_iterator_nullable_string():
-    array = na.c_array_from_buffers(
-        na.string(),
-        3,
-        buffers=[
-            na.c_buffer([1, 1, 0], na.bool()),
-            na.c_buffer([0, 2, 5, 5], na.int32()),
-            b"abcde",
-        ],
-    )
+    array = na.c_array(["ab", "cde", None], na.string())
 
     assert list(iter_py(array)) == ["ab", "cde", None]
 
@@ -86,9 +76,7 @@ def test_iterator_nullable_string():
 
 
 def test_iterator_binary():
-    array = na.c_array_from_buffers(
-        na.binary(), 2, buffers=[None, na.c_buffer([0, 2, 5], na.int32()), b"abcde"]
-    )
+    array = na.c_array([b"ab", b"cde"], na.binary())
 
     assert list(iter_py(array)) == [b"ab", b"cde"]
 
@@ -97,15 +85,7 @@ def test_iterator_binary():
 
 
 def test_iterator_nullable_binary():
-    array = na.c_array_from_buffers(
-        na.binary(),
-        3,
-        buffers=[
-            na.c_buffer([1, 1, 0], na.bool()),
-            na.c_buffer([0, 2, 5, 5], na.int32()),
-            b"abcde",
-        ],
-    )
+    array = na.c_array([b"ab", b"cde", None], na.binary())
 
     assert list(iter_py(array)) == [b"ab", b"cde", None]
 


### PR DESCRIPTION
This PR adds support for building string and binary arrays via iterable.

It also cleans up a few parts of #426 that resulted in the wheel builds failing for (at least) PyPy 3.8 and 3.9. We can circle back to the performance of building from iterables (and whether or not `pack_into()` is essential) when all the wheels are building reliably.

```python
import nanoarrow as na

strings = ["pizza", "yogurt", "noodles", "peanut butter sandwiches"]

na.Array(strings, na.string())
#> nanoarrow.Array<string>[4]
#> 'pizza'
#> 'yogurt'
#> 'noodles'
#> 'peanut butter sandwiches'

na.Array((s.encode() for s in strings), na.binary())
#> nanoarrow.Array<binary>[4]
#> b'pizza'
#> b'yogurt'
#> b'noodles'
#> b'peanut butter sandwiches'
```

The "build from iterable" code is now sufficiently complicated that it should be separated out. I did an initial attempt at that for this PR; however, it scrambles things up a bit and is complicated by the interdependence between the functions that sanitize arguments (e.g., `c_schema()`, `c_array()`) and the functions that build from iterable.

Currently faster for strings and slightly slower for bytes than pyarrow.

```python
from itertools import cycle, islice
import nanoarrow as na
import pyarrow as pa

strings = ["pizza", "yogurt", "noodles", "peanut butter sandwiches"]
binary = [s.encode() for s in strings]

def many_strings():
    return islice(cycle(strings), int(1e6))

def many_strings_with_nulls():
    return islice(cycle(strings + [None]), int(1e6))

def many_bytes():
    return islice(cycle(binary), int(1e6))

def many_bytes_with_nulls():
    return islice(cycle(binary + [None]), int(1e6))

%timeit pa.array(many_strings(), pa.string())
#> 23.4 ms ± 488 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(many_strings(), na.string())
#> 14.3 ms ± 112 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit pa.array(many_strings_with_nulls(), pa.string())
#> 21.4 ms ± 340 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(many_strings_with_nulls(), na.string())
#> 17.1 ms ± 340 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit pa.array(many_bytes(), pa.binary())
#> 19.7 ms ± 283 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit na.c_array(many_bytes(), na.binary())
#> 16.3 ms ± 136 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit pa.array(many_bytes_with_nulls(), pa.binary())
#> 17.6 ms ± 37.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
%timeit na.c_array(many_bytes_with_nulls(), na.binary())
#> 19 ms ± 378 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```