### PR TITLE
feat(python): Add `Array.from_chunks()` constructor

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2996,6 +2996,9 @@ cdef class CMaterializedArrayStream:
         cdef CMaterializedArrayStream out = CMaterializedArrayStream()
 
         for array in arrays:
+            if not isinstance(array, CArray):
+                raise TypeError(f"Expected CArray but got {type(array).__name__}")
+
             if len(array) == 0:
                 continue
 

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -788,7 +788,7 @@ cdef class CSchema:
             if not child.type_equals(other_child):
                 return False
 
-        if self.dictionary is None != other.dictionary is None:
+        if (self.dictionary is None) != (other.dictionary is None):
             return False
 
         if self.dictionary is not None:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2729,7 +2729,7 @@ cdef class CArrayStream:
         return CArrayStream(base, <uintptr_t>c_array_stream_out)
 
     @staticmethod
-    def from_array_list(arrays, CSchema schema, move=False, validate=True):
+    def from_c_arrays(arrays, CSchema schema, move=False, validate=True):
         cdef ArrowArrayStream* c_array_stream_out
         base = alloc_c_array_stream(&c_array_stream_out)
 
@@ -2949,7 +2949,7 @@ cdef class CMaterializedArrayStream:
     def __arrow_c_stream__(self, requested_schema=None):
         # When an array stream from iterable is supported, that could be used here
         # to avoid unnessary shallow copies.
-        stream = CArrayStream.from_array_list(
+        stream = CArrayStream.from_c_arrays(
             self._arrays,
             self._schema,
             move=False,

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -164,7 +164,36 @@ class Array:
             self._data = CMaterializedArrayStream.from_c_array_stream(stream)
 
     @staticmethod
-    def from_chunks(obj, schema=None, validate=True):
+    def from_chunks(obj: Iterable, schema=None, validate: bool=True):
+        """Create an Array with explicit chunks
+
+        Creates an :class:`Array` with explicit chunking from an iterable of
+        objects that can be converted to a :func:`c_array`.
+
+        Parameters
+        ----------
+        obj : iterable of array-like
+            An iterable of objects that can be passed to :func:`c_array`.
+        schema : schema-like, optional
+            An optional schema. If present, will be passed to :func:`c_array`
+            for each item in obj; if not present it will be inferred from the first
+            chunk.
+        validate : bool
+            Use ``False`` to opt out of validation steps performed when constructing
+            this array.
+
+        Examples
+        --------
+        >>> import nanoarrow as na
+        >>> na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
+        nanoarrow.Array<int32>[6]
+        1
+        2
+        3
+        4
+        5
+        6
+        """
         obj = iter(obj)
 
         if schema is None:

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -301,9 +301,9 @@ class Array:
         >>> import nanoarrow as na
         >>> array = na.Array([1, 2, 3], na.int32())
         >>> for view in array.iter_chunk_views():
-        ...     offset, length = view.offset, view.length
+        ...     offset, length = view.offset, len(view)
         ...     validity, data = view.buffers
-        ...     print(view.offset, view.length)
+        ...     print(offset, length)
         ...     print(validity)
         ...     print(data)
         0 3

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -164,7 +164,7 @@ class Array:
             self._data = CMaterializedArrayStream.from_c_array_stream(stream)
 
     @staticmethod
-    def from_chunks(obj: Iterable, schema=None, validate: bool=True):
+    def from_chunks(obj: Iterable, schema=None, validate: bool = True):
         """Create an Array with explicit chunks
 
         Creates an :class:`Array` with explicit chunking from an iterable of

--- a/python/src/nanoarrow/c_array_stream.py
+++ b/python/src/nanoarrow/c_array_stream.py
@@ -88,7 +88,7 @@ def c_array_stream(obj=None, schema=None) -> CArrayStream:
 
     try:
         array = c_array(obj, schema=schema)
-        return CArrayStream.from_array_list([array], array.schema, validate=False)
+        return CArrayStream.from_c_arrays([array], array.schema, validate=False)
     except Exception as e:
         raise TypeError(
             f"An error occurred whilst converting {type(obj).__name__} "

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -140,7 +140,7 @@ class ArrayViewBaseIterator:
             iterator = cls(stream._get_cached_schema())
             for array in stream:
                 iterator._set_array(array)
-                yield from iterator._iter_chunk(0, array.length)
+                yield from iterator._iter_chunk(0, len(array))
 
     def __init__(self, schema, *, _array_view=None):
         self._schema = c_schema(schema)
@@ -222,7 +222,7 @@ class PyIterator(ArrayViewBaseIterator):
 
     def _dictionary_iter(self, offset, length):
         dictionary = list(
-            self._dictionary._iter_chunk(0, self._dictionary._array_view.length)
+            self._dictionary._iter_chunk(0, len(self._dictionary._array_view))
         )
         for dict_index in self._primitive_iter(offset, length):
             yield None if dict_index is None else dictionary[dict_index]

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -106,7 +106,7 @@ def test_array_empty():
         assert len(arrays) == 0
 
     c_array = na.c_array(array)
-    assert c_array.length == 0
+    assert len(c_array) == 0
     assert c_array.schema.format == "i"
 
 
@@ -153,7 +153,7 @@ def test_array_contiguous():
         assert len(arrays) == 1
 
     c_array = na.c_array(array)
-    assert c_array.length == 3
+    assert len(c_array) == 3
     assert c_array.schema.format == "i"
 
 
@@ -233,7 +233,7 @@ def test_scalar_to_array():
     assert scalar.device is array.device
     as_array = na.c_array(scalar)
     assert as_array.offset == 1
-    assert as_array.length == 1
+    assert len(as_array) == 1
     assert as_array.buffers == na.c_array(array).buffers
 
     with pytest.raises(NotImplementedError):

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -67,6 +67,18 @@ def test_array_from_chunks():
         na.Array.from_chunks([])
 
 
+def test_array_from_chunks_validate():
+    chunks = [na.c_array([1, 2, 3], na.uint32()), na.c_array([1, 2, 3], na.int32())]
+    # Check that we get validation by default
+    msg = "Expected schema uint32 but got int32"
+    with pytest.raises(ValueError, match=msg):
+        na.Array.from_chunks(chunks)
+
+    # ...but that one can opt out
+    array = na.Array.from_chunks(chunks, validate=False)
+    assert list(array.iter_py()) == [1, 2, 3, 1, 2, 3]
+
+
 def test_array_empty():
     array = na.Array([], na.int32())
     assert array.schema.type == na.Type.INT32

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -70,8 +70,7 @@ def test_array_from_chunks():
 def test_array_from_chunks_validate():
     chunks = [na.c_array([1, 2, 3], na.uint32()), na.c_array([1, 2, 3], na.int32())]
     # Check that we get validation by default
-    msg = "Expected schema uint32 but got int32"
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError, match="Expected schema"):
         na.Array.from_chunks(chunks)
 
     # ...but that one can opt out

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -125,7 +125,7 @@ def test_array_contiguous():
 def test_array_chunked():
     src = [na.c_array([1, 2, 3], na.int32()), na.c_array([4, 5, 6], na.int32())]
 
-    array = na.Array(CArrayStream.from_array_list(src, na.c_schema(na.int32())))
+    array = na.Array(CArrayStream.from_c_arrays(src, na.c_schema(na.int32())))
     assert array.schema.type == na.Type.INT32
     assert len(array) == 6
 
@@ -176,7 +176,7 @@ def test_array_children():
         children=[na.c_array([123456], na.int32())] * 100,
     )
     src = [c_array, c_array]
-    array = na.Array(CArrayStream.from_array_list(src, c_array.schema))
+    array = na.Array(CArrayStream.from_c_arrays(src, c_array.schema))
 
     assert array.n_children == 100
     assert array.child(0).schema.type == na.Type.INT32

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -43,6 +43,30 @@ def test_array_alias_constructor():
     assert array.schema.type == na.Type.INT32
 
 
+def test_array_from_chunks():
+    # Check with explicit schema
+    array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
+    assert array.schema.type == na.Type.INT32
+    assert array.n_chunks == 2
+    assert list(array.iter_py()) == [1, 2, 3, 4, 5, 6]
+
+    # Check with schema inferred from first chunk
+    array = na.Array.from_chunks(array.iter_chunks())
+    assert array.schema.type == na.Type.INT32
+    assert array.n_chunks == 2
+    assert list(array.iter_py()) == [1, 2, 3, 4, 5, 6]
+
+    # Check empty
+    array = na.Array.from_chunks([], na.int32())
+    assert array.schema.type == na.Type.INT32
+    assert len(array) == 0
+    assert array.n_chunks == 0
+
+    msg = "Can't create empty Array from chunks without schema"
+    with pytest.raises(ValueError, match=msg):
+        na.Array.from_chunks([])
+
+
 def test_array_empty():
     array = na.Array([], na.int32())
     assert array.schema.type == na.Type.INT32

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -23,12 +23,12 @@ import nanoarrow as na
 
 def test_c_array_stream_from_c_array_stream():
     # Wrapping an existing stream is a no-op
-    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    array_stream = CArrayStream.from_c_arrays([], na.c_schema(na.int32()))
     stream_from_stream = na.c_array_stream(array_stream)
     assert stream_from_stream is array_stream
 
     # With requested_schema should go through capsule
-    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    array_stream = CArrayStream.from_c_arrays([], na.c_schema(na.int32()))
     with pytest.raises(NotImplementedError):
         na.c_array_stream(array_stream, na.int64())
 
@@ -42,7 +42,7 @@ def test_c_array_stream_from_capsule_protocol():
         def __arrow_c_stream__(self, *args, **kwargs):
             return self.obj.__arrow_c_stream__(*args, **kwargs)
 
-    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    array_stream = CArrayStream.from_c_arrays([], na.c_schema(na.int32()))
     array_stream_wrapper = CArrayStreamWrapper(array_stream)
     from_protocol = na.c_array_stream(array_stream_wrapper)
     assert array_stream.is_valid() is False
@@ -69,14 +69,14 @@ def test_c_array_stream_from_old_pyarrow():
 
 
 def test_c_array_stream_from_bare_capsule():
-    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    array_stream = CArrayStream.from_c_arrays([], na.c_schema(na.int32()))
 
     # Check from bare capsule without supplying a schema
     capsule = array_stream.__arrow_c_stream__()
     from_capsule = na.c_array_stream(capsule)
     assert from_capsule.get_schema().format == "i"
 
-    array_stream = CArrayStream.from_array_list([], na.c_schema(na.int32()))
+    array_stream = CArrayStream.from_c_arrays([], na.c_schema(na.int32()))
     capsule = array_stream.__arrow_c_stream__()
 
     with pytest.raises(TypeError, match="Can't import c_array_stream"):
@@ -108,13 +108,13 @@ def test_c_array_stream_error():
 def test_array_stream_from_arrays_schema():
     schema_in = na.c_schema(na.int32())
 
-    stream = CArrayStream.from_array_list([], schema_in)
+    stream = CArrayStream.from_c_arrays([], schema_in)
     assert schema_in.is_valid()
     assert list(stream) == []
     assert stream.get_schema().format == "i"
 
     # Check move of schema
-    CArrayStream.from_array_list([], schema_in, move=True)
+    CArrayStream.from_c_arrays([], schema_in, move=True)
     assert schema_in.is_valid() is False
     assert stream.get_schema().format == "i"
 
@@ -124,14 +124,14 @@ def test_array_stream_from_arrays():
     array_in = na.c_array([1, 2, 3], na.int32())
     array_in_buffers = array_in.buffers
 
-    stream = CArrayStream.from_array_list([array_in], schema_in)
+    stream = CArrayStream.from_c_arrays([array_in], schema_in)
     assert array_in.is_valid()
     arrays = list(stream)
     assert len(arrays) == 1
     assert arrays[0].buffers == array_in_buffers
 
     # Check move of array
-    stream = CArrayStream.from_array_list([array_in], schema_in, move=True)
+    stream = CArrayStream.from_c_arrays([array_in], schema_in, move=True)
     assert array_in.is_valid() is False
     arrays = list(stream)
     assert len(arrays) == 1
@@ -143,7 +143,7 @@ def test_array_stream_from_arrays_validate():
     array_in = na.c_array([1, 2, 3], na.int32())
 
     # Check that we can skip validation and proceed without error
-    stream = CArrayStream.from_array_list([array_in], schema_in, validate=False)
+    stream = CArrayStream.from_c_arrays([array_in], schema_in, validate=False)
     arrays = list(stream)
     assert len(arrays) == 1
     assert arrays[0].n_buffers == 2
@@ -151,4 +151,4 @@ def test_array_stream_from_arrays_validate():
     # ...but that validation does happen by default
     msg = "Expected schema na but got int32"
     with pytest.raises(ValueError, match=msg):
-        CArrayStream.from_array_list([array_in], schema_in)
+        CArrayStream.from_c_arrays([array_in], schema_in)

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -149,6 +149,5 @@ def test_array_stream_from_arrays_validate():
     assert arrays[0].n_buffers == 2
 
     # ...but that validation does happen by default
-    msg = "Expected schema na but got int32"
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ValueError, match="Expected schema"):
         CArrayStream.from_c_arrays([array_in], schema_in)

--- a/python/tests/test_c_array_stream.py
+++ b/python/tests/test_c_array_stream.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import pytest
-from nanoarrow._lib import NanoarrowException
 from nanoarrow.c_array_stream import CArrayStream
 
 import nanoarrow as na
@@ -122,7 +121,7 @@ def test_array_stream_from_arrays_schema():
 
 def test_array_stream_from_arrays():
     schema_in = na.c_schema(na.int32())
-    array_in = na.c_array([1, 2, 3], schema_in)
+    array_in = na.c_array([1, 2, 3], na.int32())
     array_in_buffers = array_in.buffers
 
     stream = CArrayStream.from_array_list([array_in], schema_in)
@@ -150,6 +149,6 @@ def test_array_stream_from_arrays_validate():
     assert arrays[0].n_buffers == 2
 
     # ...but that validation does happen by default
-    msg = "Expected array with 0 buffer"
-    with pytest.raises(NanoarrowException, match=msg):
+    msg = "Expected schema na but got int32"
+    with pytest.raises(ValueError, match=msg):
         CArrayStream.from_array_list([array_in], schema_in)

--- a/python/tests/test_c_schema.py
+++ b/python/tests/test_c_schema.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import pytest
-from nanoarrow.c_schema import allocate_c_schema, c_schema_view
+from nanoarrow.c_schema import CSchema, allocate_c_schema, c_schema_view
 
 import nanoarrow as na
 
@@ -164,6 +164,21 @@ def test_c_schema_equals():
 
     # Check inequality because of dictionary value type
     assert dictionary.type_equals(dictionary.modify(dictionary=struct)) is False
+
+
+def test_c_schema_assert_type_equal():
+    int32 = na.c_schema(na.int32())
+    string = na.c_schema(na.string())
+
+    with pytest.raises(TypeError):
+        CSchema.assert_type_equal(None, int32)
+
+    with pytest.raises(TypeError):
+        CSchema.assert_type_equal(int32, None)
+
+    msg = "Expected schema\n  'string'\nbut got\n  'int32'"
+    with pytest.raises(ValueError, match=msg):
+        CSchema.assert_type_equal(int32, string)
 
 
 def test_c_schema_modify():

--- a/python/tests/test_c_schema.py
+++ b/python/tests/test_c_schema.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import pytest
-from nanoarrow.c_schema import CSchema, allocate_c_schema, c_schema_view
+from nanoarrow.c_schema import allocate_c_schema, c_schema_view
 
 import nanoarrow as na
 
@@ -131,6 +131,9 @@ def test_c_schema_equals():
     int32 = na.c_schema(na.int32())
     struct = na.c_schema(na.struct({"col1": na.int32()}))
     dictionary = na.c_schema(na.dictionary(na.int32(), na.string()))
+    ordered_dictionary = na.c_schema(
+        na.dictionary(na.int32(), na.string(), dictionary_ordered=True)
+    )
 
     # Check schemas pointing to the same ArrowSchema
     assert int32.type_equals(int32)
@@ -143,8 +146,13 @@ def test_c_schema_equals():
     # Check inequality because of format
     assert int32.type_equals(struct) is False
 
-    # Check inequality because of flags
-    assert int32.type_equals(int32.modify(flags=0)) is False
+    # Check inequality because of nullability
+    assert int32.type_equals(int32.modify(flags=0), check_nullability=True) is False
+    # ...but not by default
+    assert int32.type_equals(int32.modify(flags=0)) is True
+
+    # Check inequality of type information encoded in flags
+    assert dictionary.type_equals(ordered_dictionary) is False
 
     # Check inequality because of number of children
     assert struct.type_equals(struct.modify(children=[])) is False
@@ -167,18 +175,20 @@ def test_c_schema_equals():
 
 
 def test_c_schema_assert_type_equal():
+    from nanoarrow._lib import assert_type_equal
+
     int32 = na.c_schema(na.int32())
     string = na.c_schema(na.string())
 
     with pytest.raises(TypeError):
-        CSchema.assert_type_equal(None, int32)
+        assert_type_equal(None, int32)
 
     with pytest.raises(TypeError):
-        CSchema.assert_type_equal(int32, None)
+        assert_type_equal(int32, None)
 
     msg = "Expected schema\n  'string'\nbut got\n  'int32'"
     with pytest.raises(ValueError, match=msg):
-        CSchema.assert_type_equal(int32, string)
+        assert_type_equal(int32, string)
 
 
 def test_c_schema_modify():

--- a/python/tests/test_capsules.py
+++ b/python/tests/test_capsules.py
@@ -74,7 +74,7 @@ def test_array():
         array = na.c_array(arr_obj)
         # some basic validation
         assert array.is_valid()
-        assert array.length == 3
+        assert len(array) == 3
         assert array.schema._to_string(recursive=True) == "int32"
 
         # roundtrip
@@ -98,7 +98,7 @@ def test_array_stream():
         # some basic validation
         assert array_stream.is_valid()
         array = array_stream.get_next()
-        assert array.length == 3
+        assert len(array) == 3
         assert (
             array_stream.get_schema()._to_string(recursive=True)
             == "struct<some_column: int32>"

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -43,12 +43,12 @@ def test_c_device_array():
 
     assert darray.schema.format == "i"
 
-    assert darray.array.length == 3
+    assert len(darray.array) == 3
     assert darray.array.device_type == device.cpu().device_type
     assert darray.array.device_id == device.cpu().device_id
 
     darray_view = darray.view()
-    assert darray_view.length == 3
+    assert len(darray_view) == 3
     assert list(darray_view.buffer(1)) == [1, 2, 3]
 
     # A CDeviceArray should be returned as is
@@ -75,7 +75,7 @@ def test_c_device_array_protocol():
 
     darray2 = device.c_device_array(wrapper)
     assert darray2.schema.format == "i"
-    assert darray2.array.length == 3
+    assert len(darray2.array) == 3
     assert darray2.array.buffers == darray.array.buffers
 
     with pytest.raises(NotImplementedError):

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -62,7 +62,7 @@ def test_ipc_stream_from_readable():
             with na.c_array_stream(input) as stream:
                 batches = list(stream)
                 assert len(batches) == 1
-                assert batches[0].length == 3
+                assert len(batches[0]) == 3
 
 
 def test_ipc_stream_from_path():
@@ -76,7 +76,7 @@ def test_ipc_stream_from_path():
             with na.c_array_stream(input) as stream:
                 batches = list(stream)
                 assert len(batches) == 1
-                assert batches[0].length == 3
+                assert len(batches[0]) == 3
 
 
 def test_ipc_stream_from_url():
@@ -90,7 +90,7 @@ def test_ipc_stream_from_url():
             with na.c_array_stream(input) as stream:
                 batches = list(stream)
                 assert len(batches) == 1
-                assert batches[0].length == 3
+                assert len(batches[0]) == 3
 
 
 def test_ipc_stream_python_exception_on_read():

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -89,6 +89,7 @@ def test_c_array():
     array = na.c_array(pa.array([1, 2, 3], pa.int32()))
     assert array.is_valid() is True
     assert array.length == 3
+    assert len(array) == 3
     assert array.offset == 0
     assert array.null_count == 0
     assert array.n_buffers == 2


### PR DESCRIPTION
This PR adds a public route to construct chunked arrays (and makes the other constructors safer to account for the fact that they are now user-facing). I use this quite a lot interactively to test that things work in the chunked case, and for nanoarrow to be useful in a "I can help you export things" kind of way, it needs to be able to do this (because string arrays with more than 2 GB of text or binary are not uncommon).

The main safety consideration here is ensuring that all chunks have a schema of the same type, so I had to add a function to check for that (and ensure it was being checked).

```python
import nanoarrow as na
import numpy as np

na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
na.Array.from_chunks((np.random.random(int(1e3)) for _ in range(int(1e3))))
```