### PR TITLE
feat(python): Implement bitmap unpacking

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1834,11 +1834,12 @@ cdef class CBufferView:
             PyBuffer_Release(&buffer)
             raise ValueError("Destination buffer has itemsize != 1")
 
-        if buffer.len < (dest_offset + length):
+        if dest_offset < 0 or buffer.len < (dest_offset + length):
             buffer_len = buffer.len
             PyBuffer_Release(&buffer)
             raise IndexError(
-                f"Can't unpack {length} elements into buffer of size {buffer_len}"
+                f"Can't unpack {length} elements into buffer of size {buffer_len} "
+                f"with dest_offset = {dest_offset}"
             )
 
         ArrowBitsUnpackInt8(

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1815,6 +1815,45 @@ cdef class CBufferView:
         else:
             return self._iter_dispatch(offset, length)
 
+    def unpack_bits_into(self, dest, offset=0, length=None):
+        if self._data_type != NANOARROW_TYPE_BOOL:
+            raise ValueError("Can't unpack non-boolean buffer")
+
+        if length is None:
+            length = self.n_elements
+
+        if offset < 0 or length < 0 or (offset + length) > self.n_elements:
+            raise IndexError(
+                f"offset {offset} and length {length} do not describe a valid slice "
+                f"of buffer with {self.n_elements} elements"
+            )
+
+        cdef Py_buffer buffer
+        PyObject_GetBuffer(dest, &buffer, PyBUF_WRITABLE | PyBUF_ANY_CONTIGUOUS)
+        if buffer.itemsize != 1:
+            PyBuffer_Release(&buffer)
+            raise ValueError("Destination buffer has itemsize != 1")
+
+        if buffer.len < length:
+            buffer_len = buffer.len
+            PyBuffer_Release(&buffer)
+            raise IndexError(
+                f"Can't unpack {length} elements into buffer of size {buffer_len}"
+            )
+
+        ArrowBitsUnpackInt8(self._ptr.data.as_uint8, offset, length, <int8_t*>buffer.buf)
+        PyBuffer_Release(&buffer)
+
+    def unpack_bits(self, offset=0, length=None):
+        if length is None:
+            length = self.n_elements
+
+        out = CBufferBuilder().set_data_type(NANOARROW_TYPE_UINT8)
+        out.reserve_bytes(length)
+        self.unpack_bits_into(out, offset, length)
+        out.advance(length)
+        return out.finish()
+
     def _iter_bitmap(self, int64_t offset, int64_t length):
         cdef uint8_t item
         cdef int64_t i

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -65,7 +65,7 @@ def test_buffer_view_bool_():
 def test_buffer_view_bool_unpack():
     from array import array
 
-    bool_array_view = na.c_array_view([1, 0, 0, 1], na.bool_())
+    bool_array_view = na.c_array([1, 0, 0, 1], na.bool_()).view()
     view = bool_array_view.buffer(1)
 
     # Check unpacking

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -83,6 +83,10 @@ def test_buffer_view_bool_unpack():
     view.unpack_bits_into(out, dest_offset=2)
     assert list(out) == [255, 255, 1, 0, 0, 1, 0, 0, 0, 0]
 
+    # Check error requesting out-of-bounds dest_offset
+    with pytest.raises(IndexError, match="Can't unpack"):
+        view.unpack_bits_into(out, dest_offset=-1)
+
     # Check errors from requesting out-of-bounds slices
     msg = "do not describe a valid slice"
     with pytest.raises(IndexError, match=msg):

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -78,6 +78,11 @@ def test_buffer_view_bool_unpack():
     assert len(unpacked_some) == 4
     assert list(unpacked_some) == [0, 0, 1, 0]
 
+    # Check with non-zero destination offset
+    out = bytearray([255] * 10)
+    view.unpack_bits_into(out, dest_offset=2)
+    assert list(out) == [255, 255, 1, 0, 0, 1, 0, 0, 0, 0]
+
     # Check errors from requesting out-of-bounds slices
     msg = "do not describe a valid slice"
     with pytest.raises(IndexError, match=msg):


### PR DESCRIPTION
In prototyping a real-world use case, I remembered that unpacking bits is exceedingly difficult to get right if you need to support an arbitrary offset/length. The math for this is very fiddly and we spent a few rounds getting it right in the C function `ArrowBitsUnpackInt(8|32)`. This PR makes that available so that we can do things like (1) convert bool arrays to numpy and (2) convert null masks to something that somebody else can work with (e.g., a numpy mask).

This seems to be relatively performant (thanks to @WillAyd's work optimizing this!)

```python
import numpy as np
import nanoarrow as na
import pyarrow as pa

bool_np = np.random.random(int(1e6)) > 0.5
bool_na = na.Array(iter(bool_array), na.bool_())
bool_pa = pa.array(bool_np)

def to_numpy_na(x):
    x_view = na.c_array(x).view()
    out = np.empty(x_view.length, bool)
    x_view.buffer(1).unpack_bits_into(out, x_view.offset, x_view.length)
    return out

%timeit to_numpy_na(bool_na)
#> 162 µs ± 812 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

%timeit bool_pa.to_numpy(False)
#> 609 µs ± 833 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```