### PR TITLE
ci(python): Add Python to release verification with TEST_WITH_MEMCHECK=1

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -28,3 +28,32 @@
     ...
     fun:__tls_get_addr
 }
+
+{
+   <Python>:Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:_PyObject_GC_Resize
+}
+
+{
+   <Python>:Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+}
+
+{
+   <Python>:Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+}
+
+{
+   <Python>:Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+}


### PR DESCRIPTION
This can be run locally with:

```shell
export NANOARROW_PLATFORM=ubuntu
# On M1 you might need:
# export NANOARROW_ARCH=arm64
docker compose run --rm -e TEST_WITH_MEMCHECK=1 -e TEST_DEFAULT=0 -e TEST_PYTHON=1 -e VERBOSE=1 verify
```