### PR TITLE
chore(dev/benchmarks): Fix Python benchmarks

### DIFF
--- a/dev/benchmarks/README.md
+++ b/dev/benchmarks/README.md
@@ -20,14 +20,18 @@
 # Benchmarking nanoarrow
 
 This subdirectory contains benchmarks and tools to run them. This is currently
-only implemented for the C library but may expand to include the R and Python
-bindings. The structure is as follows:
+only implemented for the C library and Python bindings but may expand to include
+the R bindings as well.
+
+## C Library
+
+The structure of the C benchmarks is as follows:
 
 - Benchmarks are documented inline using [Doxygen](https://www.doxygen.nl/).
 - Configurations are CMake build presets, and CMake handles pulling a previous
   or local nanoarrow using `FetchContent`. Benchmarks are run using `ctest`.
 - There is a bare-bones report written as a [Quarto](https://quarto.org)
-  document that renders to markdown.
+  document that renders the C library results to markdown.
 
 You can run benchmarks for a single configuration (e.g., `local`) with:
 
@@ -49,4 +53,15 @@ python generate-fixtures.py # requires pyarrow
 ./benchmark-run-all.sh
 cd apidoc && doxygen && cd ..
 quarto render benchmark-report.qmd
+```
+
+## Python bindings
+
+The Python benchmarks are a standard [asv](https://asv.readthedocs.io) project.
+You can run the benchmarks with:
+
+```shell
+# pip install asv
+python generate-fixtures.py # requires pyarrow
+asv run
 ```

--- a/dev/benchmarks/python/array.py
+++ b/dev/benchmarks/python/array.py
@@ -36,7 +36,7 @@ class CArrayBuilderSuite:
 
     def time_build_c_array_bool(self):
         """Create a bool array from 1,000,000 Python booleans"""
-        na.c_array(self.py_bools, na.bool())
+        na.c_array(self.py_bools, na.bool_())
 
     def time_build_c_array_struct_wide(self):
         """Create a struct array with 10,000 columns"""


### PR DESCRIPTION
We had renamed `bool()` to `bool_()`, which had caused the benchmarks to fail. I also documented how to run the Python benchmarks (since I'd forgotten since writing them!).