### PR TITLE
feat(python): Ensure that buffer produced by `CBufferView.unpack_bits()` has a boolean type

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -335,7 +335,7 @@ cdef c_arrow_type_from_format(format):
         return item_size, NANOARROW_TYPE_DOUBLE
 
     # Check for signed integers
-    if format in ("b", "?", "h", "i", "l", "q", "n"):
+    if format in ("b", "h", "i", "l", "q", "n"):
         if item_size == 1:
             return item_size, NANOARROW_TYPE_INT8
         elif item_size == 2:
@@ -346,7 +346,7 @@ cdef c_arrow_type_from_format(format):
             return item_size, NANOARROW_TYPE_INT64
 
     # Check for unsinged integers
-    if format in ("B", "H", "I", "L", "Q", "N"):
+    if format in ("B", "?", "H", "I", "L", "Q", "N"):
         if item_size == 1:
             return item_size, NANOARROW_TYPE_UINT8
         elif item_size == 2:
@@ -1910,7 +1910,7 @@ cdef class CBufferView:
         if length is None:
             length = self.n_elements
 
-        out = CBufferBuilder().set_data_type(NANOARROW_TYPE_UINT8)
+        out = CBufferBuilder().set_format("?")
         out.reserve_bytes(length)
         self.unpack_bits_into(out, offset, length)
         out.advance(length)
@@ -2192,6 +2192,13 @@ cdef class CBufferBuilder:
     def set_data_type(self, ArrowType type_id, int element_size_bits=0):
         """Set the data type used to interpret elements in :meth:`write_elements`."""
         self._buffer._set_data_type(type_id, element_size_bits)
+        return self
+
+    def set_format(self, str format):
+        """Set the Python buffer format used to interpret elements in
+        :meth:`write_elements`.
+        """
+        self._buffer._set_format(format)
         return self
 
     @property

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2030,6 +2030,8 @@ cdef class CBuffer:
             self._device
         )
 
+        snprintf(self._view._format, sizeof(self._view._format), "%s", self._format)
+
     @staticmethod
     def empty():
         cdef CBuffer out = CBuffer()

--- a/python/tests/test_c_buffer_view.py
+++ b/python/tests/test_c_buffer_view.py
@@ -72,6 +72,7 @@ def test_buffer_view_bool_unpack():
     unpacked_all = view.unpack_bits()
     assert len(unpacked_all) == view.n_elements
     assert unpacked_all.data_type == "uint8"
+    assert unpacked_all.format == "?"
     assert list(unpacked_all) == [1, 0, 0, 1, 0, 0, 0, 0]
 
     unpacked_some = view.unpack_bits(1, 4)


### PR DESCRIPTION
This is small change to ensure that `np.array(some_buffer.unpack_bits())` "just works" without nanoarrow having to know about numpy dtypes. Basically we just need to ensure that we can create/export a buffer with a `"?"` format string.

```python
import nanoarrow as na
import numpy as np

bool_array = na.Array([True, True, True, False, False, True], na.bool_())
np.array(bool_array.buffer(1).unpack_bits(0, len(bool_array)))
#> array([ True,  True,  True, False, False,  True])
```