### PR TITLE
feat(python): Add column-wise buffer builder

### DIFF
--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -72,7 +72,7 @@ from nanoarrow.schema import (
 )
 from nanoarrow.array import array, Array
 from nanoarrow.array_stream import ArrayStream
-from nanoarrow.visitor import nulls_as_sentinel, nulls_forbid
+from nanoarrow.visitor import nulls_as_sentinel, nulls_forbid, nulls_separate
 from nanoarrow._version import __version__  # noqa: F401
 
 # Helps Sphinx automatically populate an API reference section
@@ -116,6 +116,7 @@ __all__ = [
     "null",
     "nulls_as_sentinel",
     "nulls_forbid",
+    "nulls_separate",
     "string",
     "struct",
     "schema",

--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -72,6 +72,7 @@ from nanoarrow.schema import (
 )
 from nanoarrow.array import array, Array
 from nanoarrow.array_stream import ArrayStream
+from nanoarrow.visitor import nulls_as_sentinel, nulls_forbid
 from nanoarrow._version import __version__  # noqa: F401
 
 # Helps Sphinx automatically populate an API reference section
@@ -113,6 +114,8 @@ __all__ = [
     "large_list",
     "list_",
     "null",
+    "nulls_as_sentinel",
+    "nulls_forbid",
     "string",
     "struct",
     "schema",

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1009,6 +1009,11 @@ cdef class CSchemaView:
         if self.extension_name or self._schema_view.type != self._schema_view.storage_type:
             return None
 
+        # String/binary types do not have format strings as far as the Python
+        # buffer protocol is concerned
+        if self.layout.n_buffers != 2:
+            return None
+
         cdef char out[128]
         cdef int element_size_bits = 0
         if self._schema_view.type == NANOARROW_TYPE_FIXED_SIZE_BINARY:

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -1885,7 +1885,7 @@ cdef class CBufferView:
         return self._format.decode("UTF-8")
 
     @property
-    def item_size(self):
+    def itemsize(self):
         return self._strides
 
     def __len__(self):
@@ -1973,7 +1973,7 @@ cdef class CBufferView:
 
         cdef int64_t c_offset = offset
         cdef int64_t c_length = length
-        cdef int64_t c_item_size = self.item_size
+        cdef int64_t c_item_size = self.itemsize
         cdef int64_t c_dest_offset = dest_offset
         self._check_copy_into_bounds(&buffer, c_offset, c_length, dest_offset, c_item_size)
 
@@ -2026,7 +2026,7 @@ cdef class CBufferView:
         if length is None:
             length = self.n_elements
 
-        cdef int64_t bytes_to_copy = length * self.item_size
+        cdef int64_t bytes_to_copy = length * self.itemsize
         out = CBufferBuilder().set_data_type(self.data_type_id)
         out.reserve_bytes(bytes_to_copy)
         self.copy_into(out, offset, length)
@@ -2240,9 +2240,9 @@ cdef class CBuffer:
         return self._element_size_bits
 
     @property
-    def item_size(self):
+    def itemsize(self):
         self._assert_valid()
-        return self._view.item_size
+        return self._view.itemsize
 
     @property
     def format(self):
@@ -2354,6 +2354,13 @@ cdef class CBufferBuilder:
     def size_bytes(self):
         """The number of bytes that have been written to this buffer"""
         return self._buffer.size_bytes
+
+    @property
+    def itemsize(self):
+        return self._buffer.itemsize
+
+    def __len__(self):
+        return self._buffer.size_bytes // self.itemsize
 
     @property
     def capacity_bytes(self):

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -377,7 +377,7 @@ class Array:
         >>> names
         ['col1']
         >>> columns
-        [[1, 2, 3]]
+        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
         """
         return to_columns(self)
 

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -17,7 +17,7 @@
 
 import itertools
 from functools import cached_property
-from typing import Iterable, List, Sequence, Tuple
+from typing import Iterable, Tuple
 
 from nanoarrow._lib import (
     DEVICE_CPU,
@@ -32,7 +32,7 @@ from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.c_schema import c_schema
 from nanoarrow.iterator import iter_array_views, iter_py, iter_tuples
 from nanoarrow.schema import Schema, _schema_repr
-from nanoarrow.visitor import to_columns, to_pylist
+from nanoarrow.visitor import ArrayViewVisitable
 
 from nanoarrow import _repr_utils
 
@@ -106,7 +106,7 @@ class Scalar:
         return array.__arrow_c_array__(requested_schema=requested_schema)
 
 
-class Array:
+class Array(ArrayViewVisitable):
     """High-level in-memory Array representation
 
     The Array is nanoarrow's high-level in-memory array representation whose
@@ -344,42 +344,6 @@ class Array:
         nanoarrow.c_lib.CBufferView(int32[12 b] 1 2 3)
         """
         return iter_array_views(self)
-
-    def to_pylist(self) -> List:
-        """Convert this Array to a ``list()` of Python objects
-
-        Computes an identical value to list(:meth:`iter_py`) but can be several
-        times faster.
-
-        Examples
-        --------
-
-        >>> import nanoarrow as na
-        >>> array = na.Array([1, 2, 3], na.int32())
-        >>> array.to_pylist()
-        [1, 2, 3]
-        """
-        return to_pylist(self)
-
-    def to_columns(self) -> Tuple[str, Sequence]:
-        """Convert this Array to a ``list()` of sequences
-
-        Converts a stream of struct arrays into its column-wise representation
-        such that each column is either a contiguous buffer or a ``list()``.
-
-        Examples
-        --------
-
-        >>> import nanoarrow as na
-        >>> import pyarrow as pa
-        >>> array = na.Array(pa.record_batch([pa.array([1, 2, 3])], names=["col1"]))
-        >>> names, columns = array.to_columns()
-        >>> names
-        ['col1']
-        >>> columns
-        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
-        """
-        return to_columns(self)
 
     @property
     def n_children(self) -> int:

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from functools import cached_property
-from typing import Iterable, List, Sequence, Tuple
+from typing import Iterable, Tuple
 
 from nanoarrow._lib import CMaterializedArrayStream
 from nanoarrow._repr_utils import make_class_label
@@ -24,10 +24,10 @@ from nanoarrow.array import Array
 from nanoarrow.c_array_stream import c_array_stream
 from nanoarrow.iterator import iter_py, iter_tuples
 from nanoarrow.schema import Schema, _schema_repr
-from nanoarrow.visitor import to_columns, to_pylist
+from nanoarrow.visitor import ArrayViewVisitable
 
 
-class ArrayStream:
+class ArrayStream(ArrayViewVisitable):
     """High-level ArrayStream representation
 
     The ArrayStream is nanoarrow's high-level representation of zero
@@ -198,43 +198,6 @@ class ArrayStream:
         (3, 'c')
         """
         return iter_tuples(self)
-
-    def to_pylist(self) -> List:
-        """Convert this Array to a ``list()` of Python objects
-
-        Computes an identical value to list(:meth:`iter_py`) but can be several
-        times faster.
-
-        Examples
-        --------
-
-        >>> import nanoarrow as na
-        >>> stream = na.ArrayStream([1, 2, 3], na.int32())
-        >>> stream.to_pylist()
-        [1, 2, 3]
-        """
-        return to_pylist(self)
-
-    def to_columns(self) -> Tuple[str, Sequence]:
-        """Convert this Array to a ``list()` of sequences
-
-        Converts a stream of struct arrays into its column-wise representation
-        such that each column is either a contiguous buffer or a ``list()``.
-
-        Examples
-        --------
-
-        >>> import nanoarrow as na
-        >>> import pyarrow as pa
-        >>> batch = pa.record_batch([pa.array([1, 2, 3])], names=["col1"])
-        >>> stream = na.ArrayStream(batch)
-        >>> names, columns = stream.to_columns()
-        >>> names
-        ['col1']
-        >>> columns
-        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
-        """
-        return to_columns(self)
 
     def __repr__(self) -> str:
         cls = make_class_label(self, "nanoarrow")

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -232,7 +232,7 @@ class ArrayStream:
         >>> names
         ['col1']
         >>> columns
-        [[1, 2, 3]]
+        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
         """
         return to_columns(self)
 

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -156,10 +156,7 @@ class ArrayViewBaseIterator:
             return f"<unnamed {self._schema_view.type}>"
 
     def _contains_nulls(self):
-        return (
-            self._schema_view.nullable
-            and self._array_view.null_count != 0
-        )
+        return self._schema_view.nullable and self._array_view.null_count != 0
 
     def _set_array(self, array):
         self._array_view._set_array(array)

--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -158,7 +158,6 @@ class ArrayViewBaseIterator:
     def _contains_nulls(self):
         return (
             self._schema_view.nullable
-            and len(self._array_view.buffer(0))
             and self._array_view.null_count != 0
         )
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -135,8 +135,8 @@ def nulls_as_sentinel(sentinel=None):
 
     A null handler that assigns a sentinel to null values. This is
     done using numpy using the expression ``data[~is_valid] = sentinel``.
-    The default sentinel value of ``None`` will result in ``nan``
-    assigned to null values in numeric and boolean outputs. This
+    The default sentinel value of ``None`` will result in float output and ``nan``
+    assigned to null values for numeric and boolean inputs. This
     corresponds to numpy's handling of ``None`` in ``np.result_type()``
     and ``result[~is_valid] = None``.
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -66,12 +66,12 @@ class ArrayViewVisitable:
 
         >>> import nanoarrow as na
         >>> import pyarrow as pa
-        >>> batch = pa.record_batch([pa.array([1, 2, 3])], names=["col1"])
+        >>> batch = pa.record_batch({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
         >>> names, columns = na.Array(batch).to_column_list()
         >>> names
-        ['col1']
+        ['col1', 'col2']
         >>> columns
-        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
+        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3), ['a', 'b', 'c']]
         """
         return ColumnsBuilder.visit(self, handle_nulls=handle_nulls)
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -59,7 +59,8 @@ class ArrayViewVisitable:
         handle_nulls : callable
             A function returning a sequence based on a validity bytemap and a
             contiguous buffer of values (e.g., the callable returned by
-            :meth:`nulls_as_sentinel`).
+            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, or
+            :func:`nulls_separate`). The default value is :func:`nulls_forbid`.
 
         Examples
         --------
@@ -90,7 +91,8 @@ class ArrayViewVisitable:
         handle_nulls : callable
             A function returning a sequence based on a validity bytemap and a
             contiguous buffer of values (e.g., the callable returned by
-            :meth:`nulls_as_sentinel`).
+            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, or
+            :func:`nulls_separate`). The default value is :func:`nulls_forbid`.
 
         Examples
         --------

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -84,6 +84,8 @@ def nulls_forbid() -> Callable[[CBuffer, Sequence], Sequence]:
         if len(is_valid) > 0:
             raise ValueError("Null present with null_handler=nulls_forbid()")
 
+        return data
+
     return handle
 
 
@@ -95,7 +97,7 @@ def nulls_debug() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
 
 
 def nulls_as_sentinel(sentinel=None):
-    from numpy import array, nan
+    from numpy import array, nan, result_type
 
     if sentinel is None:
         sentinel = nan
@@ -105,9 +107,12 @@ def nulls_as_sentinel(sentinel=None):
         data = array(data, copy=False)
 
         if len(is_valid) > 0:
+            out_type = result_type(data, sentinel)
+            data = array(data, dtype=out_type, copy=True)
             data[~is_valid] = sentinel
-
-        return data
+            return data
+        else:
+            return data
 
     return handle
 
@@ -123,7 +128,7 @@ def nulls_as_masked_array():
         if len(is_valid) > 0:
             return masked_array(data, ~is_valid)
         else:
-            data
+            return data
 
     return handle
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -86,9 +86,7 @@ class ArrayViewVisitable:
         designed to work as input to ``pandas.Series`` and/or ``numpy.array()``.
 
         Parameters
-        ---------
-        schema : schema-like, optional
-            An optional schema, passed to :func:`c_array_stream`.
+        ----------
         handle_nulls : callable
             A function returning a sequence based on a validity bytemap and a
             contiguous buffer of values (e.g., the callable returned by

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -158,10 +158,10 @@ def nulls_as_sentinel(sentinel=None):
     import numpy as np
 
     def handle(is_valid, data):
-        is_valid = np.array(is_valid, copy=False)
         data = np.array(data, copy=False)
 
-        if len(is_valid) > 0:
+        if is_valid is not None:
+            is_valid = np.array(is_valid, copy=False)
             out_type = np.result_type(data, sentinel)
             data = np.array(data, dtype=out_type, copy=True)
             data[~is_valid] = sentinel

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -75,7 +75,7 @@ def to_columns(obj, schema=None, handle_nulls=None) -> Tuple[List[str], List[Seq
     >>> names
     ['col1']
     >>> columns
-    [[1, 2, 3]]
+    [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
     """
     return ColumnsBuilder.visit(obj, schema, handle_nulls=handle_nulls)
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -47,11 +47,11 @@ class ArrayViewVisitable:
         """
         return ListConverter.visit(self)
 
-    def to_column_list(self, handle_nulls=None) -> Tuple[List[str], List[Sequence]]:
+    def convert_columns(self, handle_nulls=None) -> Tuple[List[str], List[Sequence]]:
         """Convert to a ``list`` of contiguous sequences
 
         Converts a stream of struct arrays into its column-wise representation
-        according to :meth:`to_column`.
+        according to :meth:`convert`.
 
         Paramters
         ---------
@@ -67,7 +67,7 @@ class ArrayViewVisitable:
         >>> import nanoarrow as na
         >>> import pyarrow as pa
         >>> batch = pa.record_batch({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
-        >>> names, columns = na.Array(batch).to_column_list()
+        >>> names, columns = na.Array(batch).convert_columns()
         >>> names
         ['col1', 'col2']
         >>> columns

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -121,6 +121,7 @@ def nulls_forbid() -> Callable[[CBuffer, Sequence], Sequence]:
     """
 
     def handle(is_valid, data):
+        # the is_valid bytemap is only created if there was at least one null
         if is_valid is not None:
             raise ValueError("Null present with null_handler=nulls_forbid()")
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -134,8 +134,10 @@ def nulls_as_sentinel(sentinel=None):
 
     A null handler that assigns a sentinel to null values. This is
     done using numpy using the expression ``data[~is_valid] = sentinel``.
-    The default sentinel value will result in ``nan`` assigned to null
-    values in numeric and boolean outputs.
+    The default sentinel value of ``None`` will result in ``nan``
+    assigned to null values in numeric and boolean outputs. This
+    corresponds to numpy's handling of ``None`` in ``np.result_type()``
+    and ``result[~is_valid] = None``.
 
     Parameters
     ----------

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -75,7 +75,7 @@ class ArrayViewVisitable:
         >>> columns
         [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3), ['a', 'b', 'c']]
         """
-        return ToColumnListConverter.visit(self, handle_nulls=handle_nulls)
+        return ToColumnsPysequenceConverter.visit(self, handle_nulls=handle_nulls)
 
     def to_pysequence(self, *, handle_nulls=None) -> Sequence:
         """Convert to a contiguous sequence
@@ -265,7 +265,7 @@ class ToPySequenceConverter(ArrayViewVisitor):
         return self._visitor.finish()
 
 
-class ToColumnListConverter(ArrayViewVisitor):
+class ToColumnsPysequenceConverter(ArrayViewVisitor):
     def __init__(self, schema, handle_nulls=None, *, array_view=None):
         super().__init__(schema, array_view=array_view)
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -222,9 +222,11 @@ class BooleanColumnBuilder(ArrayStreamVisitor):
 
 
 class NullableColumnBuilder(ArrayStreamVisitor):
-    def __init__(self, schema, column_builder_cls, *, array_view=None):
+    def __init__(
+        self, schema, column_builder_cls=BufferColumnBuilder, *, array_view=None
+    ):
         super().__init__(schema, array_view=array_view)
-        self._column_builder = column_builder_cls(schema, array_view=None)
+        self._column_builder = column_builder_cls(schema, array_view=self._array_view)
 
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
@@ -258,8 +260,7 @@ class NullableColumnBuilder(ArrayStreamVisitor):
         self._column_builder.visit_chunk_view(array_view)
 
     def finish(self) -> Any:
-
-        return self._column_builder
+        return self._builder.finish(), self._column_builder.finish()
 
     def _fill_valid(self, length):
         builder = self._builder

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -37,7 +37,7 @@ class ArrayViewVisitable:
         >>> import nanoarrow as na
         >>> from nanoarrow import visitor
         >>> array = na.Array([1, 2, 3], na.int32())
-        >>> array.to_pylist(array)
+        >>> array.to_pylist()
         [1, 2, 3]
         """
         return ListBuilder.visit(self)
@@ -61,7 +61,7 @@ class ArrayViewVisitable:
         >>> import nanoarrow as na
         >>> import pyarrow as pa
         >>> batch = pa.record_batch([pa.array([1, 2, 3])], names=["col1"])
-        >>> names, columns = na.Array(batch).to_column_list(array)
+        >>> names, columns = na.Array(batch).to_column_list()
         >>> names
         ['col1']
         >>> columns
@@ -94,8 +94,8 @@ class ArrayViewVisitable:
         Examples
         --------
         >>> import nanoarrow as na
-        >>> array = na.Array([1, 2, 3], na.int32()).to_column()
-        [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3)]
+        >>> na.Array([1, 2, 3], na.int32()).to_column()
+        nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3)
         """
         return SingleColumnBuilder.visit(self, handle_nulls=handle_nulls)
 
@@ -145,15 +145,15 @@ def nulls_as_sentinel(sentinel=None):
     Examples
     --------
 
-    >>> from nanoarrow import visitor
+    >>> import nanoarrow as na
     >>> import numpy as np
-    >>> handler = visitor.nulls_as_sentinel()
+    >>> handler = na.nulls_as_sentinel()
     >>> data = np.array([1, 2, 3], np.int32)
     >>> handler(np.array([], np.bool_), data)
     array([1, 2, 3], dtype=int32)
     >>> handler(np.array([True, False, True], np.bool_), data)
     array([ 1., nan,  3.])
-    >>> handler = visitor.nulls_as_sentinel(-999)
+    >>> handler = na.nulls_as_sentinel(-999)
     >>> handler(np.array([True, False, True], np.bool_), data)
     array([   1, -999,    3], dtype=int32)
     """

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -53,7 +53,7 @@ class ArrayViewVisitable:
         """Convert to a ``list`` of contiguous sequences
 
         Experimentally converts a stream of struct arrays into a list of contiguous
-        sequences using the same logic as :meth:`convert`.
+        sequences using the same logic as :meth:`to_pysequence`.
 
         Paramters
         ---------
@@ -75,7 +75,7 @@ class ArrayViewVisitable:
         >>> columns
         [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3), ['a', 'b', 'c']]
         """
-        return ColumnListConverter.visit(self, handle_nulls=handle_nulls)
+        return ToColumnListConverter.visit(self, handle_nulls=handle_nulls)
 
     def to_pysequence(self, *, handle_nulls=None) -> Sequence:
         """Convert to a contiguous sequence
@@ -266,7 +266,7 @@ class ToPySequenceConverter(ArrayStreamVisitor):
         return self._visitor.finish()
 
 
-class ColumnListConverter(ArrayStreamVisitor):
+class ToColumnListConverter(ArrayStreamVisitor):
     def __init__(self, schema, handle_nulls=None, *, array_view=None):
         super().__init__(schema, array_view=array_view)
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -205,12 +205,11 @@ def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
     return handle
 
 
-class ArrayStreamVisitor(ArrayViewBaseIterator):
-    """Compute a value from one or more arrays in an ArrowArrayStream
+class ArrayViewVisitor(ArrayViewBaseIterator):
+    """Compute a value from one or more arrays as ArrowArrayViews
 
     This class supports a (currently internal) pattern for building
     output from a zero or more arrays in a stream.
-
     """
 
     @classmethod
@@ -250,7 +249,7 @@ class ArrayStreamVisitor(ArrayViewBaseIterator):
         return None
 
 
-class ToPySequenceConverter(ArrayStreamVisitor):
+class ToPySequenceConverter(ArrayViewVisitor):
     def __init__(self, schema, handle_nulls=None, *, array_view=None):
         super().__init__(schema, array_view=array_view)
         cls, kwargs = _resolve_converter_cls(self._schema, handle_nulls=handle_nulls)
@@ -266,7 +265,7 @@ class ToPySequenceConverter(ArrayStreamVisitor):
         return self._visitor.finish()
 
 
-class ToColumnListConverter(ArrayStreamVisitor):
+class ToColumnListConverter(ArrayViewVisitor):
     def __init__(self, schema, handle_nulls=None, *, array_view=None):
         super().__init__(schema, array_view=array_view)
 
@@ -310,7 +309,7 @@ class ToColumnListConverter(ArrayStreamVisitor):
         ]
 
 
-class ToPyListConverter(ArrayStreamVisitor):
+class ToPyListConverter(ArrayViewVisitor):
     def __init__(self, schema, *, iterator_cls=PyIterator, array_view=None):
         super().__init__(schema, array_view=array_view)
 
@@ -329,7 +328,7 @@ class ToPyListConverter(ArrayStreamVisitor):
         return self._lst
 
 
-class ToPyBufferConverter(ArrayStreamVisitor):
+class ToPyBufferConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format(self._schema_view.buffer_format)
@@ -352,7 +351,7 @@ class ToPyBufferConverter(ArrayStreamVisitor):
         return self._builder.finish()
 
 
-class ToBooleanBufferConverter(ArrayStreamVisitor):
+class ToBooleanBufferConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format("?")
@@ -371,7 +370,7 @@ class ToBooleanBufferConverter(ArrayStreamVisitor):
         return self._builder.finish()
 
 
-class ToNullableSequenceConverter(ArrayStreamVisitor):
+class ToNullableSequenceConverter(ArrayViewVisitor):
     def __init__(
         self,
         schema,

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -121,7 +121,7 @@ def nulls_forbid() -> Callable[[CBuffer, Sequence], Sequence]:
     """
 
     def handle(is_valid, data):
-        if len(is_valid) > 0:
+        if is_valid is not None:
             raise ValueError("Null present with null_handler=nulls_forbid()")
 
         return data
@@ -180,7 +180,7 @@ def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
 
     >>> import nanoarrow as na
     >>> na.Array([1, 2, 3], na.int32()).to_column(na.nulls_separate())
-    (nanoarrow.c_lib.CBuffer(uint8[0 b] ), nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
+    (None, nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
     >>> result = na.Array([1, None, 3], na.int32()).to_column(na.nulls_separate())
     >>> result[0]
     nanoarrow.c_lib.CBuffer(uint8[3 b] True False True)
@@ -410,7 +410,7 @@ class NullableColumnBuilder(ArrayStreamVisitor):
     def finish(self) -> Any:
         is_valid = self._builder.finish()
         column = self._column_builder.finish()
-        return self._handle_nulls(is_valid, column)
+        return self._handle_nulls(is_valid if len(is_valid) > 0 else None, column)
 
     def _fill_valid(self, length):
         builder = self._builder

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -287,6 +287,9 @@ class ColumnsBuilder(ArrayStreamVisitor):
             child_visitor.begin(total_elements)
 
     def visit_chunk_view(self, array_view: CArrayView) -> Any:
+        # This visitor does not handle nulls because it has no way to propagate these
+        # into the child columns. It is designed to be used on top-level record batch
+        # arrays which typically are marked as non-nullable or do not contain nulls.
         if array_view.null_count > 0:
             raise ValueError("null_count > 0 encountered in ColumnsBuilder")
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -75,7 +75,7 @@ class ArrayViewVisitable:
         """
         return ColumnsConverter.visit(self, handle_nulls=handle_nulls)
 
-    def to_column(self, handle_nulls=None) -> Sequence:
+    def convert(self, handle_nulls=None) -> Sequence:
         """Convert to a contiguous sequence
 
         Converts a stream of arrays into a columnar representation
@@ -97,7 +97,7 @@ class ArrayViewVisitable:
         Examples
         --------
         >>> import nanoarrow as na
-        >>> na.Array([1, 2, 3], na.int32()).to_column()
+        >>> na.Array([1, 2, 3], na.int32()).convert()
         nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3)
         """
         return SingleColumnConverter.visit(self, handle_nulls=handle_nulls)
@@ -112,9 +112,9 @@ def nulls_forbid() -> Callable[[CBuffer, Sequence], Sequence]:
     --------
 
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).to_column(na.nulls_forbid())
+    >>> na.Array([1, 2, 3], na.int32()).convert(na.nulls_forbid())
     nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3)
-    >>> na.Array([1, None, 3], na.int32()).to_column(na.nulls_forbid())
+    >>> na.Array([1, None, 3], na.int32()).convert(na.nulls_forbid())
     Traceback (most recent call last):
     ...
     ValueError: Null present with null_handler=nulls_forbid()
@@ -149,11 +149,11 @@ def nulls_as_sentinel(sentinel=None):
     --------
 
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).to_column(na.nulls_as_sentinel())
+    >>> na.Array([1, 2, 3], na.int32()).convert(na.nulls_as_sentinel())
     array([1, 2, 3], dtype=int32)
-    >>> na.Array([1, None, 3], na.int32()).to_column(na.nulls_as_sentinel())
+    >>> na.Array([1, None, 3], na.int32()).convert(na.nulls_as_sentinel())
     array([ 1., nan,  3.])
-    >>> na.Array([1, None, 3], na.int32()).to_column(na.nulls_as_sentinel(-999))
+    >>> na.Array([1, None, 3], na.int32()).convert(na.nulls_as_sentinel(-999))
     array([   1, -999,    3], dtype=int32)
     """
     import numpy as np
@@ -182,9 +182,9 @@ def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
     --------
 
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).to_column(na.nulls_separate())
+    >>> na.Array([1, 2, 3], na.int32()).convert(na.nulls_separate())
     (None, nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
-    >>> result = na.Array([1, None, 3], na.int32()).to_column(na.nulls_separate())
+    >>> result = na.Array([1, None, 3], na.int32()).convert(na.nulls_separate())
     >>> result[0]
     nanoarrow.c_lib.CBuffer(uint8[3 b] True False True)
     >>> result[1]

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -173,19 +173,18 @@ def nulls_as_sentinel(sentinel=None):
     return handle
 
 
-def nulls_debug() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
-    """Debugging null handler
+def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
+    """Return nulls as a tuple of is_valid, data
 
-    A null handler that returns its input.
+    A null handler that returns its components.
 
     Examples
     --------
 
-    >>> from nanoarrow import visitor
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).to_column(visitor.nulls_debug())
+    >>> na.Array([1, 2, 3], na.int32()).to_column(na.nulls_separate())
     (nanoarrow.c_lib.CBuffer(uint8[0 b] ), nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
-    >>> result = na.Array([1, None, 3], na.int32()).to_column(visitor.nulls_debug())
+    >>> result = na.Array([1, None, 3], na.int32()).to_column(na.nulls_separate())
     >>> result[0]
     nanoarrow.c_lib.CBuffer(uint8[3 b] True False True)
     >>> result[1]

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -105,26 +105,10 @@ def nulls_as_sentinel(sentinel=None):
         data = np.array(data, copy=False)
 
         if len(is_valid) > 0:
-            out_type = result_type(data, sentinel)
-            data = array(data, dtype=out_type, copy=True)
+            out_type = np.result_type(data, sentinel)
+            data = np.array(data, dtype=out_type, copy=True)
             data[~is_valid] = sentinel
             return data
-        else:
-            return data
-
-    return handle
-
-
-def nulls_as_masked_array():
-    from numpy import array
-    from numpy.ma import masked_array
-
-    def handle(is_valid, data):
-        is_valid = array(is_valid, copy=False)
-        data = array(data, copy=False)
-
-        if len(is_valid) > 0:
-            return masked_array(data, ~is_valid)
         else:
             return data
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -154,6 +154,7 @@ def nulls_as_sentinel(sentinel=None):
     >>> na_array = na.Array([1, 2, 3], na.int32())
     >>> na_array.convert(handle_nulls=na.nulls_as_sentinel())
     array([1, 2, 3], dtype=int32)
+    >>> na_array = na.Array([1, None, 3], na.int32())
     >>> na_array.convert(handle_nulls=na.nulls_as_sentinel())
     array([ 1., nan,  3.])
     >>> na_array.convert(handle_nulls=na.nulls_as_sentinel(-999))
@@ -185,9 +186,11 @@ def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
     --------
 
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).convert(na.nulls_separate())
+    >>> na_array = na.Array([1, 2, 3], na.int32())
+    >>> na_array.convert(handle_nulls=na.nulls_separate())
     (None, nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
-    >>> result = na.Array([1, None, 3], na.int32()).convert(na.nulls_separate())
+    >>> na_array = na.Array([1, None, 3], na.int32())
+    >>> result = na_array.convert(handle_nulls=na.nulls_separate())
     >>> result[0]
     nanoarrow.c_lib.CBuffer(uint8[3 b] True False True)
     >>> result[1]

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -98,11 +98,11 @@ def nulls_debug() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
 
 
 def nulls_as_sentinel(sentinel=None):
-    from numpy import array, result_type
+    import numpy as np
 
     def handle(is_valid, data):
-        is_valid = array(is_valid, copy=False)
-        data = array(data, copy=False)
+        is_valid = np.array(is_valid, copy=False)
+        data = np.array(data, copy=False)
 
         if len(is_valid) > 0:
             out_type = result_type(data, sentinel)

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -39,7 +39,6 @@ class ArrayViewVisitable:
 
         Examples
         --------
-
         >>> import nanoarrow as na
         >>> from nanoarrow import visitor
         >>> array = na.Array([1, 2, 3], na.int32())
@@ -58,13 +57,13 @@ class ArrayViewVisitable:
         ---------
         handle_nulls : callable
             A function returning a sequence based on a validity bytemap and a
-            contiguous buffer of values (e.g., the callable returned by
-            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, or
+            contiguous buffer of values. If the array contains no nulls, the
+            validity bytemap will be ``None``. Built-in handlers include
+            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, and
             :func:`nulls_separate`). The default value is :func:`nulls_forbid`.
 
         Examples
         --------
-
         >>> import nanoarrow as na
         >>> import pyarrow as pa
         >>> batch = pa.record_batch({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
@@ -90,8 +89,9 @@ class ArrayViewVisitable:
         ----------
         handle_nulls : callable
             A function returning a sequence based on a validity bytemap and a
-            contiguous buffer of values (e.g., the callable returned by
-            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, or
+            contiguous buffer of values. If the array contains no nulls, the
+            validity bytemap will be ``None``. Built-in handlers include
+            :func:`nulls_as_sentinel`, :func:`nulls_forbid`, and
             :func:`nulls_separate`). The default value is :func:`nulls_forbid`.
 
         Examples

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -295,7 +295,7 @@ class ColumnsBuilder(ArrayStreamVisitor):
             child_visitor.visit_chunk_view(child_array_view)
 
     def finish(self) -> Tuple[List[str], List[Sequence]]:
-        return [v.schema.name for v in self._child_visitors], [
+        return [child.name for child in self._schema.children], [
             v.finish() for v in self._child_visitors
         ]
 

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -47,7 +47,9 @@ class ArrayViewVisitable:
         """
         return ToPyListConverter.visit(self)
 
-    def convert_columns(self, *, handle_nulls=None) -> Tuple[List[str], List[Sequence]]:
+    def to_columns_pysequence(
+        self, *, handle_nulls=None
+    ) -> Tuple[List[str], List[Sequence]]:
         """Convert to a ``list`` of contiguous sequences
 
         Experimentally converts a stream of struct arrays into a list of contiguous
@@ -67,7 +69,7 @@ class ArrayViewVisitable:
         >>> import nanoarrow as na
         >>> import pyarrow as pa
         >>> batch = pa.record_batch({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
-        >>> names, columns = na.Array(batch).convert_columns()
+        >>> names, columns = na.Array(batch).to_columns_pysequence()
         >>> names
         ['col1', 'col2']
         >>> columns
@@ -75,7 +77,7 @@ class ArrayViewVisitable:
         """
         return ColumnListConverter.visit(self, handle_nulls=handle_nulls)
 
-    def convert(self, *, handle_nulls=None) -> Sequence:
+    def to_pysequence(self, *, handle_nulls=None) -> Sequence:
         """Convert to a contiguous sequence
 
         Experimentally converts a stream of arrays into a columnar representation
@@ -99,7 +101,7 @@ class ArrayViewVisitable:
         Examples
         --------
         >>> import nanoarrow as na
-        >>> na.Array([1, 2, 3], na.int32()).convert()
+        >>> na.Array([1, 2, 3], na.int32()).to_pysequence()
         nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3)
         """
         return ToPySequenceConverter.visit(self, handle_nulls=handle_nulls)
@@ -114,9 +116,9 @@ def nulls_forbid() -> Callable[[CBuffer, Sequence], Sequence]:
     --------
 
     >>> import nanoarrow as na
-    >>> na.Array([1, 2, 3], na.int32()).convert(handle_nulls=na.nulls_forbid())
+    >>> na.Array([1, 2, 3], na.int32()).to_pysequence(handle_nulls=na.nulls_forbid())
     nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3)
-    >>> na.Array([1, None, 3], na.int32()).convert(handle_nulls=na.nulls_forbid())
+    >>> na.Array([1, None, 3], na.int32()).to_pysequence(handle_nulls=na.nulls_forbid())
     Traceback (most recent call last):
     ...
     ValueError: Null present with null_handler=nulls_forbid()
@@ -152,12 +154,12 @@ def nulls_as_sentinel(sentinel=None):
 
     >>> import nanoarrow as na
     >>> na_array = na.Array([1, 2, 3], na.int32())
-    >>> na_array.convert(handle_nulls=na.nulls_as_sentinel())
+    >>> na_array.to_pysequence(handle_nulls=na.nulls_as_sentinel())
     array([1, 2, 3], dtype=int32)
     >>> na_array = na.Array([1, None, 3], na.int32())
-    >>> na_array.convert(handle_nulls=na.nulls_as_sentinel())
+    >>> na_array.to_pysequence(handle_nulls=na.nulls_as_sentinel())
     array([ 1., nan,  3.])
-    >>> na_array.convert(handle_nulls=na.nulls_as_sentinel(-999))
+    >>> na_array.to_pysequence(handle_nulls=na.nulls_as_sentinel(-999))
     array([   1, -999,    3], dtype=int32)
     """
     import numpy as np
@@ -187,10 +189,10 @@ def nulls_separate() -> Callable[[CBuffer, Sequence], Tuple[CBuffer, Sequence]]:
 
     >>> import nanoarrow as na
     >>> na_array = na.Array([1, 2, 3], na.int32())
-    >>> na_array.convert(handle_nulls=na.nulls_separate())
+    >>> na_array.to_pysequence(handle_nulls=na.nulls_separate())
     (None, nanoarrow.c_lib.CBuffer(int32[12 b] 1 2 3))
     >>> na_array = na.Array([1, None, 3], na.int32())
-    >>> result = na_array.convert(handle_nulls=na.nulls_separate())
+    >>> result = na_array.to_pysequence(handle_nulls=na.nulls_separate())
     >>> result[0]
     nanoarrow.c_lib.CBuffer(uint8[3 b] True False True)
     >>> result[1]

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -84,7 +84,7 @@ class ArrayViewVisitable:
         such that each column is either a contiguous buffer or a ``list``.
         Integer, float, and interval arrays are currently converted to their
         contiguous buffer representation; other types are returned as a list
-        of Python objects. The sequences returned by :meth:`to_column` are
+        of Python objects. The sequences returned by :meth:`to_pysequence` are
         designed to work as input to ``pandas.Series`` and/or ``numpy.array()``.
         The default conversions are subject to change based on initial user
         feedback.
@@ -270,7 +270,7 @@ class ToColumnListConverter(ArrayViewVisitor):
         super().__init__(schema, array_view=array_view)
 
         if self.schema.type != Type.STRUCT:
-            raise ValueError("ColumnListConverter can only be used on a struct array")
+            raise ValueError("ToColumnListConverter can only be used on a struct array")
 
         # Resolve the appropriate visitor for each column
         self._child_visitors = []
@@ -296,7 +296,7 @@ class ToColumnListConverter(ArrayViewVisitor):
         # into the child columns. It is designed to be used on top-level record batch
         # arrays which typically are marked as non-nullable or do not contain nulls.
         if array_view.null_count > 0:
-            raise ValueError("null_count > 0 encountered in ColumnListConverter")
+            raise ValueError("null_count > 0 encountered in ToColumnListConverter")
 
         for child_visitor, child_array_view in zip(
             self._child_visitors, array_view.children

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -32,7 +32,7 @@ class ArrayViewVisitable:
     """
 
     def to_pylist(self) -> List:
-        """Convert to a ``list()`` of Python objects
+        """Convert to a ``list`` of Python objects
 
         Computes an identical value to ``list(iter_py())`` but can be much
         faster.
@@ -49,7 +49,7 @@ class ArrayViewVisitable:
         return ListBuilder.visit(self)
 
     def to_column_list(self, handle_nulls=None) -> Tuple[List[str], List[Sequence]]:
-        """Convert to a ``list()` of contiguous sequences
+        """Convert to a ``list`` of contiguous sequences
 
         Converts a stream of struct arrays into its column-wise representation
         according to :meth:`to_column`.
@@ -79,7 +79,7 @@ class ArrayViewVisitable:
         """Convert to a contiguous sequence
 
         Converts a stream of arrays into a columnar representation
-        such that each column is either a contiguous buffer or a ``list()``.
+        such that each column is either a contiguous buffer or a ``list``.
         Integer, float, and interval arrays are currently converted to their
         contiguous buffer representation; other types are returned as a list
         of Python objects. The sequences returned by :meth:`to_column` are
@@ -87,9 +87,6 @@ class ArrayViewVisitable:
 
         Parameters
         ---------
-        obj : array stream-like
-            An array-like or array stream-like object as sanitized by
-            :func:`c_array_stream`.
         schema : schema-like, optional
             An optional schema, passed to :func:`c_array_stream`.
         handle_nulls : callable

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -200,6 +200,9 @@ def test_array_chunked():
     # Python objects by to_pylist()
     assert array.to_pylist() == list(array.iter_py())
 
+    # Sequence via to_column()
+    assert list(array.to_column()) == [1, 2, 3, 4, 5, 6]
+
     with na.c_array_stream(array) as stream:
         arrays = list(stream)
         assert len(arrays) == 2

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -201,7 +201,7 @@ def test_array_chunked():
     assert array.to_pylist() == list(array.iter_py())
 
     # Sequence via convert()
-    assert list(array.convert()) == [1, 2, 3, 4, 5, 6]
+    assert list(array.to_pysequence()) == [1, 2, 3, 4, 5, 6]
 
     with na.c_array_stream(array) as stream:
         arrays = list(stream)
@@ -234,7 +234,7 @@ def test_array_children():
     assert len(tuples) == 2
     assert len(tuples[0]) == 100
 
-    names, columns = array.convert_columns()
+    names, columns = array.to_columns_pysequence()
     assert names == [f"col{i}" for i in range(100)]
     assert all(len(col) == len(array) for col in columns)
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -200,7 +200,7 @@ def test_array_chunked():
     # Python objects by to_pylist()
     assert array.to_pylist() == list(array.iter_py())
 
-    # Sequence via convert()
+    # Sequence via to_pysequence()
     assert list(array.to_pysequence()) == [1, 2, 3, 4, 5, 6]
 
     with na.c_array_stream(array) as stream:

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -200,8 +200,8 @@ def test_array_chunked():
     # Python objects by to_pylist()
     assert array.to_pylist() == list(array.iter_py())
 
-    # Sequence via to_column()
-    assert list(array.to_column()) == [1, 2, 3, 4, 5, 6]
+    # Sequence via convert()
+    assert list(array.convert()) == [1, 2, 3, 4, 5, 6]
 
     with na.c_array_stream(array) as stream:
         arrays = list(stream)

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -234,7 +234,7 @@ def test_array_children():
     assert len(tuples) == 2
     assert len(tuples[0]) == 100
 
-    names, columns = array.to_column_list()
+    names, columns = array.convert_columns()
     assert names == [f"col{i}" for i in range(100)]
     assert all(len(col) == len(array) for col in columns)
 

--- a/python/tests/test_array.py
+++ b/python/tests/test_array.py
@@ -231,7 +231,7 @@ def test_array_children():
     assert len(tuples) == 2
     assert len(tuples[0]) == 100
 
-    names, columns = array.to_columns()
+    names, columns = array.to_column_list()
     assert names == [f"col{i}" for i in range(100)]
     assert all(len(col) == len(array) for col in columns)
 

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -80,7 +80,7 @@ def test_array_stream_to_columns():
     )
 
     stream = na.ArrayStream(c_array)
-    names, columns = stream.convert_columns()
+    names, columns = stream.to_columns_pysequence()
     assert names == ["col1", "col2"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == ["a", "b", "c"]

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -80,7 +80,7 @@ def test_array_stream_to_columns():
     )
 
     stream = na.ArrayStream(c_array)
-    names, columns = stream.to_column_list()
+    names, columns = stream.convert_columns()
     assert names == ["col1", "col2"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == ["a", "b", "c"]

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -82,8 +82,8 @@ def test_array_stream_to_columns():
     stream = na.ArrayStream(c_array)
     names, columns = stream.to_columns()
     assert names == ["col1", "col2"]
-    assert columns[0] == [1, 2, 3]
-    assert columns[1] == ["a", "b", "c"]
+    assert list(columns[0]) == [1, 2, 3]
+    assert list(columns[1]) == ["a", "b", "c"]
 
 
 def test_array_stream_read_all():

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -80,7 +80,7 @@ def test_array_stream_to_columns():
     )
 
     stream = na.ArrayStream(c_array)
-    names, columns = stream.to_columns()
+    names, columns = stream.to_column_list()
     assert names == ["col1", "col2"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == ["a", "b", "c"]

--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -252,7 +252,7 @@ def test_c_buffer_from_iterable():
     assert buffer.size_bytes == 12
     assert buffer.data_type == "int32"
     assert buffer.element_size_bits == 32
-    assert buffer.item_size == 4
+    assert buffer.itemsize == 4
     assert list(buffer) == [1, 2, 3]
 
     # An Arrow type that does not make sense as a buffer type will error
@@ -273,7 +273,7 @@ def test_c_buffer_from_fixed_size_binary_iterable():
     buffer = na.c_buffer(items, na.fixed_size_binary(4))
     assert buffer.data_type == "binary"
     assert buffer.element_size_bits == 32
-    assert buffer.item_size == 4
+    assert buffer.itemsize == 4
     assert bytes(buffer) == b"".join(items)
     assert list(buffer) == items
 
@@ -282,7 +282,7 @@ def test_c_buffer_from_day_time_iterable():
     buffer = na.c_buffer([(1, 2), (3, 4), (5, 6)], na.interval_day_time())
     assert buffer.data_type == "interval_day_time"
     assert buffer.element_size_bits == 64
-    assert buffer.item_size == 8
+    assert buffer.itemsize == 8
     assert list(buffer) == [(1, 2), (3, 4), (5, 6)]
 
 
@@ -290,7 +290,7 @@ def test_c_buffer_from_month_day_nano_iterable():
     buffer = na.c_buffer([(1, 2, 3), (4, 5, 6)], na.interval_month_day_nano())
     assert buffer.data_type == "interval_month_day_nano"
     assert buffer.element_size_bits == 128
-    assert buffer.item_size == 16
+    assert buffer.itemsize == 16
     assert list(buffer) == [(1, 2, 3), (4, 5, 6)]
 
 
@@ -302,7 +302,7 @@ def test_c_buffer_from_decimal128_iterable():
     )
     assert buffer.data_type == "decimal128"
     assert buffer.element_size_bits == 128
-    assert buffer.item_size == 16
+    assert buffer.itemsize == 16
     assert list(buffer) == [
         bytes64[0:16],
         bytes64[16:32],
@@ -316,7 +316,7 @@ def test_c_buffer_from_decimal256_iterable():
     buffer = na.c_buffer([bytes64[0:32], bytes64[32:64]], na.decimal256(10, 3))
     assert buffer.data_type == "decimal256"
     assert buffer.element_size_bits == 256
-    assert buffer.item_size == 32
+    assert buffer.itemsize == 32
     assert list(buffer) == [bytes64[0:32], bytes64[32:64]]
 
 
@@ -326,7 +326,7 @@ def test_c_buffer_bitmap_from_iterable():
     assert "10010000" in repr(buffer)
     assert buffer.size_bytes == 1
     assert buffer.data_type == "bool"
-    assert buffer.item_size == 1
+    assert buffer.itemsize == 1
     assert buffer.element_size_bits == 1
     assert list(buffer.elements()) == [
         True,

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -190,13 +190,15 @@ def test_c_array_view_null_count():
     )
     assert array.view().null_count == 0
 
-    # Infer null count == 0 because of null data buffer
+    # Infer null count == 0 because of null data buffer when the null count
+    # has not yet been computed by the producer.
     array = na.c_array_from_buffers(
         na.int32(), 3, (None, na.c_buffer([1, 2, 3], na.int32())), null_count=-1
     )
     assert array.view().null_count == 0
 
-    # Compute null count == 0 by counting validity bits
+    # Compute null count == 0 by counting validity bits when the null count
+    # has not yet been computed by the producer.
     array = na.c_array_from_buffers(
         na.int32(),
         3,
@@ -209,7 +211,8 @@ def test_c_array_view_null_count():
 
     assert array.view().null_count == 0
 
-    # Check computed null count with actual nulls
+    # Check computed null count with actual nulls when the null count
+    # has not yet been computed by the producer.
     array = na.c_array_from_buffers(
         na.int32(),
         3,

--- a/python/tests/test_nanoarrow.py
+++ b/python/tests/test_nanoarrow.py
@@ -183,6 +183,45 @@ def test_c_array_view_dictionary():
     assert "- dictionary: <nanoarrow.c_array.CArrayView>" in repr(view)
 
 
+def test_c_array_view_null_count():
+    # With explicit null count == 0
+    array = na.c_array_from_buffers(
+        na.int32(), 3, (None, na.c_buffer([1, 2, 3], na.int32())), null_count=0
+    )
+    assert array.view().null_count == 0
+
+    # Infer null count == 0 because of null data buffer
+    array = na.c_array_from_buffers(
+        na.int32(), 3, (None, na.c_buffer([1, 2, 3], na.int32())), null_count=-1
+    )
+    assert array.view().null_count == 0
+
+    # Compute null count == 0 by counting validity bits
+    array = na.c_array_from_buffers(
+        na.int32(),
+        3,
+        (
+            na.c_buffer([True, True, True], na.bool_()),
+            na.c_buffer([1, 2, 3], na.int32()),
+        ),
+        null_count=-1,
+    )
+
+    assert array.view().null_count == 0
+
+    # Check computed null count with actual nulls
+    array = na.c_array_from_buffers(
+        na.int32(),
+        3,
+        (
+            na.c_buffer([True, False, True], na.bool_()),
+            na.c_buffer([1, 2, 3], na.int32()),
+        ),
+        null_count=-1,
+    )
+    assert array.view().null_count == 1
+
+
 def test_buffers_integer():
     data_types = [
         (pa.uint8(), np.uint8()),

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -46,6 +46,26 @@ def test_to_column():
     assert strings_col == ["abc", "def", "ghi"]
 
 
+def test_to_column_non_nullable():
+    ints = na.c_array([1, 2, 3], na.int32(nullable=False))
+    bools = na.c_array([1, 0, 1], na.bool_(nullable=False))
+    strings = na.c_array(["abc", "def", "ghi"], na.string(nullable=False))
+
+    ints_col = visitor.SingleColumnBuilder.visit(ints)
+    assert isinstance(ints_col, CBuffer)
+    assert ints_col.format == "i"
+    assert list(ints_col) == [1, 2, 3]
+
+    bools_col = visitor.SingleColumnBuilder.visit(bools)
+    assert isinstance(bools_col, CBuffer)
+    assert bools_col.format == "?"
+    assert list(bools_col) == [True, False, True]
+
+    strings_col = visitor.SingleColumnBuilder.visit(strings)
+    assert isinstance(strings_col, list)
+    assert strings_col == ["abc", "def", "ghi"]
+
+
 def test_to_column_list():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool_(), "col3": na.string()}),

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -26,7 +26,7 @@ def test_to_pylist():
     assert visitor.ListConverter.visit(array) == [1, 2, 3]
 
 
-def test_to_column():
+def test_convert():
     ints = na.c_array([1, 2, 3], na.int32())
     bools = na.c_array([1, 0, 1], na.bool_())
     strings = na.c_array(["abc", "def", "ghi"], na.string())

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -66,7 +66,7 @@ def test_to_column_non_nullable():
     assert strings_col == ["abc", "def", "ghi"]
 
 
-def test_to_column_list():
+def test_convert_columns():
     array = na.c_array_from_buffers(
         na.struct({"col1": na.int32(), "col2": na.bool_(), "col3": na.string()}),
         length=3,

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -171,14 +171,13 @@ def test_nulls_forbid():
 def test_numpy_null_handling():
     np = pytest.importorskip("numpy")
 
-    is_valid_empty = memoryview(na.c_buffer([], na.uint8())).cast("?")
     is_valid_non_empty = memoryview(na.c_buffer([1, 0, 1], na.uint8())).cast("?")
     data = na.c_buffer([1, 2, 3], na.int32())
 
     # Check nulls as sentinel
     nulls_as_sentinel = visitor.nulls_as_sentinel()
     np.testing.assert_array_equal(
-        nulls_as_sentinel(is_valid_empty, data), np.array([1, 2, 3], np.int32)
+        nulls_as_sentinel(None, data), np.array([1, 2, 3], np.int32)
     )
     np.testing.assert_array_equal(
         nulls_as_sentinel(is_valid_non_empty, data),

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -87,6 +87,16 @@ def test_to_column_list():
     with pytest.raises(ValueError, match="can only be used on a struct array"):
         visitor.ColumnsBuilder.visit([], na.int32())
 
+    # Ensure that the columns builder errors for top-level nulls
+    array_with_nulls = na.c_array_from_buffers(
+        array.schema,
+        array.length,
+        [na.c_buffer([True, False, True], na.bool_())],
+        children=array.children,
+    )
+    with pytest.raises(ValueError, match="null_count > 0"):
+        visitor.ColumnsBuilder.visit(array_with_nulls)
+
 
 def test_buffer_concatenator():
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -39,8 +39,8 @@ def test_to_columms():
 
     names, columns = visitor.to_columns(array)
     assert names == ["col1", "col2", "col3"]
-    assert columns[0] == [1, 2, 3]
-    assert columns[1] == [True, False, True]
+    assert list(columns[0]) == [1, 2, 3]
+    assert list(columns[1]) == [True, False, True]
     assert columns[2] == ["abc", "def", "ghi"]
 
     with pytest.raises(ValueError, match="can only be used on a struct array"):

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -130,7 +130,7 @@ def test_unpacked_validity_bitmap_concatenator():
     is_valid, column = visitor.NullableColumnBuilder.visit(
         array, handle_nulls=na.nulls_separate()
     )
-    assert len(is_valid) == 0
+    assert is_valid is None
     assert list(column) == [1, 2, 3, 4, 5, 6]
 
     # Only nulls in the first chunk
@@ -159,12 +159,11 @@ def test_unpacked_validity_bitmap_concatenator():
 
 
 def test_nulls_forbid():
-    is_valid_empty = na.c_buffer([], na.uint8())
     is_valid_non_empty = na.c_buffer([1, 0, 1], na.uint8())
     data = na.c_buffer([1, 2, 3], na.int32())
 
     forbid_nulls = visitor.nulls_forbid()
-    assert forbid_nulls(is_valid_empty, data) is data
+    assert forbid_nulls(None, data) is data
     with pytest.raises(ValueError):
         forbid_nulls(is_valid_non_empty, data)
 

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -134,13 +134,3 @@ def test_numpy_null_handling():
         nulls_as_sentinel(is_valid_non_empty, data),
         np.array([1, np.nan, 3], dtype=np.float64),
     )
-
-    # Check nulls as masked array
-    nulls_as_masked_array = visitor.nulls_as_masked_array()
-    np.testing.assert_array_equal(
-        nulls_as_masked_array(is_valid_empty, data), np.array([1, 2, 3], np.int32)
-    )
-    np.testing.assert_array_equal(
-        nulls_as_masked_array(is_valid_non_empty, data),
-        np.ma.masked_array(np.array([1, 2, 3], np.int32), [False, True, False]),
-    )

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -78,14 +78,14 @@ def test_convert_columns():
         ],
     )
 
-    names, columns = visitor.ColumnListConverter.visit(array)
+    names, columns = visitor.ToColumnListConverter.visit(array)
     assert names == ["col1", "col2", "col3"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == [True, False, True]
     assert columns[2] == ["abc", "def", "ghi"]
 
     with pytest.raises(ValueError, match="can only be used on a struct array"):
-        visitor.ColumnListConverter.visit([], na.int32())
+        visitor.ToColumnListConverter.visit([], na.int32())
 
     # Ensure that the columns converter errors for top-level nulls
     array_with_nulls = na.c_array_from_buffers(
@@ -95,7 +95,7 @@ def test_convert_columns():
         children=array.children,
     )
     with pytest.raises(ValueError, match="null_count > 0"):
-        visitor.ColumnListConverter.visit(array_with_nulls)
+        visitor.ToColumnListConverter.visit(array_with_nulls)
 
 
 def test_contiguous_buffer_converter():

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -31,37 +31,37 @@ def test_convert():
     bools = na.c_array([1, 0, 1], na.bool_())
     strings = na.c_array(["abc", "def", "ghi"], na.string())
 
-    ints_col = visitor.SingleColumnConverter.visit(ints)
+    ints_col = visitor.DispatchingConverter.visit(ints)
     assert isinstance(ints_col, CBuffer)
     assert ints_col.format == "i"
     assert list(ints_col) == [1, 2, 3]
 
-    bools_col = visitor.SingleColumnConverter.visit(bools)
+    bools_col = visitor.DispatchingConverter.visit(bools)
     assert isinstance(bools_col, CBuffer)
     assert bools_col.format == "?"
     assert list(bools_col) == [True, False, True]
 
-    strings_col = visitor.SingleColumnConverter.visit(strings)
+    strings_col = visitor.DispatchingConverter.visit(strings)
     assert isinstance(strings_col, list)
     assert strings_col == ["abc", "def", "ghi"]
 
 
-def test_to_column_non_nullable():
+def test_convert_non_nullable():
     ints = na.c_array([1, 2, 3], na.int32(nullable=False))
     bools = na.c_array([1, 0, 1], na.bool_(nullable=False))
     strings = na.c_array(["abc", "def", "ghi"], na.string(nullable=False))
 
-    ints_col = visitor.SingleColumnConverter.visit(ints)
+    ints_col = visitor.DispatchingConverter.visit(ints)
     assert isinstance(ints_col, CBuffer)
     assert ints_col.format == "i"
     assert list(ints_col) == [1, 2, 3]
 
-    bools_col = visitor.SingleColumnConverter.visit(bools)
+    bools_col = visitor.DispatchingConverter.visit(bools)
     assert isinstance(bools_col, CBuffer)
     assert bools_col.format == "?"
     assert list(bools_col) == [True, False, True]
 
-    strings_col = visitor.SingleColumnConverter.visit(strings)
+    strings_col = visitor.DispatchingConverter.visit(strings)
     assert isinstance(strings_col, list)
     assert strings_col == ["abc", "def", "ghi"]
 
@@ -78,14 +78,14 @@ def test_convert_columns():
         ],
     )
 
-    names, columns = visitor.ColumnsConverter.visit(array)
+    names, columns = visitor.ColumnListConverter.visit(array)
     assert names == ["col1", "col2", "col3"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == [True, False, True]
     assert columns[2] == ["abc", "def", "ghi"]
 
     with pytest.raises(ValueError, match="can only be used on a struct array"):
-        visitor.ColumnsConverter.visit([], na.int32())
+        visitor.ColumnListConverter.visit([], na.int32())
 
     # Ensure that the columns converter errors for top-level nulls
     array_with_nulls = na.c_array_from_buffers(
@@ -95,39 +95,39 @@ def test_convert_columns():
         children=array.children,
     )
     with pytest.raises(ValueError, match="null_count > 0"):
-        visitor.ColumnsConverter.visit(array_with_nulls)
+        visitor.ColumnListConverter.visit(array_with_nulls)
 
 
-def test_buffer_concatenator():
+def test_contiguous_buffer_converter():
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
-    buffer = visitor.BufferColumnConverter.visit(array)
+    buffer = visitor.ContiguousBufferConverter.visit(array)
     assert list(buffer) == [1, 2, 3, 4, 5, 6]
 
 
-def test_buffer_concatenator_with_offsets():
+def test_contiguous_buffer_converter_with_offsets():
     src = [na.c_array([1, 2, 3], na.int32())[1:], na.c_array([4, 5, 6], na.int32())[2:]]
     array = na.Array.from_chunks(src)
-    buffer = visitor.BufferColumnConverter.visit(array)
+    buffer = visitor.ContiguousBufferConverter.visit(array)
     assert list(buffer) == [2, 3, 6]
 
 
-def test_unpacked_bitmap_concatenator():
+def test_boolean_bytes_converter():
     array = na.Array.from_chunks([[0, 1, 1], [1, 0, 0]], na.bool_())
-    buffer = visitor.BooleanColumnConverter.visit(array)
+    buffer = visitor.BooleanBytesConverter.visit(array)
     assert list(buffer) == [False, True, True, True, False, False]
 
 
-def test_unpacked_bitmap_concatenator_with_offsets():
+def test_boolean_bytes_converter_with_offsets():
     src = [na.c_array([0, 1, 1], na.bool_())[1:], na.c_array([1, 0, 0], na.bool_())[2:]]
     array = na.Array.from_chunks(src)
-    buffer = visitor.BooleanColumnConverter.visit(array)
+    buffer = visitor.BooleanBytesConverter.visit(array)
     assert list(buffer) == [True, True, False]
 
 
-def test_unpacked_validity_bitmap_concatenator():
+def test_nullable_converter():
     # All valid
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnConverter.visit(
+    is_valid, column = visitor.NullableConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert is_valid is None
@@ -135,7 +135,7 @@ def test_unpacked_validity_bitmap_concatenator():
 
     # Only nulls in the first chunk
     array = na.Array.from_chunks([[1, None, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnConverter.visit(
+    is_valid, column = visitor.NullableConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, True, True]
@@ -143,7 +143,7 @@ def test_unpacked_validity_bitmap_concatenator():
 
     # Only nulls in the second chunk
     array = na.Array.from_chunks([[1, 2, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnConverter.visit(
+    is_valid, column = visitor.NullableConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, True, True, True, False, True]
@@ -151,7 +151,7 @@ def test_unpacked_validity_bitmap_concatenator():
 
     # Nulls in both chunks
     array = na.Array.from_chunks([[1, None, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnConverter.visit(
+    is_valid, column = visitor.NullableConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, False, True]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -76,24 +76,32 @@ def test_unpacked_bitmap_concatenator_with_offsets():
 def test_unpacked_validity_bitmap_concatenator():
     # All valid
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnBuilder.visit(array)
+    is_valid, column = visitor.NullableColumnBuilder.visit(
+        array, handle_nulls=visitor.nulls_debug()
+    )
     assert len(is_valid) == 0
     assert list(column) == [1, 2, 3, 4, 5, 6]
 
     # Only nulls in the first chunk
     array = na.Array.from_chunks([[1, None, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnBuilder.visit(array)
+    is_valid, column = visitor.NullableColumnBuilder.visit(
+        array, handle_nulls=visitor.nulls_debug()
+    )
     assert list(is_valid) == [True, False, True, True, True, True]
     assert list(column) == [1, 0, 3, 4, 5, 6]
 
     # Only nulls in the second chunk
     array = na.Array.from_chunks([[1, 2, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnBuilder.visit(array)
+    is_valid, column = visitor.NullableColumnBuilder.visit(
+        array, handle_nulls=visitor.nulls_debug()
+    )
     assert list(is_valid) == [True, True, True, True, False, True]
     assert list(column) == [1, 2, 3, 4, 0, 6]
 
     # Nulls in both chunks
     array = na.Array.from_chunks([[1, None, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableColumnBuilder.visit(array)
+    is_valid, column = visitor.NullableColumnBuilder.visit(
+        array, handle_nulls=visitor.nulls_debug()
+    )
     assert list(is_valid) == [True, False, True, True, False, True]
     assert list(column) == [1, 0, 3, 4, 0, 6]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -118,7 +118,7 @@ def test_unpacked_validity_bitmap_concatenator():
     # All valid
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
     is_valid, column = visitor.NullableColumnBuilder.visit(
-        array, handle_nulls=visitor.nulls_debug()
+        array, handle_nulls=na.nulls_separate()
     )
     assert len(is_valid) == 0
     assert list(column) == [1, 2, 3, 4, 5, 6]
@@ -126,7 +126,7 @@ def test_unpacked_validity_bitmap_concatenator():
     # Only nulls in the first chunk
     array = na.Array.from_chunks([[1, None, 3], [4, 5, 6]], na.int32())
     is_valid, column = visitor.NullableColumnBuilder.visit(
-        array, handle_nulls=visitor.nulls_debug()
+        array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, True, True]
     assert list(column) == [1, 0, 3, 4, 5, 6]
@@ -134,7 +134,7 @@ def test_unpacked_validity_bitmap_concatenator():
     # Only nulls in the second chunk
     array = na.Array.from_chunks([[1, 2, 3], [4, None, 6]], na.int32())
     is_valid, column = visitor.NullableColumnBuilder.visit(
-        array, handle_nulls=visitor.nulls_debug()
+        array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, True, True, True, False, True]
     assert list(column) == [1, 2, 3, 4, 0, 6]
@@ -142,7 +142,7 @@ def test_unpacked_validity_bitmap_concatenator():
     # Nulls in both chunks
     array = na.Array.from_chunks([[1, None, 3], [4, None, 6]], na.int32())
     is_valid, column = visitor.NullableColumnBuilder.visit(
-        array, handle_nulls=visitor.nulls_debug()
+        array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, False, True]
     assert list(column) == [1, 0, 3, 4, 0, 6]

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -78,14 +78,14 @@ def test_convert_columns():
         ],
     )
 
-    names, columns = visitor.ToColumnListConverter.visit(array)
+    names, columns = visitor.ToColumnsPysequenceConverter.visit(array)
     assert names == ["col1", "col2", "col3"]
     assert list(columns[0]) == [1, 2, 3]
     assert list(columns[1]) == [True, False, True]
     assert columns[2] == ["abc", "def", "ghi"]
 
     with pytest.raises(ValueError, match="can only be used on a struct array"):
-        visitor.ToColumnListConverter.visit([], na.int32())
+        visitor.ToColumnsPysequenceConverter.visit([], na.int32())
 
     # Ensure that the columns converter errors for top-level nulls
     array_with_nulls = na.c_array_from_buffers(
@@ -95,7 +95,7 @@ def test_convert_columns():
         children=array.children,
     )
     with pytest.raises(ValueError, match="null_count > 0"):
-        visitor.ToColumnListConverter.visit(array_with_nulls)
+        visitor.ToColumnsPysequenceConverter.visit(array_with_nulls)
 
 
 def test_contiguous_buffer_converter():

--- a/python/tests/test_visitor.py
+++ b/python/tests/test_visitor.py
@@ -23,7 +23,7 @@ from nanoarrow import visitor
 
 def test_to_pylist():
     array = na.c_array([1, 2, 3], na.int32())
-    assert visitor.ListConverter.visit(array) == [1, 2, 3]
+    assert visitor.ToPyListConverter.visit(array) == [1, 2, 3]
 
 
 def test_convert():
@@ -31,17 +31,17 @@ def test_convert():
     bools = na.c_array([1, 0, 1], na.bool_())
     strings = na.c_array(["abc", "def", "ghi"], na.string())
 
-    ints_col = visitor.DispatchingConverter.visit(ints)
+    ints_col = visitor.ToPySequenceConverter.visit(ints)
     assert isinstance(ints_col, CBuffer)
     assert ints_col.format == "i"
     assert list(ints_col) == [1, 2, 3]
 
-    bools_col = visitor.DispatchingConverter.visit(bools)
+    bools_col = visitor.ToPySequenceConverter.visit(bools)
     assert isinstance(bools_col, CBuffer)
     assert bools_col.format == "?"
     assert list(bools_col) == [True, False, True]
 
-    strings_col = visitor.DispatchingConverter.visit(strings)
+    strings_col = visitor.ToPySequenceConverter.visit(strings)
     assert isinstance(strings_col, list)
     assert strings_col == ["abc", "def", "ghi"]
 
@@ -51,17 +51,17 @@ def test_convert_non_nullable():
     bools = na.c_array([1, 0, 1], na.bool_(nullable=False))
     strings = na.c_array(["abc", "def", "ghi"], na.string(nullable=False))
 
-    ints_col = visitor.DispatchingConverter.visit(ints)
+    ints_col = visitor.ToPySequenceConverter.visit(ints)
     assert isinstance(ints_col, CBuffer)
     assert ints_col.format == "i"
     assert list(ints_col) == [1, 2, 3]
 
-    bools_col = visitor.DispatchingConverter.visit(bools)
+    bools_col = visitor.ToPySequenceConverter.visit(bools)
     assert isinstance(bools_col, CBuffer)
     assert bools_col.format == "?"
     assert list(bools_col) == [True, False, True]
 
-    strings_col = visitor.DispatchingConverter.visit(strings)
+    strings_col = visitor.ToPySequenceConverter.visit(strings)
     assert isinstance(strings_col, list)
     assert strings_col == ["abc", "def", "ghi"]
 
@@ -100,34 +100,34 @@ def test_convert_columns():
 
 def test_contiguous_buffer_converter():
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
-    buffer = visitor.ContiguousBufferConverter.visit(array)
+    buffer = visitor.ToPyBufferConverter.visit(array)
     assert list(buffer) == [1, 2, 3, 4, 5, 6]
 
 
 def test_contiguous_buffer_converter_with_offsets():
     src = [na.c_array([1, 2, 3], na.int32())[1:], na.c_array([4, 5, 6], na.int32())[2:]]
     array = na.Array.from_chunks(src)
-    buffer = visitor.ContiguousBufferConverter.visit(array)
+    buffer = visitor.ToPyBufferConverter.visit(array)
     assert list(buffer) == [2, 3, 6]
 
 
 def test_boolean_bytes_converter():
     array = na.Array.from_chunks([[0, 1, 1], [1, 0, 0]], na.bool_())
-    buffer = visitor.BooleanBytesConverter.visit(array)
+    buffer = visitor.ToBooleanBufferConverter.visit(array)
     assert list(buffer) == [False, True, True, True, False, False]
 
 
 def test_boolean_bytes_converter_with_offsets():
     src = [na.c_array([0, 1, 1], na.bool_())[1:], na.c_array([1, 0, 0], na.bool_())[2:]]
     array = na.Array.from_chunks(src)
-    buffer = visitor.BooleanBytesConverter.visit(array)
+    buffer = visitor.ToBooleanBufferConverter.visit(array)
     assert list(buffer) == [True, True, False]
 
 
 def test_nullable_converter():
     # All valid
     array = na.Array.from_chunks([[1, 2, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableConverter.visit(
+    is_valid, column = visitor.ToNullableSequenceConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert is_valid is None
@@ -135,7 +135,7 @@ def test_nullable_converter():
 
     # Only nulls in the first chunk
     array = na.Array.from_chunks([[1, None, 3], [4, 5, 6]], na.int32())
-    is_valid, column = visitor.NullableConverter.visit(
+    is_valid, column = visitor.ToNullableSequenceConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, True, True]
@@ -143,7 +143,7 @@ def test_nullable_converter():
 
     # Only nulls in the second chunk
     array = na.Array.from_chunks([[1, 2, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableConverter.visit(
+    is_valid, column = visitor.ToNullableSequenceConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, True, True, True, False, True]
@@ -151,7 +151,7 @@ def test_nullable_converter():
 
     # Nulls in both chunks
     array = na.Array.from_chunks([[1, None, 3], [4, None, 6]], na.int32())
-    is_valid, column = visitor.NullableConverter.visit(
+    is_valid, column = visitor.ToNullableSequenceConverter.visit(
         array, handle_nulls=na.nulls_separate()
     )
     assert list(is_valid) == [True, False, True, True, False, True]


### PR DESCRIPTION
This PR implements building columns buffer-wise for the types where this makes sense. It also implements a few other changes:

- `item_size` was renamed to `itemsize` to match the memoryview property name
- The visitor methods are now the `ArrayViewVisitable` mixin such that they are available in both the `Array` and `ArrayView` without duplicating documentation.

Functionally this means that the `Array` and `ArrayStream` now have `to_column()` and `to_column_list()` methods that do something that more closely matches what somebody would expect.

A quick demo:

```python
import nanoarrow as na
import pyarrow as pa

batch = pa.record_batch({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
batch_with_nulls = pa.record_batch({"col1": [1, None, 3], "col2": ["a", "b", None]})

# Either builds a buffer or a list depending on column types
na.Array(batch).to_columns_pysequence()
#> (['col1', 'col2'],
#>  [nanoarrow.c_lib.CBuffer(int64[24 b] 1 2 3), ['a', 'b', 'c']])

# One can inject a null handler (a few experimental ones provided)
na.Array(batch_with_nulls).to_columns_pysequence(handle_nulls=na.nulls_as_sentinel())
#> (['col1', 'col2'], [array([ 1., nan,  3.]), ['a', 'b', None]])

# ...by default you have to choose how to do this or we error
na.Array(batch_with_nulls).to_columns_pysequence()
#> ValueError: Null present with null_handler=nulls_forbid()
```

This will basically get you data frame conversion:

```python
import nanoarrow as na
import pandas as pd

url = "https://github.com/apache/arrow-experiments/raw/main/data/arrow-commits/arrow-commits.arrows"
names, data = na.ArrayStream.from_url(url).to_columns_pysequence(handle_nulls=na.nulls_as_sentinel())
pd.DataFrame({k: v for k, v in zip(names, data)})
#>                                          commit                      time  \
#> 0      49cdb0fe4e98fda19031c864a18e6156c6edbf3c 2024-03-07 02:00:52+00:00   
#> 1      1d966e98e41ce817d1f8c5159c0b9caa4de75816 2024-03-06 21:51:34+00:00   
#> 2      96f26a89bd73997f7532643cdb27d04b70971530 2024-03-06 20:29:15+00:00   
#> 3      ee1a8c39a55f3543a82fed900dadca791f6e9f88 2024-03-06 07:46:45+00:00   
#> 4      3d467ac7bfae03cf2db09807054c5672e1959aec 2024-03-05 16:13:32+00:00   
#> ...                                         ...                       ...   
#> 15482  23c4b08d154f8079806a1f0258d7e4af17bdf5fd 2016-02-17 12:39:03+00:00   
#> 15483  16e44e3d456219c48595142d0a6814c9c950d30c 2016-02-17 12:38:39+00:00   
#> 15484  fa5f0299f046c46e1b2f671e5e3b4f1956522711 2016-02-17 12:38:39+00:00   
#> 15485  cbc56bf8ac423c585c782d5eda5c517ea8df8e3c 2016-02-17 12:38:39+00:00   
#> 15486  d5aa7c46692474376a3c31704cfc4783c86338f2 2016-02-05 20:08:35+00:00   
#> 
#>        files  merge                                            message  
#> 0          2  False  GH-40370: [C++] Define ARROW_FORCE_INLINE for ...  
#> 1          1  False     GH-40386: [Python] Fix except clauses (#40387)  
#> 2          1  False  GH-40227: [R] ensure executable files in `crea...  
#> 3          1  False  GH-40366: [C++] Remove const qualifier from Bu...  
#> 4          1  False  GH-20127: [Python][CI] Remove legacy hdfs test...  
#> ...      ...    ...                                                ...  
#> 15482     73  False  ARROW-4: This provides an partial C++11 implem...  
#> 15483      8  False  ARROW-3: This patch includes a WIP draft speci...  
#> 15484    124  False                 ARROW-1: Initial Arrow Code Commit  
#> 15485      2  False             Update readme and add license in root.  
#> 15486      1  False                                     Initial Commit  
#> 
#> [15487 rows x 5 columns]
```
