### PR TITLE
fix(python): Make shallow CArray copies less shallow to accomodate moving children

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -206,7 +206,8 @@ cdef void c_array_shallow_copy(object base, const ArrowArray* src, ArrowArray* d
     for i in range(src.n_buffers):
         if src.buffers[i] != NULL:
             c_pyobject_buffer(base, src.buffers[i], 0, ArrowArrayBuffer(tmp, i))
-            tmp.buffers[i] = src.buffers[i]
+
+        tmp.buffers[i] = src.buffers[i]
 
     tmp.n_buffers = src.n_buffers
 
@@ -223,7 +224,7 @@ cdef void c_array_shallow_copy(object base, const ArrowArray* src, ArrowArray* d
         code = ArrowArrayAllocateDictionary(tmp)
         Error.raise_error_not_ok("ArrowArrayAllocateDictionary()", code)
 
-        c_array_shallow_copy(base, src.dictionary, dst.dictionary)
+        c_array_shallow_copy(base, src.dictionary, tmp.dictionary)
 
     # Move tmp into dst
     ArrowArrayMove(tmp, dst)

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -89,7 +89,7 @@ cdef void pycapsule_schema_deleter(object schema_capsule) noexcept:
     ArrowFree(schema)
 
 
-cdef object alloc_c_schema(ArrowSchema** c_schema) noexcept:
+cdef object alloc_c_schema(ArrowSchema** c_schema):
     c_schema[0] = <ArrowSchema*> ArrowMalloc(sizeof(ArrowSchema))
     # Ensure the capsule destructor doesn't call a random release pointer
     c_schema[0].release = NULL
@@ -107,7 +107,7 @@ cdef void pycapsule_array_deleter(object array_capsule) noexcept:
     ArrowFree(array)
 
 
-cdef object alloc_c_array(ArrowArray** c_array) noexcept:
+cdef object alloc_c_array(ArrowArray** c_array):
     c_array[0] = <ArrowArray*> ArrowMalloc(sizeof(ArrowArray))
     # Ensure the capsule destructor doesn't call a random release pointer
     c_array[0].release = NULL
@@ -125,7 +125,7 @@ cdef void pycapsule_array_stream_deleter(object stream_capsule) noexcept:
     ArrowFree(stream)
 
 
-cdef object alloc_c_array_stream(ArrowArrayStream** c_stream) noexcept:
+cdef object alloc_c_array_stream(ArrowArrayStream** c_stream):
     c_stream[0] = <ArrowArrayStream*> ArrowMalloc(sizeof(ArrowArrayStream))
     # Ensure the capsule destructor doesn't call a random release pointer
     c_stream[0].release = NULL
@@ -143,7 +143,7 @@ cdef void pycapsule_device_array_deleter(object device_array_capsule) noexcept:
     ArrowFree(device_array)
 
 
-cdef object alloc_c_device_array(ArrowDeviceArray** c_device_array) noexcept:
+cdef object alloc_c_device_array(ArrowDeviceArray** c_device_array):
     c_device_array[0] = <ArrowDeviceArray*> ArrowMalloc(sizeof(ArrowDeviceArray))
     # Ensure the capsule destructor doesn't call a random release pointer
     c_device_array[0].array.release = NULL
@@ -160,7 +160,7 @@ cdef void pycapsule_array_view_deleter(object array_capsule) noexcept:
     ArrowFree(array_view)
 
 
-cdef object alloc_c_array_view(ArrowArrayView** c_array_view) noexcept:
+cdef object alloc_c_array_view(ArrowArrayView** c_array_view):
     c_array_view[0] = <ArrowArrayView*> ArrowMalloc(sizeof(ArrowArrayView))
     ArrowArrayViewInitFromType(c_array_view[0], NANOARROW_TYPE_UNINITIALIZED)
     return PyCapsule_New(c_array_view[0], 'nanoarrow_array_view', &pycapsule_array_view_deleter)


### PR DESCRIPTION
This PR updates the logic that creates a "shallow copy" of an `ArrowArray`. Before, it simply made a shallow copy of the outer array, which works in most cases. However, the spec allows for "moving" child arrays, which means that the guarantee of a valid *outer* array does not guarantee anything about the validity of the `ArrowArray*` child pointers. It's difficult, but possible, to trigger this in Python (below); however, I think this sort of code is common for importers (because it allows the lifecycle of columns in an array to be independent).

```python
import nanoarrow as na
import pyarrow as pa

# Given some array
array = na.c_array_from_buffers(
    na.struct({"col1": na.int32()}),
    3,
    [None],
    children=[na.c_array([1, 2, 3], na.int32())]
)

user_array = na.Array(array)
user_array
#> nanoarrow.Array<int32>[3]
#> {'col1': 1}
#> {'col1': 2}
#> {'col1': 3}

# totally valid shallow copy of this array
schema_capsule, array_capsule = array.__arrow_c_array__()
array2 = na.c_array(array_capsule, schema_capsule)

# A consumer is technically allowed to move a child array
x = pa.Array._import_from_c(array2.child(0)._addr(), pa.int32())
del array
del x

# With the previous shallow copy implementation, this could segfault or fail
list(user_array.iter_py())
# Instead of a segfault I tend to get:
#> NanoarrowException: ArrowBasicArrayStreamValidate() failed (22): Expected int32 array buffer 1 to have size >= 12 bytes but found buffer with 0 bytes
```

After this PR the original array remains valid:

```python
list(user_array.iter_py())
#> [{'col1': 1}, {'col1': 2}, {'col1': 3}]
```

This does, however, have a non-trivial effect when making a shallow copy where a lot of children are involved:

```python
import nanoarrow as na
import pyarrow as pa

n_col = int(1e3)
n_items = int(1e5)

array_wide = na.c_array_from_buffers(
    na.struct({f"col{i}": na.int32() for i in range(n_col)}),
    n_items,
    [None],
    children=[na.c_array(range(n_items), na.int32())] * n_col
)

%timeit pa.array(array_wide)
#> Before this PR
#> 595 µs ± 5.72 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
#> After this Pr
#> 828 µs ± 2.83 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```