### PR TITLE
feat(python): Add user-facing ArrayStream class

### DIFF
--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -74,10 +74,12 @@ from nanoarrow.schema import (
     struct,
 )
 from nanoarrow.array import array, Array
+from nanoarrow.array_stream import ArrayStream
 from nanoarrow._version import __version__  # noqa: F401
 
 # Helps Sphinx automatically populate an API reference section
 __all__ = [
+    "ArrayStream",
     "Schema",
     "TimeUnit",
     "Type",

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from functools import cached_property
+from typing import Iterable
+
+from nanoarrow._lib import CMaterializedArrayStream
+from nanoarrow.c_lib import c_array_stream
+from nanoarrow.array import Array
+from nanoarrow.schema import Schema
+
+
+class ArrayStream:
+
+    def __init__(self, obj, schema=None) -> None:
+        self._c_array_stream = c_array_stream(obj, schema)
+
+    @cached_property
+    def schema(self):
+        return Schema(self._c_array_stream._get_cached_schema())
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        return self._c_array_stream.__arrow_c_stream__(
+            requested_schema=requested_schema
+        )
+
+    def __iter__(self) -> Iterable[Array]:
+        for c_array in self._c_array_stream:
+            yield Array(CMaterializedArrayStream.from_c_array(c_array))
+
+    def read_all(self) -> Array:
+        return Array(self._c_array_stream)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def close(self):
+        self._c_array_stream.release()
+
+    @staticmethod
+    def from_readable(obj):
+        from nanoarrow.ipc import Stream
+
+        with Stream.from_readable(obj) as ipc_stream:
+            return ArrayStream(ipc_stream)
+
+    @staticmethod
+    def from_path(obj, *args, **kwargs):
+        from nanoarrow.ipc import Stream
+
+        with Stream.from_path(obj, *args, **kwargs) as ipc_stream:
+            return ArrayStream(ipc_stream)
+
+    @staticmethod
+    def from_url(obj, *args, **kwargs):
+        from nanoarrow.ipc import Stream
+
+        with Stream.from_url(obj, *args, **kwargs) as ipc_stream:
+            return ArrayStream(ipc_stream)

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -251,7 +251,7 @@ class ArrayStream:
 
     @staticmethod
     def from_url(obj, *args, **kwargs):
-        """Create an ArrayStream from an IPC stream at a local file path
+        """Create an ArrayStream from an IPC stream at a URL
 
         Examples
         --------

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -19,13 +19,13 @@ from functools import cached_property
 from typing import Iterable
 
 from nanoarrow._lib import CMaterializedArrayStream
-from nanoarrow.c_lib import c_array_stream
+from nanoarrow._repr_utils import make_class_label
 from nanoarrow.array import Array
+from nanoarrow.c_lib import c_array_stream
 from nanoarrow.schema import Schema
 
 
 class ArrayStream:
-
     def __init__(self, obj, schema=None) -> None:
         self._c_array_stream = c_array_stream(obj, schema)
 
@@ -51,8 +51,12 @@ class ArrayStream:
     def __exit__(self, *args, **kwargs):
         self.close()
 
-    def close(self):
+    def close(self) -> None:
         self._c_array_stream.release()
+
+    def __repr__(self) -> str:
+        cls = make_class_label(self, "nanoarrow")
+        return f"<{cls}: {self.schema}>"
 
     @staticmethod
     def from_readable(obj):

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -77,7 +77,7 @@ class Stream:
 
     @staticmethod
     def from_readable(obj):
-        """Wrap an open readable object as an Arrow stream
+        """Wrap an open readable file or buffer as an Arrow IPC stream
 
         Wraps a readable object (specificially, an object that implements a
         ``readinto()`` method) as a non-owning Stream. Closing ``obj`` remains
@@ -112,7 +112,7 @@ class Stream:
 
     @staticmethod
     def from_path(obj, *args, **kwargs):
-        """Wrap a local file as an Arrow stream
+        """Wrap a local file as an IPC stream
 
         Wraps a pathlike object (specificially, one that can be passed to ``open()``)
         as an owning Stream. The file will be opened in binary mode and will be closed
@@ -149,7 +149,7 @@ class Stream:
 
     @staticmethod
     def from_url(obj, *args, **kwargs):
-        """Wrap a URL as an Arrow stream
+        """Wrap a URL as an IPC stream
 
         Wraps a URL (specificially, one that can be passed to
         ``urllib.request.urlopen()``) as an owning Stream. The URL will be
@@ -190,7 +190,7 @@ class Stream:
 
     @staticmethod
     def example():
-        """Example Stream
+        """Example IPC Stream
 
         A self-contained example whose value is the serialized version of
         ``DataFrame({"some_col": [1, 2, 3]})``. This may be used for testing

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -43,6 +43,16 @@ def test_array_stream_read_all():
     assert list(array.iter_py()) == [1, 2, 3]
 
 
+def test_array_stream_read_next():
+    stream = na.ArrayStream([1, 2, 3], na.int32())
+    array = stream.read_next()
+    assert array.schema.type == na.Type.INT32
+    assert list(array.iter_py()) == [1, 2, 3]
+
+    with pytest.raises(StopIteration):
+        stream.read_next()
+
+
 def test_array_stream_close():
     stream = na.ArrayStream([], na.int32())
     stream.close()

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+import nanoarrow as na
+from nanoarrow.ipc import Stream
+
+
+def test_array_stream_iter():
+    stream = na.ArrayStream([1, 2, 3], na.int32())
+    assert stream.schema.type == na.Type.INT32
+    stream_iter = iter(stream)
+
+    assert list(next(stream_iter).iter_py()) == [1, 2, 3]
+    with pytest.raises(StopIteration):
+        next(stream_iter)
+
+
+def test_array_stream_read_all():
+    stream = na.ArrayStream([1, 2, 3], na.int32())
+    array = stream.read_all()
+    assert array.schema.type == na.Type.INT32
+    assert list(array.iter_py()) == [1, 2, 3]
+
+def test_array_stream_close():
+    stream = na.ArrayStream([], na.int32())
+    stream.close()
+    with pytest.raises(RuntimeError, match="array stream is released"):
+        stream.read_all()
+
+def test_array_stream_context_manager():
+    stream = na.ArrayStream([], na.int32())
+    with stream:
+        pass
+
+    with pytest.raises(RuntimeError, match="array stream is released"):
+        stream.read_all()
+
+
+def test_array_stream_from_readable():
+    stream = na.ArrayStream.from_readable(Stream.example_bytes())
+    assert stream.schema.type == na.Type.STRUCT
+    assert list(stream.read_all().iter_tuples()) == [(1,), (2,), (3,)]
+
+
+def test_array_stream_from_path():
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "test.arrows")
+        with open(path, "wb") as f:
+            f.write(Stream.example_bytes())
+
+        stream = na.ArrayStream.from_path(path)
+        assert stream.schema.type == na.Type.STRUCT
+        assert list(stream.read_all().iter_tuples()) == [(1,), (2,), (3,)]
+
+
+def test_array_stream_from_url():
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "test.arrows")
+        with open(path, "wb") as f:
+            f.write(Stream.example_bytes())
+
+        uri = pathlib.Path(path).as_uri()
+        with na.ArrayStream.from_url(uri) as stream:
+            assert stream.schema.type == na.Type.STRUCT
+            assert list(stream.read_all().iter_tuples()) == [(1,), (2,), (3,)]

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -21,9 +21,9 @@ import pathlib
 import tempfile
 
 import pytest
+from nanoarrow.ipc import Stream
 
 import nanoarrow as na
-from nanoarrow.ipc import Stream
 
 
 def test_array_stream_iter():
@@ -42,11 +42,13 @@ def test_array_stream_read_all():
     assert array.schema.type == na.Type.INT32
     assert list(array.iter_py()) == [1, 2, 3]
 
+
 def test_array_stream_close():
     stream = na.ArrayStream([], na.int32())
     stream.close()
     with pytest.raises(RuntimeError, match="array stream is released"):
         stream.read_all()
+
 
 def test_array_stream_context_manager():
     stream = na.ArrayStream([], na.int32())

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -53,6 +53,18 @@ def test_ipc_stream_example():
         assert list(batch.child(0).buffer(1)) == [1, 2, 3]
 
 
+def test_ipc_stream_from_readable():
+    with io.BytesIO(Stream.example_bytes()) as f:
+        with Stream.from_readable(f) as input:
+            assert input._is_valid() is True
+            assert "BytesIO object" in repr(input)
+
+            with na.c_array_stream(input) as stream:
+                batches = list(stream)
+                assert len(batches) == 1
+                assert batches[0].length == 3
+
+
 def test_ipc_stream_from_path():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "test.arrows")


### PR DESCRIPTION
This class provides an interface to the ArrowArrayStream whose methods return `Schema`s and `Array`s. It also provides a more ergonomic interface to the `ipc.Stream` interface.

```python
import nanoarrow as na

na.ArrayStream([1, 2, 3], na.int32())
#> <nanoarrow.ArrayStream: Schema(INT32)>

na.ArrayStream([1, 2, 3], na.int32()).read_all()
#> nanoarrow.Array<int32>[3]
#> 1
#> 2
#> 3

url = "https://github.com/apache/arrow-experiments/raw/main/data/arrow-commits/arrow-commits.arrows"
na.ArrayStream.from_url(url).read_all()
#> nanoarrow.Array<struct<commit: string, time: timestamp('us', 'UTC'), ...>[15487]
#> {'commit': '49cdb0fe4e98fda19031c864a18e6156c6edbf3c', 'time': datetime.datet...
#> {'commit': '1d966e98e41ce817d1f8c5159c0b9caa4de75816', 'time': datetime.datet...
#> {'commit': '96f26a89bd73997f7532643cdb27d04b70971530', 'time': datetime.datet...
#> {'commit': 'ee1a8c39a55f3543a82fed900dadca791f6e9f88', 'time': datetime.datet...
#> {'commit': '3d467ac7bfae03cf2db09807054c5672e1959aec', 'time': datetime.datet...
#> {'commit': 'ef6ea6beed071ed070daf03508f4c14b4072d6f2', 'time': datetime.datet...
#> {'commit': '53e0c745ad491af98a5bf18b67541b12d7790beb', 'time': datetime.datet...
#> {'commit': '3ba6d286caad328b8572a3b9228045da8c8d2043', 'time': datetime.datet...
#> {'commit': '4ce9a5edd2710fb8bf0c642fd0e3863b01c2ea20', 'time': datetime.datet...
#> {'commit': '2445975162905bd8d9a42ffc9cd0daa0e19d3251', 'time': datetime.datet...
#> ...and 15477 more items
```