### PR TITLE
feat(python): Add visitor pattern + builders for column sequences

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1009,9 +1009,6 @@ cdef class CSchemaView:
         if self.extension_name or self._schema_view.type != self._schema_view.storage_type:
             return None
 
-        if self.layout.n_buffers != 2:
-            return None
-
         cdef char out[128]
         cdef int element_size_bits = 0
         if self._schema_view.type == NANOARROW_TYPE_FIXED_SIZE_BINARY:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1009,6 +1009,9 @@ cdef class CSchemaView:
         if self.extension_name or self._schema_view.type != self._schema_view.storage_type:
             return None
 
+        if self.layout.n_buffers != 2:
+            return None
+
         cdef char out[128]
         cdef int element_size_bits = 0
         if self._schema_view.type == NANOARROW_TYPE_FIXED_SIZE_BINARY:

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -17,7 +17,7 @@
 
 import itertools
 from functools import cached_property
-from typing import Iterable, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 from nanoarrow._lib import (
     DEVICE_CPU,
@@ -32,6 +32,7 @@ from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.c_schema import c_schema
 from nanoarrow.iterator import iter_array_views, iter_py, iter_tuples
 from nanoarrow.schema import Schema, _schema_repr
+from nanoarrow.visitor import to_columns, to_pylist
 
 from nanoarrow import _repr_utils
 
@@ -343,6 +344,42 @@ class Array:
         nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)
         """
         return iter_array_views(self)
+
+    def to_pylist(self) -> List:
+        """Convert this Array to a ``list()` of Python objects
+
+        Computes an identical value to list(:meth:`iter_py`) but can be several
+        times faster.
+
+        Examples
+        --------
+
+        >>> import nanoarrow as na
+        >>> array = na.Array([1, 2, 3], na.int32())
+        >>> array.to_pylist()
+        [1, 2, 3]
+        """
+        return to_pylist(self)
+
+    def to_columns(self) -> Tuple[str, Sequence]:
+        """Convert this Array to a ``list()` of sequences
+
+        Converts a stream of struct arrays into its column-wise representation
+        such that each column is either a contiguous buffer or a ``list()``.
+
+        Examples
+        --------
+
+        >>> import nanoarrow as na
+        >>> import pyarrow as pa
+        >>> array = na.Array(pa.record_batch([pa.array([1, 2, 3])], names=["col1"]))
+        >>> names, columns = array.to_columns()
+        >>> names
+        ['col1']
+        >>> columns
+        [[1, 2, 3]]
+        """
+        return to_columns(self)
 
     @property
     def n_children(self) -> int:

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from functools import cached_property
-from typing import Iterable, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 from nanoarrow._lib import CMaterializedArrayStream
 from nanoarrow._repr_utils import make_class_label
@@ -24,6 +24,7 @@ from nanoarrow.array import Array
 from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.iterator import iter_py, iter_tuples
 from nanoarrow.schema import Schema, _schema_repr
+from nanoarrow.visitor import to_columns, to_pylist
 
 
 class ArrayStream:
@@ -197,6 +198,43 @@ class ArrayStream:
         (3, 'c')
         """
         return iter_tuples(self)
+
+    def to_pylist(self) -> List:
+        """Convert this Array to a ``list()` of Python objects
+
+        Computes an identical value to list(:meth:`iter_py`) but can be several
+        times faster.
+
+        Examples
+        --------
+
+        >>> import nanoarrow as na
+        >>> stream = na.ArrayStream([1, 2, 3], na.int32())
+        >>> stream.to_pylist()
+        [1, 2, 3]
+        """
+        return to_pylist(self)
+
+    def to_columns(self) -> Tuple[str, Sequence]:
+        """Convert this Array to a ``list()` of sequences
+
+        Converts a stream of struct arrays into its column-wise representation
+        such that each column is either a contiguous buffer or a ``list()``.
+
+        Examples
+        --------
+
+        >>> import nanoarrow as na
+        >>> import pyarrow as pa
+        >>> batch = pa.record_batch([pa.array([1, 2, 3])], names=["col1"])
+        >>> stream = na.ArrayStream(batch)
+        >>> names, columns = stream.to_columns()
+        >>> names
+        ['col1']
+        >>> columns
+        [[1, 2, 3]]
+        """
+        return to_columns(self)
 
     def __repr__(self) -> str:
         cls = make_class_label(self, "nanoarrow")

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -151,26 +151,8 @@ class ArrayViewBaseIterator:
         else:
             self._array_view = _array_view
 
-        self._children = list(
-            map(self._make_child, self._schema.children, self._array_view.children)
-        )
-
-        if self._schema.dictionary is None:
-            self._dictionary = None
-        else:
-            self._dictionary = self._make_child(
-                self._schema.dictionary, self._array_view.dictionary
-            )
-
-    def _make_child(self, schema, array_view):
-        return type(self)(schema, _array_view=array_view)
-
     def _iter_chunk(self, offset, length) -> Iterable:
         yield self._array_view
-
-    @cached_property
-    def _child_names(self):
-        return [child.name for child in self._schema.children]
 
     @cached_property
     def _object_label(self):
@@ -198,6 +180,27 @@ class PyIterator(ArrayViewBaseIterator):
     """Iterate over the Python object version of values in an ArrowArrayView.
     Intended for internal use.
     """
+
+    def __init__(self, schema, *, _array_view=None):
+        super().__init__(schema, _array_view=_array_view)
+
+        self._children = list(
+            map(self._make_child, self._schema.children, self._array_view.children)
+        )
+
+        if self._schema.dictionary is None:
+            self._dictionary = None
+        else:
+            self._dictionary = self._make_child(
+                self._schema.dictionary, self._array_view.dictionary
+            )
+
+    def _make_child(self, schema, array_view):
+        return type(self)(schema, _array_view=array_view)
+
+    @cached_property
+    def _child_names(self):
+        return [child.name for child in self._schema.children]
 
     def _iter_chunk(self, offset, length):
         # Check for an extension type first since this isn't reflected by

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -20,7 +20,7 @@ from functools import cached_property
 from itertools import islice
 from typing import Iterable, Tuple
 
-from nanoarrow._lib import CArray, CArrayView, CArrowType, CSchema, CSchemaView
+from nanoarrow._lib import CArrayView, CArrowType
 from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.c_schema import c_schema, c_schema_view
 
@@ -192,37 +192,6 @@ class ArrayViewBaseIterator:
 
     def _warn(self, message, category):
         warnings.warn(f"{self._object_label}: {message}", category)
-
-
-class ArrayStreamVisitor:
-    def __init__(self, iterator_cls=ArrayViewBaseIterator) -> None:
-        self._iterator_cls = iterator_cls
-
-    def visit(self, obj, schema=None):
-        with c_array_stream(obj, schema=schema) as stream:
-            iterator = self._iterator_cls(stream._get_cached_schema())
-            self.visit_schema(iterator._schema, iterator._schema_view)
-
-            iterator_set_array = iterator._set_array
-            visit_array = self.visit_array
-            array_view = iterator._array_view
-
-            for array in stream:
-                iterator_set_array(array)
-                visit_array(array, array_view, iterator)
-
-        return self.finish()
-
-    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
-        pass
-
-    def visit_array(
-        self, array: CArray, array_view: CArrayView, iterator: ArrayViewBaseIterator
-    ):
-        pass
-
-    def finish(self):
-        pass
 
 
 class PyIterator(ArrayViewBaseIterator):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -20,7 +20,7 @@ from functools import cached_property
 from itertools import islice
 from typing import Iterable, Tuple
 
-from nanoarrow._lib import CArrayView, CArrowType
+from nanoarrow._lib import CArray, CArrayView, CArrowType, CSchema, CSchemaView
 from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.c_schema import c_schema, c_schema_view
 
@@ -192,6 +192,37 @@ class ArrayViewBaseIterator:
 
     def _warn(self, message, category):
         warnings.warn(f"{self._object_label}: {message}", category)
+
+
+class ArrayStreamVisitor:
+    def __init__(self, iterator_cls=ArrayViewBaseIterator) -> None:
+        self._iterator_cls = iterator_cls
+
+    def visit(self, obj, schema=None):
+        with c_array_stream(obj, schema=schema) as stream:
+            iterator = self._iterator_cls(stream._get_cached_schema())
+            self.visit_schema(iterator._schema, iterator._schema_view)
+
+            iterator_set_array = iterator._set_array
+            visit_array = self.visit_array
+            array_view = iterator._array_view
+
+            for array in stream:
+                iterator_set_array(array)
+                visit_array(array, array_view, iterator)
+
+        return self.finish()
+
+    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
+        pass
+
+    def visit_array(
+        self, array: CArray, array_view: CArrayView, iterator: ArrayViewBaseIterator
+    ):
+        pass
+
+    def finish(self):
+        pass
 
 
 class PyIterator(ArrayViewBaseIterator):

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -206,7 +206,7 @@ class PyIterator(ArrayViewBaseIterator):
 
     def __iter__(self):
         """Iterate over all elements in the current chunk"""
-        return self._iter_chunk(0, self._array_view.length)
+        return self._iter_chunk(0, len(self._array_view))
 
     def _iter_chunk(self, offset, length):
         """Iterate over all elements in a slice of the current chunk"""

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -135,14 +135,14 @@ class ArrayViewBaseIterator:
     as the basis for conversion to Python objects. Intended for internal use.
     """
 
-    def __init__(self, schema, *, _array_view=None):
+    def __init__(self, schema, *, array_view=None):
         self._schema = c_schema(schema)
         self._schema_view = c_schema_view(schema)
 
-        if _array_view is None:
+        if array_view is None:
             self._array_view = CArrayView.from_schema(self._schema)
         else:
-            self._array_view = _array_view
+            self._array_view = array_view
 
     @cached_property
     def schema(self) -> Schema:
@@ -183,8 +183,8 @@ class PyIterator(ArrayViewBaseIterator):
                 iterator._set_array(array)
                 yield from iterator
 
-    def __init__(self, schema, *, _array_view=None):
-        super().__init__(schema, _array_view=_array_view)
+    def __init__(self, schema, *, array_view=None):
+        super().__init__(schema, array_view=array_view)
 
         self._children = list(
             map(self._make_child, self._schema.children, self._array_view.children)
@@ -198,7 +198,7 @@ class PyIterator(ArrayViewBaseIterator):
             )
 
     def _make_child(self, schema, array_view):
-        return type(self)(schema, _array_view=array_view)
+        return type(self)(schema, array_view=array_view)
 
     @cached_property
     def _child_names(self):
@@ -490,8 +490,8 @@ class RowTupleIterator(PyIterator):
     Intended for internal use.
     """
 
-    def __init__(self, schema, *, _array_view=None):
-        super().__init__(schema, _array_view=_array_view)
+    def __init__(self, schema, *, array_view=None):
+        super().__init__(schema, array_view=array_view)
         if self._schema_view.type != "struct":
             raise TypeError(
                 "RowTupleIterator can only iterate over struct arrays "
@@ -499,7 +499,7 @@ class RowTupleIterator(PyIterator):
             )
 
     def _make_child(self, schema, array_view):
-        return PyIterator(schema, _array_view=array_view)
+        return PyIterator(schema, array_view=array_view)
 
     def _iter_chunk(self, offset, length):
         return self._struct_tuple_iter(offset, length)

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from nanoarrow._lib import CArray, CArrayView, CSchema, CSchemaView
+from nanoarrow.c_array_stream import c_array_stream
+from nanoarrow.iterator import ArrayViewBaseIterator
+
+
+class ArrayStreamVisitor:
+    def __init__(self, iterator_cls=ArrayViewBaseIterator) -> None:
+        self._iterator_cls = iterator_cls
+
+    def visit(self, obj, schema=None):
+        with c_array_stream(obj, schema=schema) as stream:
+            iterator = self._iterator_cls(stream._get_cached_schema())
+            state = self.visit_schema(iterator._schema, iterator._schema_view)
+
+            iterator_set_array = iterator._set_array
+            visit_array = self.visit_array
+            array_view = iterator._array_view
+
+            for array in stream:
+                iterator_set_array(array)
+                visit_array(array, array_view, iterator, state)
+
+        return self.finish(state)
+
+    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
+        return None
+
+    def visit_array(
+        self,
+        array: CArray,
+        array_view: CArrayView,
+        iterator: ArrayViewBaseIterator,
+        state,
+    ):
+        pass
+
+    def finish(self, state):
+        return state

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -125,11 +125,11 @@ class ArrayStreamVisitor(ArrayViewBaseIterator):
 
 
 class ListBuilder(ArrayStreamVisitor):
-    def __init__(self, schema, *, iterator_cls=PyIterator, _array_view=None):
-        super().__init__(schema, _array_view=_array_view)
+    def __init__(self, schema, *, iterator_cls=PyIterator, array_view=None):
+        super().__init__(schema, array_view=array_view)
 
         # Ensure that self._iterator._array_view is self._array_view
-        self._iterator = iterator_cls(schema, _array_view=self._array_view)
+        self._iterator = iterator_cls(schema, array_view=self._array_view)
 
     def begin(self, total_elements: Union[int, None] = None):
         self._lst = []
@@ -144,8 +144,8 @@ class ListBuilder(ArrayStreamVisitor):
 
 
 class ColumnsBuilder(ArrayStreamVisitor):
-    def __init__(self, schema, *, _array_view=None):
-        super().__init__(schema, _array_view=_array_view)
+    def __init__(self, schema, *, array_view=None):
+        super().__init__(schema, array_view=array_view)
 
         if self.schema.type != Type.STRUCT:
             raise ValueError("ColumnsBuilder can only be used on a struct array")
@@ -161,7 +161,7 @@ class ColumnsBuilder(ArrayStreamVisitor):
 
     def _resolve_child_visitor(self, child_schema, child_array_view):
         # TODO: Resolve more efficient column builders for single-buffer types
-        return ListBuilder(child_schema, _array_view=child_array_view)
+        return ListBuilder(child_schema, array_view=child_array_view)
 
     def begin(self, total_elements: Union[int, None] = None) -> None:
         for child_visitor in self._child_visitors:

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -72,7 +72,7 @@ def to_columns(obj, schema=None) -> Tuple[List[str], List[Sequence]]:
     >>> array = pa.record_batch([pa.array([1, 2, 3])], names=["col1"])
     >>> names, columns = visitor.to_columns(array)
     >>> names
-    ["col1"]
+    ['col1']
     >>> columns
     [[1, 2, 3]]
     """

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -17,8 +17,9 @@
 
 from typing import Any, Callable, Iterable
 
-from nanoarrow._lib import CArrayView, CSchema, CSchemaView
+from nanoarrow._lib import CArrayView, CArrowType
 from nanoarrow.c_array_stream import c_array_stream
+from nanoarrow.c_buffer import CBufferBuilder
 from nanoarrow.iterator import ArrayViewBaseIterator, PyIterator
 
 
@@ -29,7 +30,7 @@ class ArrayStreamVisitor:
 
         with c_array_stream(obj, schema=schema) as stream:
             iterator = visitor._iterator_cls(stream._get_cached_schema())
-            state = visitor.visit_schema(iterator._schema, iterator._schema_view)
+            state = visitor.begin(iterator)
 
             iterator_set_array = iterator._set_array
             iterator_iter_chunk = iterator._iter_chunk
@@ -45,7 +46,7 @@ class ArrayStreamVisitor:
     def __init__(self, *, iterator_cls=ArrayViewBaseIterator) -> None:
         self._iterator_cls = iterator_cls
 
-    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
+    def begin(self, iterator: ArrayViewBaseIterator):
         return None
 
     def visit_array(
@@ -61,10 +62,10 @@ class ArrayStreamVisitor:
 
 
 class ListBuilder(ArrayStreamVisitor):
-    def __init__(self, *, iterator_cls=PyIterator) -> None:
+    def __init__(self, *, iterator_cls=PyIterator, total_elements=None) -> None:
         super().__init__(iterator_cls=iterator_cls)
 
-    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
+    def begin(self, iterator: ArrayViewBaseIterator):
         return []
 
     def visit_array(
@@ -77,15 +78,75 @@ class ListBuilder(ArrayStreamVisitor):
         return state
 
 
-class NumpyObjectArrayBuilder(ListBuilder):
-    def __init__(self, *, iterator_cls=PyIterator, n=None) -> None:
-        super().__init__(iterator_cls=iterator_cls)
-        self._n = n
+class BufferConcatenator(ArrayStreamVisitor):
+    def __init__(self, *, buffer=1, total_elements=None) -> None:
+        super().__init__(iterator_cls=ArrayViewBaseIterator)
+        self._buffer = buffer
+        self._total_elements = total_elements
 
-    def visit_schema(self, schema: CSchema, schema_view: CSchemaView):
+    def _copy_method_bitmap(self, buffer_view, builder, offset, length, dest_offset):
+        buffer_view.unpack_bits_into(builder, offset, length, dest_offset)
+        builder.advance(length)
+
+    def _copy_method_non_bitmap(
+        self, buffer_view, builder, offset, length, dest_offset
+    ):
+        src = memoryview(buffer_view)[offset : offset + length]
+        dst = memoryview(builder).cast(src.format)
+        dst[dest_offset : dest_offset + length] = src
+        builder.advance(len(src))
+
+    def begin(self, iterator: ArrayViewBaseIterator):
+        buffer_index = self._buffer
+        buffer_data_type = iterator._schema_view.layout.buffer_data_type_id[
+            buffer_index
+        ]
+        element_size_bits = iterator._schema_view.layout.element_size_bits[buffer_index]
+
+        if buffer_data_type == CArrowType.BOOL:
+            element_size_bytes = 1
+            buffer_data_type = CArrowType.UINT8
+            copy_method = self._copy_method_bitmap
+        else:
+            element_size_bytes = element_size_bits // 8
+            copy_method = self._copy_method_non_bitmap
+
+        builder = CBufferBuilder()
+        builder.set_data_type(buffer_data_type)
+
+        if self._total_elements is not None:
+            builder.reserve_bytes(self._total_elements * element_size_bytes)
+
+        return 0, buffer_index, builder, copy_method
+
+    def visit_array(
+        self,
+        array_view: CArrayView,
+        iterator: Callable[[int, int], Iterable],
+        state: Any,
+    ):
+        out_start, buffer_index, writable_buffer, copy_method = state
+        offset = array_view.offset
+        length = array_view.length
+        copy_method(
+            array_view.buffer(buffer_index), writable_buffer, offset, length, out_start
+        )
+
+        return out_start + length, buffer_index, writable_buffer, copy_method
+
+    def finish(self, state):
+        return state[2].finish()
+
+
+class NumpyObjectArrayBuilder(ArrayStreamVisitor):
+    def __init__(self, *, iterator_cls=PyIterator, total_elements=None) -> None:
+        super().__init__(iterator_cls=iterator_cls)
+        self._total_elements = total_elements
+
+    def begin(self, iterator: ArrayViewBaseIterator):
         from numpy import empty, fromiter
 
-        array = empty(self._n, "O")
+        array = empty(self._total_elements, "O")
         return 0, array, array.dtype, fromiter
 
     def visit_array(

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -198,7 +198,6 @@ class UnpackedBitmapConcatenator(BufferConcatenator):
 
 
 class ValidityBufferConcatenator(UnpackedBitmapConcatenator):
-
     def __init__(self, schema, *, _array_view=None):
         super().__init__(schema, buffer_index=0, _array_view=_array_view)
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -161,22 +161,17 @@ class BufferConcatenator(ArrayStreamVisitor):
 
 
 class UnpackedBitmapConcatenator(BufferConcatenator):
-    def begin(self, iterator: ArrayViewBaseIterator):
-        buffer_index = self._buffer
+    def begin(self, total_elements: int | None = None):
+        buffer_index = self._buffer_index
         builder = CBufferBuilder()
         builder.set_data_type(CArrowType.UINT8)
 
-        if self._total_elements is not None:
-            builder.reserve_bytes(self._total_elements)
+        if total_elements is not None:
+            builder.reserve_bytes(total_elements)
 
         return 0, buffer_index, builder
 
-    def visit_array(
-        self,
-        array_view: CArrayView,
-        iterator: Callable[[int, int], Iterable],
-        state: Any,
-    ):
+    def visit_chunk_view(self, array_view: CArrayView, state: Any) -> Any:
         out_start, buffer_index, writable_buffer = state
         offset = array_view.offset
         length = array_view.length

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -15,108 +15,102 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, List, Mapping, Sequence, Union
+from typing import Any, List, Sequence, Tuple, Union
 
 from nanoarrow._lib import CArrayView
 from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.iterator import ArrayViewBaseIterator, PyIterator
+from nanoarrow.schema import Type
 
 
 def to_pylist(obj, schema=None) -> List:
     return ListBuilder.visit(obj, schema)
 
 
-def to_columns(obj, schema=None) -> Mapping[str, Sequence]:
+def to_columns(obj, schema=None) -> Tuple[List[str], List[Sequence]]:
     return ColumnsBuilder.visit(obj, schema)
 
 
 class ArrayStreamVisitor(ArrayViewBaseIterator):
     @classmethod
-    def visit(cls, obj, schema=None, **kwargs):
-        if hasattr(obj, "__len__"):
+    def visit(cls, obj, schema=None, total_elements=None, **kwargs):
+        if total_elements is None and hasattr(obj, "__len__"):
             total_elements = len(obj)
-        else:
-            total_elements = None
 
         with c_array_stream(obj, schema=schema) as stream:
             visitor = cls(stream._get_cached_schema(), **kwargs)
-            state = visitor.begin(total_elements)
+            visitor.begin(total_elements)
 
-            iterator_set_array = visitor._set_array
+            visitor_set_array = visitor._set_array
             visit_chunk_view = visitor.visit_chunk_view
             array_view = visitor._array_view
 
             for array in stream:
-                iterator_set_array(array)
-                state = visit_chunk_view(array_view, state)
+                visitor_set_array(array)
+                visit_chunk_view(array_view)
 
-        return visitor.finish(state)
+        return visitor.finish()
 
     def begin(self, total_elements: Union[int, None] = None):
+        pass
+
+    def visit_chunk_view(self, array_view: CArrayView) -> None:
+        pass
+
+    def finish(self) -> Any:
         return None
-
-    def visit_chunk_view(self, array_view: CArrayView, state: Any) -> Any:
-        return state
-
-    def finish(self, state: Any) -> Any:
-        return state
 
 
 class ListBuilder(ArrayStreamVisitor):
     def __init__(self, schema, *, iterator_cls=PyIterator, _array_view=None):
         super().__init__(schema, _array_view=_array_view)
+
+        # Ensure that self._iterator._array_view is self._array_view
         self._iterator = iterator_cls(schema, _array_view=self._array_view)
 
     def begin(self, total_elements: Union[int, None] = None):
-        return self._iterator._iter_chunk, []
+        self._lst = []
 
-    def visit_chunk_view(self, array_view: CArrayView, state: Any):
-        iter_chunk, out = state
-        out.extend(iter_chunk(0, array_view.length))
-        return iter_chunk, out
+    def visit_chunk_view(self, array_view: CArrayView):
+        # The constructor here ensured that self._iterator._array_view
+        # is populated when self._set_array() is called.
+        self._lst.extend(self._iterator)
 
-    def finish(self, state: Any):
-        return state[1]
+    def finish(self) -> List:
+        return self._lst
 
 
 class ColumnsBuilder(ArrayStreamVisitor):
     def __init__(self, schema, *, _array_view=None):
         super().__init__(schema, _array_view=_array_view)
 
+        if self.schema.type != Type.STRUCT:
+            raise ValueError("ColumnsBuilder can only be used on a struct array")
+
+        # Resolve the appropriate visitor for each column
         self._child_visitors = []
-        self._child_array_views = []
         for child_schema, child_array_view in zip(
             self._schema.children, self._array_view.children
         ):
             self._child_visitors.append(
                 self._resolve_child_visitor(child_schema, child_array_view)
             )
-            self._child_array_views.append(child_array_view)
 
     def _resolve_child_visitor(self, child_schema, child_array_view):
-        # TODO: Resolve more efficient builders for single-buffer types
+        # TODO: Resolve more efficient column builders for single-buffer types
         return ListBuilder(child_schema, _array_view=child_array_view)
 
-    def begin(self, total_elements: Union[int, None] = None):
-        child_visitors = self._child_visitors
-        child_state = [child.begin(total_elements) for child in child_visitors]
-        return child_visitors, child_state, self._child_array_views
+    def begin(self, total_elements: Union[int, None] = None) -> None:
+        for child_visitor in self._child_visitors:
+            child_visitor.begin(total_elements)
 
-    def visit_chunk_view(self, array_view: CArrayView, state: Any) -> Any:
-        child_visitors, child_state, child_array_views = state
+    def visit_chunk_view(self, array_view: CArrayView) -> Any:
+        for child_visitor, child_array_view in zip(
+            self._child_visitors, array_view.children
+        ):
+            child_visitor.visit_chunk_view(child_array_view)
 
-        for i in range(len(child_visitors)):
-            child_state[i] = child_visitors[i].visit_chunk_view(
-                child_array_views[i], child_state[i]
-            )
-
-        return state
-
-    def finish(self, state: Any) -> Any:
-        child_visitors, child_state, _ = state
-
-        out = {}
-        for i, schema in enumerate(self._schema.children):
-            out[schema.name] = child_visitors[i].finish(child_state[i])
-
-        return out
+    def finish(self) -> Tuple[List[str], List[Sequence]]:
+        return [v.schema.name for v in self._child_visitors], [
+            v.finish() for v in self._child_visitors
+        ]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -21,7 +21,8 @@ from nanoarrow import visitor
 
 
 def test_to_pylist():
-    assert visitor.to_pylist([1, 2, 3], na.int32()) == [1, 2, 3]
+    array = na.c_array([1, 2, 3], na.int32())
+    assert visitor.to_pylist(array) == [1, 2, 3]
 
 
 def test_to_columms():

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pytest
 
 import nanoarrow as na
 from nanoarrow import visitor
@@ -35,8 +36,11 @@ def test_to_columms():
         ],
     )
 
-    columns = visitor.to_columns(array)
-    assert list(columns.keys()) == ["col1", "col2", "col3"]
-    assert list(columns["col1"]) == [1, 2, 3]
-    assert list(columns["col2"]) == [True, False, True]
-    assert columns["col3"] == ["abc", "def", "ghi"]
+    names, columns = visitor.to_columns(array)
+    assert names == ["col1", "col2", "col3"]
+    assert columns[0] == [1, 2, 3]
+    assert columns[1] == [True, False, True]
+    assert columns[2] == ["abc", "def", "ghi"]
+
+    with pytest.raises(ValueError, match="can only be used on a struct array"):
+        visitor.to_columns([], na.int32())

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from nanoarrow.c_array_stream import CArrayStream
-
 import nanoarrow as na
 from nanoarrow import visitor
 
@@ -42,56 +40,3 @@ def test_to_columms():
     assert list(columns["col1"]) == [1, 2, 3]
     assert list(columns["col2"]) == [True, False, True]
     assert columns["col3"] == ["abc", "def", "ghi"]
-
-
-def test_buffer_concatenator():
-    src = [na.c_array([1, 2, 3], na.int32()), na.c_array([4, 5, 6], na.int32())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    buffer = visitor.BufferConcatenator.visit(stream, buffer_index=1)
-    assert list(buffer) == [1, 2, 3, 4, 5, 6]
-
-
-def test_buffer_concatenator_with_offsets():
-    src = [na.c_array([1, 2, 3], na.int32())[1:], na.c_array([4, 5, 6], na.int32())[2:]]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    buffer = visitor.BufferConcatenator.visit(stream, buffer_index=1)
-    assert list(buffer) == [2, 3, 6]
-
-
-def test_unpacked_bitmap_concatenator():
-    src = [na.c_array([0, 1, 1], na.bool_()), na.c_array([1, 0, 0], na.bool_())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.bool_()))
-    buffer = visitor.UnpackedBitmapConcatenator.visit(stream, buffer_index=1)
-    assert list(buffer) == [False, True, True, True, False, False]
-
-
-def test_unpacked_bitmap_concatenator_with_offsets():
-    src = [na.c_array([0, 1, 1], na.bool_())[1:], na.c_array([1, 0, 0], na.bool_())[2:]]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.bool_()))
-    buffer = visitor.UnpackedBitmapConcatenator.visit(stream, buffer_index=1)
-    assert list(buffer) == [True, True, False]
-
-
-def test_unpacked_validity_bitmap_concatenator():
-    # All valid
-    src = [na.c_array([1, 2, 3], na.int32()), na.c_array([4, 5, 6], na.int32())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    assert visitor.ValidityBufferConcatenator.visit(stream) is None
-
-    # Only nulls in the first chunk
-    src = [na.c_array([1, None, 3], na.int32()), na.c_array([4, 5, 6], na.int32())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    buffer = visitor.ValidityBufferConcatenator.visit(stream)
-    assert list(buffer) == [True, False, True, True, True, True]
-
-    # Only nulls in the second chunk
-    src = [na.c_array([1, 2, 3], na.int32()), na.c_array([4, None, 6], na.int32())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    buffer = visitor.ValidityBufferConcatenator.visit(stream)
-    assert list(buffer) == [True, True, True, True, False, True]
-
-    # Nulls in both chunks
-    src = [na.c_array([1, None, 3], na.int32()), na.c_array([4, None, 6], na.int32())]
-    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
-    buffer = visitor.ValidityBufferConcatenator.visit(stream)
-    assert list(buffer) == [True, False, True, True, False, True]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import nanoarrow as na
+from nanoarrow import visitor
+
+def test_to_pylist():
+    assert visitor.to_pylist([1, 2, 3], na.int32()) == [1, 2, 3]
+
+def test_to_columms():
+    array = na.c_array_from_buffers(
+        na.struct({"col1": na.int32(), "col2": na.bool_(), "col3": na.string()}),
+        length=3,
+        buffers=[None],
+        children=[
+            na.c_array([1, 2, 3], na.int32()),
+            na.c_array([1, 0, 1], na.bool_()),
+            na.c_array(["abc", "def", "ghi"], na.string()),
+        ],
+    )
+
+    columns = visitor.to_columns(array)
+    assert list(columns.keys()) == ["col1", "col2", "col3"]
+    assert columns["col1"] == [1, 2, 3]
+    assert columns["col2"] == [True, False, True]
+    assert columns["col3"] == ["abc", "def", "ghi"]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -15,11 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from nanoarrow.c_array_stream import CArrayStream
+
 import nanoarrow as na
 from nanoarrow import visitor
 
+
 def test_to_pylist():
     assert visitor.to_pylist([1, 2, 3], na.int32()) == [1, 2, 3]
+
 
 def test_to_columms():
     array = na.c_array_from_buffers(
@@ -38,3 +42,10 @@ def test_to_columms():
     assert columns["col1"] == [1, 2, 3]
     assert columns["col2"] == [True, False, True]
     assert columns["col3"] == ["abc", "def", "ghi"]
+
+
+def test_buffer_concatenator():
+    src = [na.c_array([1, 2, 3], na.int32()), na.c_array([4, 5, 6], na.int32())]
+    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
+    buffer = visitor.BufferConcatenator.visit(stream, buffer_index=1)
+    assert list(buffer) == [1, 2, 3, 4, 5, 6]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -51,8 +51,22 @@ def test_buffer_concatenator():
     assert list(buffer) == [1, 2, 3, 4, 5, 6]
 
 
+def test_buffer_concatenator_with_offsets():
+    src = [na.c_array([1, 2, 3], na.int32())[1:], na.c_array([4, 5, 6], na.int32())[2:]]
+    stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
+    buffer = visitor.BufferConcatenator.visit(stream, buffer_index=1)
+    assert list(buffer) == [2, 3, 6]
+
+
 def test_unpacked_bitmap_concatenator():
     src = [na.c_array([0, 1, 1], na.bool_()), na.c_array([1, 0, 0], na.bool_())]
     stream = CArrayStream.from_array_list(src, na.c_schema(na.bool_()))
     buffer = visitor.UnpackedBitmapConcatenator.visit(stream, buffer_index=1)
     assert list(buffer) == [False, True, True, True, False, False]
+
+
+def test_unpacked_bitmap_concatenator_with_offsets():
+    src = [na.c_array([0, 1, 1], na.bool_())[1:], na.c_array([1, 0, 0], na.bool_())[2:]]
+    stream = CArrayStream.from_array_list(src, na.c_schema(na.bool_()))
+    buffer = visitor.UnpackedBitmapConcatenator.visit(stream, buffer_index=1)
+    assert list(buffer) == [True, True, False]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -39,8 +39,8 @@ def test_to_columms():
 
     columns = visitor.to_columns(array)
     assert list(columns.keys()) == ["col1", "col2", "col3"]
-    assert columns["col1"] == [1, 2, 3]
-    assert columns["col2"] == [True, False, True]
+    assert list(columns["col1"]) == [1, 2, 3]
+    assert list(columns["col2"]) == [True, False, True]
     assert columns["col3"] == ["abc", "def", "ghi"]
 
 

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -49,3 +49,10 @@ def test_buffer_concatenator():
     stream = CArrayStream.from_array_list(src, na.c_schema(na.int32()))
     buffer = visitor.BufferConcatenator.visit(stream, buffer_index=1)
     assert list(buffer) == [1, 2, 3, 4, 5, 6]
+
+
+def test_unpacked_bitmap_concatenator():
+    src = [na.c_array([0, 1, 1], na.bool_()), na.c_array([1, 0, 0], na.bool_())]
+    stream = CArrayStream.from_array_list(src, na.c_schema(na.bool_()))
+    buffer = visitor.UnpackedBitmapConcatenator.visit(stream, buffer_index=1)
+    assert list(buffer) == [False, True, True, True, False, False]


### PR DESCRIPTION
Assembling columns from chunked things is rather difficult to do and is a valid thing that somebody might want to assemble from Arrow data. This PR adds a "visitor" pattern that can be extended to build "column"s, which are currently just `list()`s. Before trimming down this PR to a managable set of changes, I also implemented the visitor that concatenates data buffers for single data buffer types ( https://gist.github.com/paleolimbot/17263e38b5d97c770e44d33b11181eaf ), which will be needed for `to_columns()` to be used in any kind of serious way.

To support the "visitor" pattern, I moved some of the `PyIterator`-specific pieces into the `PyIterator` so that the visitor can re-use the relevant pieces of `ArrayViewBaseIterator`. This pattern also solves one of the problems I had when attempting a "repr" iterator, which is that I was trying to build something rather than iterate over it.

```python
import nanoarrow as na
import pandas as pd
from nanoarrow import visitor

url = "https://github.com/apache/arrow-experiments/raw/main/data/arrow-commits/arrow-commits.arrows"
array = na.ArrayStream.from_url(url).read_all()

# to_columns() doesn't (and won't) produce anything numpy or pandas-related
names, columns = visitor.to_columns(array)

# ..but lets data frames be built rather compactly
pd.DataFrame({k: v for k, v in zip(names, columns)})
```