### PR TITLE
fix(python): Ensure reference-counting tests are skipped on PyPy

### DIFF
--- a/ci/scripts/test-python-wheels.sh
+++ b/ci/scripts/test-python-wheels.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -o pipefail
+
+if [ ${VERBOSE:-0} -gt 0 ]; then
+  set -x
+fi
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+NANOARROW_DIR="$(cd "${SOURCE_DIR}/../.." && pwd)"
+
+case $# in
+  0) export CIBW_BUILD=""
+     ;;
+  1) export CIBW_BUILD="$1"
+     ;;
+  *) echo "Usage:"
+     echo "  Build and test wheels locally using cibuildwheel"
+     echo "    (requires pip install cibuildwheel)"
+     echo "    $0  ...builds all wheels"
+     echo "    $0 'pp*' ...builds and tests just pypy wheels"
+     exit 1
+     ;;
+esac
+
+# Respect existing CIBW_TEST_REQUIRES (could be used to test all wheels
+# with numpy and pyarrow installed, for example)
+export CIBW_TEST_REQUIRES="pytest $CIBW_TEST_REQUIRES"
+export CIBW_TEST_COMMAND="pytest {package}/tests -vv"
+
+pushd "${NANOARROW_DIR}"
+python -m cibuildwheel --output-dir python/dist python
+popd

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -143,11 +143,15 @@ def test_c_array_slice_errors():
 
 def test_c_array_shallow_copy():
     import gc
-
+    import platform
     from nanoarrow._lib import get_pyobject_buffer_count
 
-    gc.collect()
+    if platform.python_implementation() == "PyPy":
+        pytest.skip(
+            "Reference counting/garbage collection is non-deterministic on PyPy"
+        )
 
+    gc.collect()
     initial_ref_count = get_pyobject_buffer_count()
 
     # Create an array with children

--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -144,6 +144,7 @@ def test_c_array_slice_errors():
 def test_c_array_shallow_copy():
     import gc
     import platform
+
     from nanoarrow._lib import get_pyobject_buffer_count
 
     if platform.python_implementation() == "PyPy":


### PR DESCRIPTION
PyPy's garbage collector/object deletion is not as predictable as CPython's, so you can't be sure that when you run `gc.collect()` that all unreferenced objects will be removed, and when you `del` an object, basically nothing happens (except that future garbage collections might destroy it). I did check to make sure the deleters are actually running on pypy (using `brew install pypy3.10`) manually and added a wrapper around cibuildwheel such that one can check pypy locally when debugging one of these issues.