### PR TITLE
feat(python): Iterate over array buffers

### DIFF
--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -27,7 +27,7 @@ from nanoarrow._lib import (
     Device,
 )
 from nanoarrow.c_lib import c_array, c_array_stream, c_array_view
-from nanoarrow.iterator import iter_array_data, iter_py, iter_tuples
+from nanoarrow.iterator import iter_array_view, iter_py, iter_tuples
 from nanoarrow.schema import Schema
 
 from nanoarrow import _repr_utils
@@ -288,7 +288,7 @@ class Array:
         nanoarrow.c_lib.CBufferView(bool[0 b] )
         nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)
         """
-        return iter_array_data(self)
+        return iter_array_view(self)
 
     @property
     def n_children(self) -> int:

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -27,7 +27,7 @@ from nanoarrow._lib import (
     Device,
 )
 from nanoarrow.c_lib import c_array, c_array_stream, c_array_view
-from nanoarrow.iterator import iter_array_view, iter_py, iter_tuples
+from nanoarrow.iterator import iter_array_views, iter_py, iter_tuples
 from nanoarrow.schema import Schema
 
 from nanoarrow import _repr_utils
@@ -268,7 +268,7 @@ class Array:
         view = c_array_view(self)
         return tuple(view.buffers)
 
-    def iter_chunk_data(self) -> Iterable[CArrayView]:
+    def iter_chunk_views(self) -> Iterable[CArrayView]:
         """Iterate over prepared views of each chunk
 
         Examples
@@ -276,7 +276,7 @@ class Array:
 
         >>> import nanoarrow as na
         >>> array = na.Array([1, 2, 3], na.int32())
-        >>> for view in array.iter_chunk_data():
+        >>> for view in array.iter_chunk_views():
         ...     offset, length = view.offset, view.length
         ...     validity, data = view.buffers
         ...     print(view.offset, view.length)
@@ -286,7 +286,7 @@ class Array:
         nanoarrow.c_lib.CBufferView(bool[0 b] )
         nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)
         """
-        return iter_array_view(self)
+        return iter_array_views(self)
 
     @property
     def n_children(self) -> int:

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -235,10 +235,8 @@ class Array:
         """
         if self._data.n_arrays == 0:
             return 0
-        elif self._data.n_arrays == 1:
-            return self._data.array(0).offset
-
         self._assert_one_chunk("scalar offset")
+        return self._data.array(0).offset
 
     def buffer(self, i: int) -> CBuffer:
         """Access a single buffer of a contiguous array
@@ -271,7 +269,7 @@ class Array:
         return tuple(view.buffers)
 
     def iter_chunk_data(self) -> Iterable[CArrayView]:
-        """Iterate over Iterate over prepared views of each chunk
+        """Iterate over prepared views of each chunk
 
         Examples
         --------

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -263,9 +263,9 @@ class Array:
         ...     offset, length = view.offset, view.length
         ...     validity, data = view.buffers
         ...     print(view.offset, view.length)
-        ...     print(data)
         ...     print(validity)
-        (0, 3)
+        ...     print(data)
+        0 3
         nanoarrow.c_lib.CBufferView(bool[0 b] )
         nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)
         """

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -79,7 +79,7 @@ def iter_tuples(obj, schema=None) -> Iterable[Tuple]:
     return RowTupleIterator.get_iterator(obj, schema=schema)
 
 
-def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
+def iter_array_data(obj, schema=None) -> Iterable[CArrayView]:
     """Iterate over prepared views of each array
 
     Returns an iterator which yields a :func:`c_array_view`
@@ -99,7 +99,7 @@ def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
     >>> import nanoarrow as na
     >>> from nanoarrow import iterator
     >>> array = na.c_array([1, 2, 3], na.int32())
-    >>> list(iterator.iter_array_view(array))
+    >>> list(iterator.iter_array_data(array))
     [<nanoarrow.c_lib.CArrayView>
     - storage_type: 'int32'
     - length: 3

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -18,9 +18,9 @@
 import warnings
 from functools import cached_property
 from itertools import islice
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
-from nanoarrow._lib import CArrayView, CArrowType, CBufferView
+from nanoarrow._lib import CArrayView, CArrowType
 from nanoarrow.c_lib import c_array_stream, c_schema, c_schema_view
 
 
@@ -79,24 +79,46 @@ def iter_tuples(obj, schema=None) -> Iterable[Tuple]:
     return RowTupleIterator.get_iterator(obj, schema=schema)
 
 
-def iter_buffers_recursive(
-    obj, schema=None
-) -> Iterable[Tuple[List[int], List[int], Tuple[CBufferView]]]:
-    return RecursiveBufferIterator.get_iterator(obj, schema=schema)
+def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
+    """Iterate over prepared views of each array
 
+    Returns an iterator which yields a :func:`c_array_view`
+    for each chunk in ``obj``.
 
-def iter_buffers(obj, schema=None) -> Iterable[Tuple]:
-    return BufferIterator.get_iterator(obj, schema=schema)
+    For performance reasons, the :class:`CArrayView` yielded by this iterator
+    is the same Python object for each chunk backed by a different
+    :class:`CArray` on each iteration. The buffers obtained by
+    ``item.buffer()`` or ``item.buffers()`` are independent of this view
+    (i.e., they hold a strong reference to the underlying :class:`CArray`
+    but not the :class:`CArrayView` instance).
 
+    Paramters
+    ---------
+    obj : array stream-like
+        An array-like or array stream-like object as sanitized by
+        :func:`c_array_stream`.
+    schema : schema-like, optional
+        An optional schema, passed to :func:`c_array_stream`.
 
-def iter_av_mutable(obj, schema=None):
+    Examples
+    --------
+
+    >>> import nanoarrow as na
+    >>> from nanoarrow import iterator
+    >>> array = na.c_array([1, 2, 3], na.int32())
+    >>> list(iterator.iter_array_view(array))
+    [<nanoarrow.c_lib.CArrayView>
+     - storage_type: 'int32'
+     - length: 3
+     - offset: 0
+     - null_count: 0
+     - buffers[2]:
+     - validity <bool[0 b] >
+     - data <int32[12 b] 1 2 3>
+     - dictionary: NULL
+     - children[0]:]
+    """
     return ArrayViewIterator.get_iterator(obj, schema=schema)
-
-
-def iter_av_copies(obj, schema=None):
-    with c_array_stream(obj, schema=schema) as stream:
-        for array in stream:
-            yield array.view()
 
 
 class InvalidArrayWarning(UserWarning):
@@ -107,7 +129,7 @@ class LossyConversionWarning(UserWarning):
     pass
 
 
-class ArrayViewIterator:
+class ArrayViewBaseIterator:
     """Base class for iterators that use an internal ArrowArrayView
     as the basis for conversion to Python objects. Intended for internal use.
     """
@@ -143,7 +165,7 @@ class ArrayViewIterator:
     def _make_child(self, schema, array_view):
         return type(self)(schema, _array_view=array_view)
 
-    def _iter1(self, offset, length):
+    def _iter1(self, offset, length) -> Iterable:
         yield self._array_view
 
     @cached_property
@@ -172,61 +194,22 @@ class ArrayViewIterator:
         warnings.warn(f"{self._object_label}: {message}", category)
 
 
-class BufferIterator(ArrayViewIterator):
-    def __init__(self, schema, *, _array_view=None):
-        super().__init__(schema, _array_view=_array_view)
+class ArrayViewIterator(ArrayViewBaseIterator):
+    """Yield the prepared CArrayView backed by successive arrays in a stream.
+    Intended for internal use.
+    """
+
+    def __init__(self, schema):
+        # We don't child iterators for this iterator implementation
+        self._schema = c_schema(schema)
+        self._schema_view = c_schema_view(schema)
+        self._array_view = CArrayView.from_schema(self._schema)
 
     def _iter1(self, offset, length):
-        yield (
-            self._array_view.offset + offset,
-            length,
-            tuple(self._array_view.buffers),
-            tuple(self._child_buffers()),
-            self._dictionary_buffers(),
-        )
-
-    def _child_buffers(self):
-        for child in self._children:
-            yield next(child._iter1(0, child._array_view.length))
-
-    def _dictionary_buffers(self):
-        if self._dictionary:
-            return next(
-                self._dictionary._iter1(
-                    0,
-                    self._dictionary._array_view.length,
-                )
-            )
+        yield self._array_view
 
 
-class RecursiveBufferIterator(BufferIterator):
-    def _make_child(self, schema, array_view):
-        return BufferIterator(schema, _array_view=array_view)
-
-    def _iter1(
-        self, offset, length
-    ) -> Iterable[Tuple[List[int], List[int], Tuple[CBufferView]]]:
-        item = next(super()._iter1(offset, length))
-        offsets = []
-        lengths = []
-        buffers = tuple(self._buffers_from_parent(item, offsets, lengths))
-        offsets[0] += offset
-        lengths[0] = length
-        yield offsets, lengths, buffers
-
-    def _buffers_from_parent(self, parent_item, offsets, lengths):
-        offset, length, buffers, children, dictionary = parent_item
-        if dictionary:
-            raise ValueError("RecursiveBufferIterator not implemented for dictionary")
-
-        offsets.append(offset)
-        lengths.append(length)
-        yield from buffers
-        for child in children:
-            yield from self._buffers_from_parent(child, offsets, lengths)
-
-
-class PyIterator(ArrayViewIterator):
+class PyIterator(ArrayViewBaseIterator):
     """Iterate over the Python object version of values in an ArrowArrayView.
     Intended for internal use.
     """

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -79,7 +79,7 @@ def iter_tuples(obj, schema=None) -> Iterable[Tuple]:
     return RowTupleIterator.get_iterator(obj, schema=schema)
 
 
-def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
+def iter_array_views(obj, schema=None) -> Iterable[CArrayView]:
     """Iterate over prepared views of each array
 
     Returns an iterator which yields a :func:`c_array_view`
@@ -99,7 +99,7 @@ def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
     >>> import nanoarrow as na
     >>> from nanoarrow import iterator
     >>> array = na.c_array([1, 2, 3], na.int32())
-    >>> list(iterator.iter_array_view(array))
+    >>> list(iterator.iter_array_views(array))
     [<nanoarrow.c_lib.CArrayView>
     - storage_type: 'int32'
     - length: 3

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -79,7 +79,7 @@ def iter_tuples(obj, schema=None) -> Iterable[Tuple]:
     return RowTupleIterator.get_iterator(obj, schema=schema)
 
 
-def iter_array_data(obj, schema=None) -> Iterable[CArrayView]:
+def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
     """Iterate over prepared views of each array
 
     Returns an iterator which yields a :func:`c_array_view`
@@ -99,7 +99,7 @@ def iter_array_data(obj, schema=None) -> Iterable[CArrayView]:
     >>> import nanoarrow as na
     >>> from nanoarrow import iterator
     >>> array = na.c_array([1, 2, 3], na.int32())
-    >>> list(iterator.iter_array_data(array))
+    >>> list(iterator.iter_array_view(array))
     [<nanoarrow.c_lib.CArrayView>
     - storage_type: 'int32'
     - length: 3

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -108,15 +108,15 @@ def iter_array_view(obj, schema=None) -> Iterable[CArrayView]:
     >>> array = na.c_array([1, 2, 3], na.int32())
     >>> list(iterator.iter_array_view(array))
     [<nanoarrow.c_lib.CArrayView>
-     - storage_type: 'int32'
-     - length: 3
-     - offset: 0
-     - null_count: 0
-     - buffers[2]:
-     - validity <bool[0 b] >
-     - data <int32[12 b] 1 2 3>
-     - dictionary: NULL
-     - children[0]:]
+    - storage_type: 'int32'
+    - length: 3
+    - offset: 0
+    - null_count: 0
+    - buffers[2]:
+      - validity <bool[0 b] >
+      - data <int32[12 b] 1 2 3>
+    - dictionary: NULL
+    - children[0]:]
     """
     return ArrayViewIterator.get_iterator(obj, schema=schema)
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -89,6 +89,16 @@ def iter_buffers(obj, schema=None) -> Iterable[Tuple]:
     return BufferIterator.get_iterator(obj, schema=schema)
 
 
+def iter_av_mutable(obj, schema=None):
+    return ArrayViewIterator.get_iterator(obj, schema=schema)
+
+
+def iter_av_copies(obj, schema=None):
+    with c_array_stream(obj, schema=schema) as stream:
+        for array in stream:
+            yield array.view()
+
+
 class InvalidArrayWarning(UserWarning):
     pass
 
@@ -134,7 +144,7 @@ class ArrayViewIterator:
         return type(self)(schema, _array_view=array_view)
 
     def _iter1(self, offset, length):
-        raise NotImplementedError()
+        yield self._array_view
 
     @cached_property
     def _child_names(self):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -47,7 +47,7 @@ def test_array_empty():
     assert array.n_buffers == 2
     assert list(array.buffer(0)) == []
     assert list(array.buffer(1)) == []
-    assert list(array.iter_chunk_data()) == []
+    assert list(array.iter_chunk_views()) == []
 
     assert array.n_children == 0
 
@@ -84,7 +84,7 @@ def test_array_contiguous():
     assert array.buffer(0) is validity
     assert array.buffer(1) is data
 
-    chunk_views = list(array.iter_chunk_data())
+    chunk_views = list(array.iter_chunk_views())
     assert len(chunk_views) == array.n_chunks
     assert chunk_views[0].n_buffers == array.n_buffers
     assert list(chunk_views[0].buffer(1)) == [1, 2, 3]
@@ -128,7 +128,7 @@ def test_array_chunked():
     with pytest.raises(ValueError, match="Can't export ArrowArray"):
         array.buffers
 
-    chunk_views = list(array.iter_chunk_data())
+    chunk_views = list(array.iter_chunk_views())
     assert len(chunk_views) == array.n_chunks
     assert chunk_views[0].n_buffers == array.n_buffers
     assert list(chunk_views[0].buffer(1)) == [1, 2, 3]

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -46,7 +46,7 @@ def test_array_empty():
     assert array.n_buffers == 2
     assert list(array.buffer(0)) == []
     assert list(array.buffer(1)) == []
-    assert list(array.iter_buffers()) == []
+    assert list(array.iter_chunk_views()) == []
 
     assert array.n_children == 0
 
@@ -82,10 +82,10 @@ def test_array_contiguous():
     assert array.buffer(0) is validity
     assert array.buffer(1) is data
 
-    chunk_buffers = list(array.iter_buffers())
-    assert len(chunk_buffers) == array.n_chunks
-    assert len(chunk_buffers[0]) == array.n_buffers
-    assert list(chunk_buffers[0][1]) == [1, 2, 3]
+    chunk_views = list(array.iter_chunk_views())
+    assert len(chunk_views) == array.n_chunks
+    assert chunk_views[0].n_buffers == array.n_buffers
+    assert list(chunk_views[0].buffer(1)) == [1, 2, 3]
 
     assert array.n_children == 0
     assert list(array.iter_children()) == []
@@ -126,11 +126,11 @@ def test_array_chunked():
     with pytest.raises(ValueError, match="Can't export ArrowArray"):
         array.buffers
 
-    chunk_buffers = list(array.iter_buffers())
-    assert len(chunk_buffers) == array.n_chunks
-    assert len(chunk_buffers[0]) == array.n_buffers
-    assert list(chunk_buffers[0][1]) == [1, 2, 3]
-    assert list(chunk_buffers[1][1]) == [4, 5, 6]
+    chunk_views = list(array.iter_chunk_views())
+    assert len(chunk_views) == array.n_chunks
+    assert chunk_views[0].n_buffers == array.n_buffers
+    assert list(chunk_views[0].buffer(1)) == [1, 2, 3]
+    assert list(chunk_views[1].buffer(1)) == [4, 5, 6]
 
     assert array.n_children == 0
     assert list(array.iter_children()) == []

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -42,6 +42,7 @@ def test_array_empty():
     array = na.Array([], na.int32())
     assert array.schema.type == na.Type.INT32
     assert len(array) == 0
+    assert array.offset == 0
 
     assert array.n_buffers == 2
     assert list(array.buffer(0)) == []
@@ -73,6 +74,7 @@ def test_array_contiguous():
     array = na.Array([1, 2, 3], na.int32())
     assert array.schema.type == na.Type.INT32
     assert len(array) == 3
+    assert array.offset == 0
 
     assert array.n_buffers == 2
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -46,7 +46,7 @@ def test_array_empty():
     assert array.n_buffers == 2
     assert list(array.buffer(0)) == []
     assert list(array.buffer(1)) == []
-    assert list(array.iter_chunk_views()) == []
+    assert list(array.iter_chunk_data()) == []
 
     assert array.n_children == 0
 
@@ -82,7 +82,7 @@ def test_array_contiguous():
     assert array.buffer(0) is validity
     assert array.buffer(1) is data
 
-    chunk_views = list(array.iter_chunk_views())
+    chunk_views = list(array.iter_chunk_data())
     assert len(chunk_views) == array.n_chunks
     assert chunk_views[0].n_buffers == array.n_buffers
     assert list(chunk_views[0].buffer(1)) == [1, 2, 3]
@@ -126,7 +126,7 @@ def test_array_chunked():
     with pytest.raises(ValueError, match="Can't export ArrowArray"):
         array.buffers
 
-    chunk_views = list(array.iter_chunk_views())
+    chunk_views = list(array.iter_chunk_data())
     assert len(chunk_views) == array.n_chunks
     assert chunk_views[0].n_buffers == array.n_buffers
     assert list(chunk_views[0].buffer(1)) == [1, 2, 3]

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -23,6 +23,7 @@ from nanoarrow.iterator import (
     ArrayViewBaseIterator,
     InvalidArrayWarning,
     LossyConversionWarning,
+    iter_array_view,
     iter_py,
     iter_tuples,
 )
@@ -39,6 +40,14 @@ def test_iterator_warnings():
     with pytest.warns(LossyConversionWarning, match=msg_named):
         iterator = ArrayViewBaseIterator(na.Schema(na.Type.INT32, name="some_colname"))
         iterator._warn("something", LossyConversionWarning)
+
+
+def test_array_data_iterator():
+    array = na.c_array([1, 2, 3], na.int32())
+    views = list(iter_array_view(array))
+    assert len(views) == 1
+    assert views[0].storage_type == "int32"
+    assert list(views[0].buffer(1)) == [1, 2, 3]
 
 
 def test_iterator_primitive():

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -20,7 +20,7 @@ import decimal
 
 import pytest
 from nanoarrow.iterator import (
-    ArrayViewIterator,
+    ArrayViewBaseIterator,
     InvalidArrayWarning,
     LossyConversionWarning,
     iter_py,
@@ -33,11 +33,11 @@ import nanoarrow as na
 def test_iterator_warnings():
     msg_unnamed = "<unnamed int32>: something"
     with pytest.warns(LossyConversionWarning, match=msg_unnamed):
-        ArrayViewIterator(na.int32())._warn("something", LossyConversionWarning)
+        ArrayViewBaseIterator(na.int32())._warn("something", LossyConversionWarning)
 
     msg_named = "some_colname <int32>: something"
     with pytest.warns(LossyConversionWarning, match=msg_named):
-        iterator = ArrayViewIterator(na.Schema(na.Type.INT32, name="some_colname"))
+        iterator = ArrayViewBaseIterator(na.Schema(na.Type.INT32, name="some_colname"))
         iterator._warn("something", LossyConversionWarning)
 
 

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -42,7 +42,7 @@ def test_iterator_warnings():
         iterator._warn("something", LossyConversionWarning)
 
 
-def test_array_data_iterator():
+def test_array_view_iterator():
     array = na.c_array([1, 2, 3], na.int32())
     views = list(iter_array_view(array))
     assert len(views) == 1

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -23,7 +23,7 @@ from nanoarrow.iterator import (
     ArrayViewBaseIterator,
     InvalidArrayWarning,
     LossyConversionWarning,
-    iter_array_view,
+    iter_array_views,
     iter_py,
     iter_tuples,
 )
@@ -44,7 +44,7 @@ def test_iterator_warnings():
 
 def test_array_view_iterator():
     array = na.c_array([1, 2, 3], na.int32())
-    views = list(iter_array_view(array))
+    views = list(iter_array_views(array))
     assert len(views) == 1
     assert views[0].storage_type == "int32"
     assert list(views[0].buffer(1)) == [1, 2, 3]


### PR DESCRIPTION
The idea with this change is to support efficient buffer access for chunked/streaming input (e.g., make a numpy array). The efficient implementation is compact but I am not sure it is easy to guess for anybody not familiar with nanoarrow internals:

```python
with c_array_stream(obj, schema) as stream:
        for array in stream:
            view = array.view()
```

I'm not sure that `iter_chun_data()` is the best name here, but one would use it like:

```python
import nanoarrow as na

array = na.Array([1, 2, 3], na.int32())

for view in array.iter_chunk_data():
    print(view.offset, view.length, list(view.buffers))
#> 0 3 [nanoarrow.c_lib.CBufferView(bool[0 b] ), nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)]
```

This would replace `iter_buffers()` which is a little dangerous to use (since one might assume the whole buffer represents the array, where we really need the offset everywhere one might access a buffer). It also cleans up some of the `ArrayViewIterator` terminology (since an earlier version of this used the `ArrayViewIterator` instead of the simpler approach it now uses).

The below benchmark is engineered to find the point where a this iterator would be slower than `pa.ChunkedArray.to_numpy()` (for a million doubles in this specific example, PyArrow becomes faster between 100 and 1000 chunks).

```python
import nanoarrow as na
from nanoarrow import c_lib
import pyarrow as pa
import numpy as np

n = int(1e6)
chunk_size = int(1e4)
num_chunks = n // chunk_size
n = chunk_size * num_chunks

chunks = [na.c_array(np.random.random(chunk_size)) for i in range(num_chunks)]
array = na.Array(c_lib.CArrayStream.from_array_list(chunks, na.c_schema(na.float64())))

def make():
    out = np.empty(len(array), dtype=np.float64)

    cursor = 0
    for view in array.iter_chunk_data():
        offset = view.offset
        length = view.length
        data = np.array(view.buffer(1), copy=False)[offset:(offset + length)]
        out[cursor:(cursor + length)] = np.array(data, copy=False)
        cursor += length

    return out


%timeit make()
#> 749 µs ± 37.8 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

chunked = pa.chunked_array([pa.array(item) for item in chunks])
%timeit chunked.to_numpy()
#> 2.07 ms ± 17.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# With 1000 chunks of size 1000, the number would be
# iter_array_view()
#> 3.02 ms ± 238 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# chunked.to_numpy()
#> 2.07 ms ± 16.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

np.testing.assert_equal(make(), chunked.to_numpy())
```