### PR TITLE
chore(python): Remove C sources from wheels

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-src/nanoarrow/vendor
+vendor/
 src/nanoarrow/_lib.c
 src/nanoarrow/_ipc_lib.c
 

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-exclude bootstrap.py
 recursive-include src/nanoarrow/vendor *.c *.h *.pxd
 include src/nanoarrow/nanoarrow_device_c.pxd
+
+exclude bootstrap.py
+exclude src/nanoarrow/*.c
+recursive-exclude src/nanoarrow *.o *.so

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-recursive-include src/nanoarrow/vendor *.c *.h *.pxd
+recursive-include vendor *.c *.h *.pxd
 include src/nanoarrow/nanoarrow_device_c.pxd
 
 exclude bootstrap.py

--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -181,7 +181,7 @@ class NanoarrowPxdGenerator:
 def copy_or_generate_nanoarrow_c():
     this_dir = os.path.abspath(os.path.dirname(__file__))
     source_dir = os.path.dirname(this_dir)
-    vendor_dir = os.path.join(this_dir, "src", "nanoarrow", "vendor")
+    vendor_dir = os.path.join(this_dir, "vendor")
 
     vendored_files = [
         "nanoarrow.h",
@@ -266,8 +266,8 @@ def copy_or_generate_nanoarrow_c():
 # Runs the pxd generator with some information about the file name
 def generate_nanoarrow_pxd():
     this_dir = os.path.abspath(os.path.dirname(__file__))
-    maybe_nanoarrow_h = os.path.join(this_dir, "src/nanoarrow/vendor/nanoarrow.h")
-    maybe_nanoarrow_pxd = os.path.join(this_dir, "src/nanoarrow/vendor/nanoarrow_c.pxd")
+    maybe_nanoarrow_h = os.path.join(this_dir, "vendor/nanoarrow.h")
+    maybe_nanoarrow_pxd = os.path.join(this_dir, "vendor/nanoarrow_c.pxd")
 
     NanoarrowPxdGenerator().generate_nanoarrow_pxd(
         maybe_nanoarrow_h, maybe_nanoarrow_pxd

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,12 +69,12 @@ setup(
     ext_modules=[
         Extension(
             name="nanoarrow._lib",
-            include_dirs=["src/nanoarrow", "src/nanoarrow/vendor"],
+            include_dirs=["src/nanoarrow", "vendor"],
             language="c",
             sources=[
                 "src/nanoarrow/_lib.pyx",
-                "src/nanoarrow/vendor/nanoarrow.c",
-                "src/nanoarrow/vendor/nanoarrow_device.c",
+                "vendor/nanoarrow.c",
+                "vendor/nanoarrow_device.c",
             ],
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,
@@ -82,13 +82,13 @@ setup(
         ),
         Extension(
             name="nanoarrow._ipc_lib",
-            include_dirs=["src/nanoarrow", "src/nanoarrow/vendor"],
+            include_dirs=["src/nanoarrow", "vendor"],
             language="c",
             sources=[
                 "src/nanoarrow/_ipc_lib.pyx",
-                "src/nanoarrow/vendor/nanoarrow.c",
-                "src/nanoarrow/vendor/nanoarrow_ipc.c",
-                "src/nanoarrow/vendor/flatcc.c",
+                "vendor/nanoarrow.c",
+                "vendor/nanoarrow_ipc.c",
+                "vendor/flatcc.c",
             ],
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,


### PR DESCRIPTION
Even though the binaries were quite small, nanoarrow's wheels were about 1 MB and the installed size was about 5 MB. This is because the flatcc headers and cython generated code was rather extensive and had ended up in the built wheel. After this change the wheels are ~400kb and installed size is 1.5 MB (for me).

The main change here is to move the directory where we vendor the C files from elsewhere in the repo outside `src/` such they are not automatically included in the wheel.