### PR TITLE
fix(python): Add iterator for null/na type

### DIFF
--- a/python/src/nanoarrow/iterator.py
+++ b/python/src/nanoarrow/iterator.py
@@ -17,7 +17,7 @@
 
 import warnings
 from functools import cached_property
-from itertools import islice
+from itertools import islice, repeat
 from typing import Iterable, Tuple
 
 from nanoarrow._lib import CArrayView, CArrowType
@@ -482,6 +482,9 @@ class PyIterator(ArrayViewBaseIterator):
         else:
             return iter(items)
 
+    def _null_iter(self, offset, length):
+        return repeat(None, length)
+
 
 class RowTupleIterator(PyIterator):
     """Iterate over rows of a struct array (stream) where each row is a
@@ -545,6 +548,7 @@ def _get_tzinfo(tz_string, strategy=None):
 
 
 _ITEMS_ITER_LOOKUP = {
+    CArrowType.NA: "_null_iter",
     CArrowType.BINARY: "_binary_iter",
     CArrowType.LARGE_BINARY: "_binary_iter",
     CArrowType.STRING: "_string_iter",

--- a/python/tests/test_iterator.py
+++ b/python/tests/test_iterator.py
@@ -513,3 +513,8 @@ def test_iterator_extension():
 
     with pytest.warns(UnregisteredExtensionWarning):
         assert list(iter_py(extension_array)) == [1, 2, 3]
+
+
+def test_iterator_null():
+    array = na.c_array_from_buffers(na.null(), 3, [])
+    assert list(iter_py(array)) == [None, None, None]


### PR DESCRIPTION
Closes #465.

```python
import nanoarrow as na
import pyarrow as pa

arr = na.array(pa.array([None]))
arr.schema
#> <Schema> na
arr
#> nanoarrow.Array<na>[1]
#> None
```