### PR TITLE
fix: Ensure nanoarrow.hpp compiles on gcc 4.8

### DIFF
--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -906,11 +906,7 @@ inline bool operator==(ArrowStringView l, ArrowStringView r) {
 }
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView
-// clang-format off
-operator ""
-    // clang-format on
-    _v(const char* data, std::size_t size_bytes) {
+inline ArrowStringView operator"" _v(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 /// @}

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -556,11 +556,11 @@ struct Nothing {};
 template <typename T>
 class Maybe {
  public:
-  Maybe() : nothing_{Nothing{}}, is_something_{false} {}
-  Maybe(Nothing) : Maybe{} {}
+  Maybe() : nothing_(Nothing()), is_something_(false) {}
+  Maybe(Nothing) : Maybe() {}
 
   Maybe(T something)  // NOLINT(google-explicit-constructor)
-      : something_{something}, is_something_{true} {}
+      : something_(something), is_something_(true) {}
 
   explicit constexpr operator bool() const { return is_something_; }
 
@@ -575,7 +575,8 @@ class Maybe {
   T value_or(T val) const { return is_something_ ? something_ : val; }
 
  private:
-  static_assert(std::is_trivially_copyable<T>::value, "");
+  // When support for gcc 4.8 is dropped, we should also assert
+  // is_trivially_copyable<T>::value
   static_assert(std::is_trivially_destructible<T>::value, "");
 
   union {
@@ -631,7 +632,7 @@ struct InputRange {
   };
 
   iterator begin() { return {this, next()}; }
-  iterator end() { return {this, {}}; }
+  iterator end() { return {this, ValueOrFalsy()}; }
 };
 }  // namespace internal
 
@@ -825,7 +826,7 @@ class ViewArrayAsFixedSizeBytes {
 class ViewArrayStream {
  public:
   ViewArrayStream(ArrowArrayStream* stream, ArrowErrorCode* code, ArrowError* error)
-      : range_{Next{this, stream, UniqueArray{}}}, code_{code}, error_{error} {}
+      : range_{Next{this, stream, UniqueArray()}}, code_{code}, error_{error} {}
 
   ViewArrayStream(ArrowArrayStream* stream, ArrowError* error)
       : ViewArrayStream{stream, &internal_code_, error} {}
@@ -905,7 +906,11 @@ inline bool operator==(ArrowStringView l, ArrowStringView r) {
 }
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView operator""_v(const char* data, std::size_t size_bytes) {
+inline ArrowStringView
+// clang-format off
+operator ""
+    // clang-format on
+    _v(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 /// @}

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -271,7 +271,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsTest) {
   struct ArrowArray array {};
   array.length = 7;
   array.null_count = 2;
-  array.n_buffers = std::size(buffers);
+  array.n_buffers = 2;
   array.buffers = buffers;
 
   int i = 0;
@@ -300,7 +300,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsBytesTest) {
   struct ArrowArray array {};
   array.length = 7;
   array.null_count = 2;
-  array.n_buffers = std::size(buffers);
+  array.n_buffers = 2;
   array.buffers = buffers;
 
   int i = 0;
@@ -327,7 +327,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsFixedSizeBytesTest) {
   struct ArrowArray array {};
   array.length = 7;
   array.null_count = 2;
-  array.n_buffers = std::size(buffers);
+  array.n_buffers = 2;
   array.buffers = buffers;
 
   int i = 0;


### PR DESCRIPTION
Apparently gcc4.8 takes issue with the use of braces in some places and does not provide `is_trivially_copyable()` or `std::size()` 🤷 

Closes #462 .

Tested via

```
export NANOARROW_PLATFORM=centos7
export NANOARROW_ARCH=arm64  # because I'm on MacOS M1
docker compose run --rm verify
```