### PR TITLE
feat(python): function to inspect a single-chunk Array

### DIFF
--- a/python/src/nanoarrow/_repr_utils.py
+++ b/python/src/nanoarrow/_repr_utils.py
@@ -250,7 +250,7 @@ def device_repr(device):
     return "\n".join([title_line, device_type, device_id])
 
 
-def array_dump(array, indent=0, max_char_width=80):
+def array_inspect(array, indent=0, max_char_width=80):
     array_view = array.view()
 
     if max_char_width < 20:
@@ -280,14 +280,14 @@ def array_dump(array, indent=0, max_char_width=80):
         )
 
     if array.dictionary:
-        dictionary_repr = array_dump(array.dictionary, indent=indent + 2)
+        dictionary_repr = array_inspect(array.dictionary, indent=indent + 2)
         lines.append(f"{indent_str}- dictionary: {dictionary_repr}")
     else:
         lines.append(f"{indent_str}- dictionary: NULL")
 
     lines.append(f"{indent_str}- children[{array.n_children}]:")
     for child in array.children:
-        child_repr = array_dump(child, indent=indent + 4)
+        child_repr = array_inspect(child, indent=indent + 4)
         lines.append(f"{indent_str}  {repr(child.schema.name)}: {child_repr}")
 
     return "\n".join(lines)

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -491,6 +491,10 @@ class Array:
     def __repr__(self) -> str:
         return self.to_string()
 
-    def inspect(self): # or dump?
+    def inspect(self):
+        """
+        Print the details of the array (type, length, offset, buffers,
+        and children arrays).
+        """
         self._assert_one_chunk("inspect")
         print(_repr_utils.array_dump(c_array(self)))

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -497,4 +497,4 @@ class Array:
         and children arrays).
         """
         self._assert_one_chunk("inspect")
-        print(_repr_utils.array_dump(c_array(self)))
+        print(_repr_utils.array_inspect(c_array(self)))

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -490,3 +490,7 @@ class Array:
 
     def __repr__(self) -> str:
         return self.to_string()
+
+    def inspect(self): # or dump?
+        self._assert_one_chunk("inspect")
+        print(_repr_utils.array_dump(c_array(self)))

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -280,3 +280,22 @@ def test_array_repr_long():
     assert len(repr_lines) == 2
     assert repr_lines[1].endswith("...")
     assert len(repr_lines[1]) == 80
+
+
+def test_array_inspect(capsys):
+    array = na.Array(range(10), na.int32())
+    array.inspect()
+    captured = capsys.readouterr()
+    assert captured.out.startswith("<ArrowArray int32>")
+
+    # with children
+    c_array = na.c_array_from_buffers(
+        na.struct({f"col{i}": na.int32() for i in range(100)}),
+        length=1,
+        buffers=[None],
+        children=[na.c_array([123456], na.int32())] * 100,
+    )
+    array = na.Array(c_array)
+    array.inspect()
+    captured = capsys.readouterr()
+    assert captured.out.startswith("<ArrowArray struct<col0: int32")


### PR DESCRIPTION
Addresses https://github.com/apache/arrow-nanoarrow/issues/435

Reusing the existing repr utilities, the current code gives this:

```
In [1]: import nanoarrow as na

In [2]: pa_arr = pa.array([[0, 1], [None, 3], None, [4]])

In [3]: arr = na.Array(pa_arr)

In [4]: arr.inspect()
<ArrowArray list<item: int64>>
- length: 4
- offset: 0
- null_count: 1
- buffers[2]:
  - validity <bool[1 b] 11010000>
  - data_offset <int32[20 b] 0 2 4 4 5>
- dictionary: NULL
- children[1]:
  'item': <ArrowArray int64>
    - length: 5
    - offset: 0
    - null_count: 1
    - buffers[2]:
      - validity <bool[1 b] 11011000>
      - data <int64[40 b] 0 1 0 3 4>
    - dictionary: NULL
    - children[0]:
```