### PR TITLE
chore(python): Clean up top-level namespace

### DIFF
--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -25,16 +25,9 @@ Arrow C Data and Arrow C Stream interfaces.
 """
 
 from nanoarrow._lib import c_version
-from nanoarrow.c_array import (
-    c_array_from_buffers,
-    c_array,
-    allocate_c_array,
-)
-from nanoarrow.c_array_stream import c_array_stream, allocate_c_array_stream
-from nanoarrow.c_schema import (
-    c_schema,
-    allocate_c_schema,
-)
+from nanoarrow.c_array import c_array_from_buffers, c_array
+from nanoarrow.c_array_stream import c_array_stream
+from nanoarrow.c_schema import c_schema
 from nanoarrow.c_buffer import c_buffer
 from nanoarrow.schema import (
     Schema,
@@ -86,9 +79,6 @@ __all__ = [
     "Schema",
     "TimeUnit",
     "Type",
-    "allocate_c_array",
-    "allocate_c_array_stream",
-    "allocate_c_schema",
     "binary",
     "bool_",
     "c_array",

--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -67,6 +67,7 @@ from nanoarrow.schema import (
     interval_month_day_nano,
     decimal128,
     decimal256,
+    schema,
     struct,
 )
 from nanoarrow.array import array, Array
@@ -114,6 +115,7 @@ __all__ = [
     "null",
     "string",
     "struct",
+    "schema",
     "time32",
     "time64",
     "timestamp",

--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -28,13 +28,11 @@ from nanoarrow._lib import c_version
 from nanoarrow.c_array import (
     c_array_from_buffers,
     c_array,
-    c_array_view,
     allocate_c_array,
 )
 from nanoarrow.c_array_stream import c_array_stream, allocate_c_array_stream
 from nanoarrow.c_schema import (
     c_schema,
-    c_schema_view,
     allocate_c_schema,
 )
 from nanoarrow.c_buffer import c_buffer
@@ -96,11 +94,9 @@ __all__ = [
     "c_array",
     "c_array_from_buffers",
     "c_array_stream",
-    "c_array_view",
     "c_buffer",
     "c_lib",
     "c_schema",
-    "c_schema_view",
     "c_version",
     "date32",
     "date64",

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -527,9 +527,9 @@ class Array:
         print(_repr_utils.array_inspect(c_array(self)))
 
 
-def array(*args, **kwargs) -> Array:
+def array(obj, schema=None) -> Array:
     """
     Alias for the :class:`Array` class constructor. The use of
     ``nanoarrow.Array()`` is preferred over ``nanoarrow.array()``.
     """
-    return Array(*args, **kwargs)
+    return Array(obj, schema=schema)

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -527,39 +527,9 @@ class Array:
         print(_repr_utils.array_inspect(c_array(self)))
 
 
-def array(obj, schema=None, device=None) -> Array:
+def array(*args, **kwargs) -> Array:
     """
-    Create a nanoarrow.Array from array-like input.
-
-    The :class:`Array` class is nanoarrow's high-level in-memory array
-    representation whose scope maps to that of a fully-consumed
-    ArrowArrayStream in the Arrow C Data interface. Note that an
-    :class:`Array` is not necessarily contiguous in memory (i.e.,
-    it may consist of zero or more ``ArrowArray``s).
-    See :class:`Array` for class details.
-
-    Parameters
-    ----------
-    obj : array or array stream-like
-        An array-like or array stream-like object. This can be any object
-        supporting the Arrow PyCapsule interface, the Python buffer
-        protocol, or an iterable of Python objects.
-    schema : schema-like, optional
-        An optional schema. This can be a Schema object, or object
-        implementing the Arrow PyCapsule interface for schemas
-        (i.e. having the ``__arrow_c_schema__`` protocol method).
-    device : Device, optional
-        The device associated with the buffers held by this Array.
-        Defaults to the CPU device.
-
-    Examples
-    --------
-
-    >>> import nanoarrow as na
-    >>> na.array([1, 2, 3], na.int32())
-    nanoarrow.Array<int32>[3]
-    1
-    2
-    3
+    Alias for the :class:`Array` class constructor. The use of
+    ``nanoarrow.Array()`` is preferred over ``nanoarrow.array()``.
     """
-    return Array(obj, schema=schema, device=device)
+    return Array(*args, **kwargs)

--- a/python/src/nanoarrow/c_array.py
+++ b/python/src/nanoarrow/c_array.py
@@ -156,9 +156,9 @@ def allocate_c_array(schema=None) -> CArray:
     --------
 
     >>> import pyarrow as pa
-    >>> import nanoarrow as na
-    >>> schema = na.allocate_c_schema()
-    >>> pa.int32()._export_to_c(schema._addr())
+    >>> from nanoarrow.c_array import allocate_c_array
+    >>> array = allocate_c_array()
+    >>> pa.array([1, 2, 3])._export_to_c(array._addr())
     """
     if schema is not None:
         schema = c_schema(schema)
@@ -254,9 +254,8 @@ def c_array_from_buffers(
 
     >>> import nanoarrow as na
     >>> c_array = na.c_array_from_buffers(na.uint8(), 5, [None, b"12345"])
-    >>> na.c_array_view(c_array)
-    <nanoarrow.c_lib.CArrayView>
-    - storage_type: 'uint8'
+    >>> na.Array(c_array).inspect()
+    <ArrowArray uint8>
     - length: 5
     - offset: 0
     - null_count: 0

--- a/python/src/nanoarrow/c_array.py
+++ b/python/src/nanoarrow/c_array.py
@@ -182,8 +182,10 @@ def c_array_view(obj, schema=None) -> CArrayView:
     >>> import pyarrow as pa
     >>> import numpy as np
     >>> import nanoarrow as na
+    >>> from nanoarrow.c_array import c_array_view
+    >>>
     >>> array = na.c_array(pa.array(["one", "two", "three", None]))
-    >>> array_view = na.c_array_view(array)
+    >>> array_view = c_array_view(array)
     >>> np.array(array_view.buffer(1))
     array([ 0,  3,  6, 11, 11], dtype=int32)
     >>> np.array(array_view.buffer(2))

--- a/python/src/nanoarrow/c_array_stream.py
+++ b/python/src/nanoarrow/c_array_stream.py
@@ -103,11 +103,11 @@ def allocate_c_array_stream() -> CArrayStream:
     --------
 
     >>> import pyarrow as pa
-    >>> import nanoarrow as na
+    >>> from nanoarrow.c_array_stream import allocate_c_array_stream
     >>> pa_column = pa.array([1, 2, 3], pa.int32())
     >>> pa_batch = pa.record_batch([pa_column], names=["col1"])
     >>> pa_reader = pa.RecordBatchReader.from_batches(pa_batch.schema, [pa_batch])
-    >>> array_stream = na.allocate_c_array_stream()
+    >>> array_stream = allocate_c_array_stream()
     >>> pa_reader._export_to_c(array_stream._addr())
     """
     return CArrayStream.allocate()

--- a/python/src/nanoarrow/c_schema.py
+++ b/python/src/nanoarrow/c_schema.py
@@ -91,8 +91,9 @@ def c_schema_view(obj) -> CSchemaView:
 
     >>> import pyarrow as pa
     >>> import nanoarrow as na
+    >>> from nanoarrow.c_schema import c_schema_view
     >>> schema = na.c_schema(pa.decimal128(10, 3))
-    >>> schema_view = na.c_schema_view(schema)
+    >>> schema_view = c_schema_view(schema)
     >>> schema_view.type
     'decimal128'
     >>> schema_view.decimal_bitwidth
@@ -116,8 +117,8 @@ def allocate_c_schema() -> CSchema:
     --------
 
     >>> import pyarrow as pa
-    >>> import nanoarrow as na
-    >>> schema = na.allocate_c_schema()
+    >>> from nanoarrow.c_schema import allocate_c_schema
+    >>> schema = allocate_c_schema()
     >>> pa.int32()._export_to_c(schema._addr())
     """
     return CSchema.allocate()

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -460,12 +460,12 @@ class Schema:
         return self._c_schema.__arrow_c_schema__()
 
 
-def schema(*args, **kwargs) -> Schema:
+def schema(obj, **kwargs) -> Schema:
     """
     Alias for the :class:`Schema` class constructor. The use of
     ``nanoarrow.Schema()`` is preferred over ``nanoarrow.schema()``.
     """
-    return Schema(*args, **kwargs)
+    return Schema(obj, **kwargs)
 
 
 def null(nullable: bool = True) -> Schema:

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -460,6 +460,14 @@ class Schema:
         return self._c_schema.__arrow_c_schema__()
 
 
+def schema(*args, **kwargs) -> Schema:
+    """
+    Alias for the :class:`Schema` class constructor. The use of
+    ``nanoarrow.Schema()`` is preferred over ``nanoarrow.schema()``.
+    """
+    return Schema(*args, **kwargs)
+
+
 def null(nullable: bool = True) -> Schema:
     """Create an instance of a null type.
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -38,7 +38,7 @@ def test_array_construct():
         iter(array)
 
 
-def test_array_constructor():
+def test_array_alias_constructor():
     array = na.array([1, 2, 3], na.int32())
     assert array.schema.type == na.Type.INT32
 

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -17,6 +17,7 @@
 
 import pytest
 from nanoarrow._lib import CArrayBuilder, NanoarrowException
+from nanoarrow.c_schema import c_schema_view
 
 import nanoarrow as na
 
@@ -162,9 +163,9 @@ def test_c_array_from_pybuffer_uint8():
     assert c_array.length == len(data)
     assert c_array.null_count == 0
     assert c_array.offset == 0
-    assert na.c_schema_view(c_array.schema).type == "uint8"
+    assert c_schema_view(c_array.schema).type == "uint8"
 
-    c_array_view = na.c_array_view(c_array)
+    c_array_view = c_array.view()
     assert list(c_array_view.buffer(1)) == list(data)
 
 
@@ -175,9 +176,9 @@ def test_c_array_from_pybuffer_string():
     assert c_array.length == len(data)
     assert c_array.null_count == 0
     assert c_array.offset == 0
-    assert na.c_schema_view(c_array.schema).type == "int8"
+    assert c_schema_view(c_array.schema).type == "int8"
 
-    c_array_view = na.c_array_view(c_array)
+    c_array_view = c_array.view()
     assert list(c_array_view.buffer(1)) == list(data)
 
 
@@ -190,10 +191,10 @@ def test_c_array_from_pybuffer_fixed_size_binary():
     assert c_array.length == len(items)
     assert c_array.null_count == 0
     assert c_array.offset == 0
-    assert na.c_schema_view(c_array.schema).type == "fixed_size_binary"
-    assert na.c_schema_view(c_array.schema).fixed_size == 4
+    assert c_schema_view(c_array.schema).type == "fixed_size_binary"
+    assert c_schema_view(c_array.schema).fixed_size == 4
 
-    c_array_view = na.c_array_view(c_array)
+    c_array_view = c_array.view()
     assert list(c_array_view.buffer(1)) == items
 
 
@@ -205,9 +206,9 @@ def test_c_array_from_pybuffer_numpy():
     assert c_array.length == len(data)
     assert c_array.null_count == 0
     assert c_array.offset == 0
-    assert na.c_schema_view(c_array.schema).type == "int32"
+    assert c_schema_view(c_array.schema).type == "int32"
 
-    c_array_view = na.c_array_view(c_array)
+    c_array_view = c_array.view()
     assert list(c_array_view.buffer(1)) == list(data)
 
 
@@ -218,7 +219,7 @@ def test_c_array_from_iterable_empty():
     assert empty_string.offset == 0
     assert empty_string.n_buffers == 3
 
-    array_view = na.c_array_view(empty_string)
+    array_view = empty_string.view()
     assert len(array_view.buffer(0)) == 0
     assert len(array_view.buffer(1)) == 0
     assert len(array_view.buffer(2)) == 0
@@ -229,7 +230,7 @@ def test_c_array_from_iterable_string():
     assert string.length == 3
     assert string.null_count == 1
 
-    array_view = na.c_array_view(string)
+    array_view = string.view()
     assert len(array_view.buffer(0)) == 1
     assert len(array_view.buffer(1)) == 4
     assert len(array_view.buffer(2)) == 7
@@ -244,7 +245,7 @@ def test_c_array_from_iterable_bytes():
     assert string.length == 3
     assert string.null_count == 1
 
-    array_view = na.c_array_view(string)
+    array_view = string.view()
     assert len(array_view.buffer(0)) == 1
     assert len(array_view.buffer(1)) == 4
     assert len(array_view.buffer(2)) == 7
@@ -267,7 +268,7 @@ def test_c_array_from_iterable_non_empty_nullable_without_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 0
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0)) == []
     assert list(view.buffer(1)) == [1, 2, 3]
 
@@ -277,7 +278,7 @@ def test_c_array_from_iterable_non_empty_non_nullable():
     assert c_array.length == 3
     assert c_array.null_count == 0
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0)) == []
     assert list(view.buffer(1)) == [1, 2, 3]
 
@@ -287,7 +288,7 @@ def test_c_array_from_iterable_int_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [1, 0, 3]
 
@@ -297,7 +298,7 @@ def test_c_array_from_iterable_float_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [1.0, 0.0, 3.0]
 
@@ -307,7 +308,7 @@ def test_c_array_from_iterable_bool_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1).elements()) == [True, False, False] + [False] * 5
 
@@ -317,7 +318,7 @@ def test_c_array_from_iterable_fixed_size_binary_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [b"1234", b"\x00\x00\x00\x00", b"5678"]
 
@@ -327,7 +328,7 @@ def test_c_array_from_iterable_day_time_interval_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [(1, 2), (0, 0), (3, 4)]
 
@@ -337,7 +338,7 @@ def test_c_array_from_iterable_month_day_nano_interval_with_nulls():
     assert c_array.length == 3
     assert c_array.null_count == 1
 
-    view = na.c_array_view(c_array)
+    view = c_array.view()
     assert list(view.buffer(0).elements()) == [True, False, True] + [False] * 5
     assert list(view.buffer(1)) == [(1, 2, 3), (0, 0, 0), (4, 5, 6)]
 
@@ -353,7 +354,7 @@ def test_c_array_from_buffers():
     assert c_array.null_count == 0
     assert c_array.offset == 0
 
-    array_view = na.c_array_view(c_array)
+    array_view = c_array.view()
     assert array_view.storage_type == "uint8"
     assert bytes(array_view.buffer(0)) == b""
     assert bytes(array_view.buffer(1)) == b"12345"
@@ -393,7 +394,7 @@ def test_c_array_from_buffers_recursive():
     assert c_array.length == 5
     assert c_array.n_children == 1
 
-    array_view = na.c_array_view(c_array)
+    array_view = c_array.view()
     assert bytes(array_view.child(0).buffer(1)) == b"12345"
 
     with pytest.raises(ValueError, match="Expected 1 children but got 0"):

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -21,7 +21,7 @@ import nanoarrow as na
 
 
 def test_buffer_view_bool_():
-    bool_array_view = na.c_array_view([1, 0, 0, 1], na.bool_())
+    bool_array_view = na.c_array([1, 0, 0, 1], na.bool_()).view()
     view = bool_array_view.buffer(1)
 
     assert view.element_size_bits == 1
@@ -63,7 +63,7 @@ def test_buffer_view_bool_():
 
 
 def test_buffer_view_non_bool():
-    array_view = na.c_array_view([1, 2, 3, 5], na.int32())
+    array_view = na.c_array([1, 2, 3, 5], na.int32()).view()
     view = array_view.buffer(1)
 
     assert view.element_size_bits == 32

--- a/python/tests/test_c_schema.py
+++ b/python/tests/test_c_schema.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import pytest
-from nanoarrow.c_schema import c_schema_view
+from nanoarrow.c_schema import allocate_c_schema, c_schema_view
 
 import nanoarrow as na
 
 
 def test_c_schema_basic():
-    schema = na.allocate_c_schema()
+    schema = allocate_c_schema()
     assert schema.is_valid() is False
     assert schema._to_string() == "[invalid: schema is released]"
     assert repr(schema) == "<nanoarrow.c_lib.CSchema <released>>"
@@ -66,7 +66,7 @@ def test_schema_metadata():
 
 
 def test_c_schema_view():
-    schema = na.allocate_c_schema()
+    schema = allocate_c_schema()
     with pytest.raises(RuntimeError):
         c_schema_view(schema)
 

--- a/python/tests/test_c_schema.py
+++ b/python/tests/test_c_schema.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import pytest
+from nanoarrow.c_schema import c_schema_view
 
 import nanoarrow as na
 
@@ -67,10 +68,10 @@ def test_schema_metadata():
 def test_c_schema_view():
     schema = na.allocate_c_schema()
     with pytest.raises(RuntimeError):
-        na.c_schema_view(schema)
+        c_schema_view(schema)
 
     schema = na.c_schema(na.int32())
-    view = na.c_schema_view(schema)
+    view = c_schema_view(schema)
     assert "- type: 'int32'" in repr(view)
     assert view.type == "int32"
     assert view.storage_type == "int32"
@@ -86,23 +87,23 @@ def test_c_schema_view():
 
 
 def test_c_schema_view_extra_params():
-    view = na.c_schema_view(na.fixed_size_binary(12))
+    view = c_schema_view(na.fixed_size_binary(12))
     assert view.fixed_size == 12
 
-    view = na.c_schema_view(na.decimal128(10, 3))
+    view = c_schema_view(na.decimal128(10, 3))
     assert view.decimal_bitwidth == 128
     assert view.decimal_precision == 10
     assert view.decimal_scale == 3
 
-    view = na.c_schema_view(na.decimal256(10, 3))
+    view = c_schema_view(na.decimal256(10, 3))
     assert view.decimal_bitwidth == 256
     assert view.decimal_precision == 10
     assert view.decimal_scale == 3
 
-    view = na.c_schema_view(na.duration("us"))
+    view = c_schema_view(na.duration("us"))
     assert view.time_unit == "us"
 
-    view = na.c_schema_view(na.timestamp("us", "America/Halifax"))
+    view = c_schema_view(na.timestamp("us", "America/Halifax"))
     assert view.type == "timestamp"
     assert view.storage_type == "int64"
     assert view.time_unit == "us"
@@ -110,7 +111,7 @@ def test_c_schema_view_extra_params():
 
     pa = pytest.importorskip("pyarrow")
 
-    view = na.c_schema_view(pa.list_(pa.int32(), 12))
+    view = c_schema_view(pa.list_(pa.int32(), 12))
     assert view.fixed_size == 12
 
 
@@ -121,7 +122,7 @@ def test_c_schema_metadata():
     }
 
     schema = na.c_schema(na.int32()).modify(metadata=meta)
-    view = na.c_schema_view(schema)
+    view = c_schema_view(schema)
     assert view.extension_name == "some_name"
     assert view.extension_metadata == b"some_metadata"
 

--- a/python/tests/test_capsules.py
+++ b/python/tests/test_capsules.py
@@ -16,6 +16,9 @@
 # under the License.
 
 import pytest
+from nanoarrow.c_array import allocate_c_array
+from nanoarrow.c_array_stream import allocate_c_array_stream
+from nanoarrow.c_schema import allocate_c_schema
 
 import nanoarrow as na
 
@@ -125,18 +128,18 @@ def test_array_stream_requested_schema():
 
 
 def test_export_invalid():
-    schema = na.allocate_c_schema()
+    schema = allocate_c_schema()
     assert schema.is_valid() is False
 
     with pytest.raises(RuntimeError, match="schema is released"):
         pa.schema(schema)
 
-    array = na.allocate_c_array()
+    array = allocate_c_array()
     assert array.is_valid() is False
     with pytest.raises(RuntimeError, match="CArray is released"):
         pa.array(array)
 
-    array_stream = na.allocate_c_array_stream()
+    array_stream = allocate_c_array_stream()
     assert array_stream.is_valid() is False
     with pytest.raises(RuntimeError, match="array stream is released"):
         pa.table(array_stream)

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -49,7 +49,7 @@ def test_ipc_stream_example():
 
         assert stream.is_valid() is False
         assert len(batches) == 1
-        batch = na.c_array_view(batches[0])
+        batch = na.c_array(batches[0]).view()
         assert list(batch.child(0).buffer(1)) == [1, 2, 3]
 
 

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -19,6 +19,7 @@ import re
 import sys
 
 import pytest
+from nanoarrow.c_array import c_array_view
 
 import nanoarrow as na
 
@@ -66,12 +67,12 @@ def test_array_stream_helper():
 
 
 def test_array_view_helper():
-    from nanoarrow.c_array import CArrayView
+    from nanoarrow.c_array import CArrayView, c_array_view
 
     array = na.c_array(pa.array([1, 2, 3]))
-    view = na.c_array_view(array)
+    view = c_array_view(array)
     assert isinstance(view, CArrayView)
-    assert na.c_array_view(view) is view
+    assert c_array_view(view) is view
 
 
 def test_c_array_empty():
@@ -116,7 +117,7 @@ def test_c_array_dictionary():
 
 def test_c_array_view():
     array = na.c_array(pa.array([1, 2, 3], pa.int32()))
-    view = na.c_array_view(array)
+    view = array.view()
 
     assert view.storage_type == "int32"
     assert "- storage_type: 'int32'" in repr(view)
@@ -153,7 +154,7 @@ def test_c_array_view_recursive():
     assert array.child(0).length == 3
     assert array.child(0).schema._addr() == array.schema.child(0)._addr()
 
-    view = na.c_array_view(array)
+    view = array.view()
     assert view.n_buffers == 1
     assert len(list(view.buffers)) == 1
     assert view.n_children == 1
@@ -171,7 +172,7 @@ def test_c_array_view_dictionary():
     assert array.schema.format == "i"
     assert array.dictionary.schema.format == "u"
 
-    view = na.c_array_view(array)
+    view = array.view()
     assert view.n_buffers == 2
     assert view.dictionary.n_buffers == 3
     assert "- dictionary: <nanoarrow.c_lib.CArrayView>" in repr(view)
@@ -190,7 +191,7 @@ def test_buffers_integer():
     ]
 
     for pa_type, np_type in data_types:
-        view = na.c_array_view(pa.array([0, 1, 2], pa_type))
+        view = c_array_view(pa.array([0, 1, 2], pa_type))
         data_buffer = view.buffer(1)
 
         # Check via buffer interface
@@ -215,7 +216,7 @@ def test_buffers_float():
     ]
 
     for pa_type, np_type in data_types:
-        view = na.c_array_view(pa.array([0, 1, 2], pa_type))
+        view = c_array_view(pa.array([0, 1, 2], pa_type))
         data_buffer = view.buffer(1)
 
         # Check via buffer interface
@@ -236,7 +237,7 @@ def test_buffers_float():
 def test_buffers_half_float():
     # pyarrrow can only create half_float from np.float16()
     np_array = np.array([0, 1, 2], np.float16())
-    view = na.c_array_view(pa.array(np_array))
+    view = c_array_view(pa.array(np_array))
     data_buffer = view.buffer(1)
 
     # Check via buffer interface
@@ -255,7 +256,7 @@ def test_buffers_half_float():
 
 
 def test_buffers_bool():
-    view = na.c_array_view(pa.array([True, True, True, False]))
+    view = c_array_view(pa.array([True, True, True, False]))
     data_buffer = view.buffer(1)
 
     assert data_buffer.size_bytes == 1
@@ -292,7 +293,7 @@ def test_buffers_bool():
 
 
 def test_buffers_string():
-    view = na.c_array_view(pa.array(["a", "bc", "def"]))
+    view = c_array_view(pa.array(["a", "bc", "def"]))
 
     assert view.buffer(0).size_bytes == 0
     assert view.buffer(1).size_bytes == 16
@@ -316,7 +317,7 @@ def test_buffers_string():
 
 
 def test_buffers_binary():
-    view = na.c_array_view(pa.array([b"a", b"bc", b"def"]))
+    view = c_array_view(pa.array([b"a", b"bc", b"def"]))
 
     assert view.buffer(0).size_bytes == 0
     assert view.buffer(1).size_bytes == 16
@@ -341,7 +342,7 @@ def test_buffers_binary():
 
 
 def test_buffers_fixed_size_binary():
-    view = na.c_array_view(pa.array([b"abc", b"def", b"ghi"], pa.binary(3)))
+    view = c_array_view(pa.array([b"abc", b"def", b"ghi"], pa.binary(3)))
 
     assert view.buffer(1).size_bytes == 9
 
@@ -355,7 +356,7 @@ def test_buffers_fixed_size_binary():
 
 
 def test_buffers_interval_month_day_nano():
-    view = na.c_array_view(
+    view = c_array_view(
         pa.array([pa.scalar((1, 15, -30), type=pa.month_day_nano_interval())])
     )
 

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -33,9 +33,9 @@ def test_c_version():
 
 
 def test_c_schema_helper():
-    from nanoarrow.c_schema import CSchema
+    from nanoarrow.c_schema import CSchema, allocate_c_schema
 
-    schema = na.allocate_c_schema()
+    schema = allocate_c_schema()
     assert na.c_schema(schema) is schema
 
     schema = na.c_schema(pa.null())
@@ -46,9 +46,9 @@ def test_c_schema_helper():
 
 
 def test_c_array_helper():
-    from nanoarrow.c_array import CArray
+    from nanoarrow.c_array import CArray, allocate_c_array
 
-    array = na.allocate_c_array()
+    array = allocate_c_array()
     assert na.c_array(array) is array
 
     array = na.c_array(pa.array([], pa.null()))
@@ -59,7 +59,9 @@ def test_c_array_helper():
 
 
 def test_array_stream_helper():
-    array_stream = na.allocate_c_array_stream()
+    from nanoarrow.c_array_stream import allocate_c_array_stream
+
+    array_stream = allocate_c_array_stream()
     assert na.c_array_stream(array_stream) is array_stream
 
     with pytest.raises(TypeError):
@@ -76,7 +78,9 @@ def test_array_view_helper():
 
 
 def test_c_array_empty():
-    array = na.allocate_c_array()
+    from nanoarrow.c_array import allocate_c_array
+
+    array = allocate_c_array()
     assert array.is_valid() is False
     assert repr(array) == "<nanoarrow.c_lib.CArray <released>>"
 
@@ -372,7 +376,9 @@ def test_buffers_interval_month_day_nano():
 
 
 def test_c_array_stream():
-    array_stream = na.allocate_c_array_stream()
+    from nanoarrow.c_array_stream import allocate_c_array_stream
+
+    array_stream = allocate_c_array_stream()
     assert na.c_array_stream(array_stream) is array_stream
     assert repr(array_stream) == "<nanoarrow.c_lib.CArrayStream <released>>"
 

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -251,3 +251,8 @@ def test_schema_extension():
     assert schema_obj.extension.metadata is None
     assert schema_obj.extension.storage.type == na.Type.INT32
     assert schema_obj.nullable is False
+
+
+def test_schema_alias_constructor():
+    schema = na.schema(na.Type.INT32)
+    assert isinstance(schema, na.Schema)


### PR DESCRIPTION
This PR cleans up the top-level namespace such that more advanced concepts that might be confusing to new nanoarrow users are tucked away in modules (i.e., they can be used and are documented, but better alternatives are likely to be discovered first). The changes are:

- `allocate_c_array()`, `allocate_c_schema()`, and `allocate_c_array_stream()` were removed. These are useful for testing invalid input but pretty much nothing else.
- `c_array_view()` and `c_schema_view()` were removed. These are tools used by the iterators, the `Array`, and the `Schema`, but most people should use the higher level concepts for buffer access.
- A `schema()` alias for `Schema()` was added (because it is easy to accidentally type `schema()` and get a wildly inappropriate error message). This mirrors `array()` as an alias for `Array()`.