### PR TITLE
fix!: Change `ArrowBufferResize()` and `ArrowBitmapResize()` to update `size_bytes`

### DIFF
--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -528,8 +528,8 @@ TEST(BitmapTest, BitmapTestResize) {
 
   // Check normal usage, which is resize to the final length
   // after appending a bunch of values
-  ASSERT_EQ(ArrowBitmapResize(&bitmap, 200, false), NANOARROW_OK);
-  EXPECT_EQ(bitmap.buffer.size_bytes, 200 / 8);
+  ASSERT_EQ(ArrowBitmapReserve(&bitmap, 200), NANOARROW_OK);
+  EXPECT_EQ(bitmap.buffer.size_bytes, 0);
   EXPECT_EQ(bitmap.buffer.capacity_bytes, 200 / 8);
   EXPECT_EQ(bitmap.size_bits, 0);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -620,14 +620,12 @@ static inline void ArrowBufferReset(struct ArrowBuffer* buffer);
 /// address and resets buffer.
 static inline void ArrowBufferMove(struct ArrowBuffer* src, struct ArrowBuffer* dst);
 
-/// \brief Grow or shrink a buffer to a given capacity
+/// \brief Grow or shrink a buffer to a given size
 ///
 /// When shrinking the capacity of the buffer, the buffer is only reallocated
-/// if shrink_to_fit is non-zero. Calling ArrowBufferResize() does not
-/// adjust the buffer's size member except to ensure that the invariant
-/// capacity >= size remains true.
+/// if shrink_to_fit is non-zero.
 static inline ArrowErrorCode ArrowBufferResize(struct ArrowBuffer* buffer,
-                                               int64_t new_capacity_bytes,
+                                               int64_t new_size_bytes,
                                                char shrink_to_fit);
 
 /// \brief Ensure a buffer has at least a given additional capacity


### PR DESCRIPTION
Currently, `ArrowBufferResize()` and `ArrowBitmapResize()` update the *capacity* of the underlying buffer but do not update the *size*. This was documented and is consistent with Arrow C++'s `BufferBuilder` but inconsistent with `std::vector`, Arrow C++'s `PoolBuffer`, and user expectations given the name of the function.

After this PR, `ArrowBufferResize()` and `ArrowBitmapResize()` update the `size_bytes` of the underlying buffer.

This is a breaking change.