### PR TITLE
chore(dev/release): Do nanoarrow vendoring using R_BIN instead of R CMD INSTALL on Windows

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -277,11 +277,12 @@ test_r() {
 
   show_info "Build the R package source tarball"
 
-  # Running R CMD INSTALL on the R source directory is the most reliable cross-platform
-  # method to ensure the proper version of nanoarrow is vendored into the R package.
-  # Do this in a temporary library so not to overwrite the a user's existing package.
+  # Run bootstrap.R from within the r subdirectory
+  pushd r
+  "$R_BIN" -e 'source("bootstrap.R", echo = TRUE)'
+  popd
+
   mkdir "$NANOARROW_TMPDIR/tmplib"
-  "$R_BIN" CMD INSTALL r --preclean --library="$NANOARROW_TMPDIR/tmplib"
 
   # Builds the R source tarball
   pushd $NANOARROW_TMPDIR

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -12,3 +12,5 @@
 ^bootstrap\.R$
 ^\.cache$
 ^compile_commands\.json$
+^configure\.win$
+^configure$


### PR DESCRIPTION
It seems that running R CMD INSTALL is not sufficient on Windows to vendor the proper files. It may have worked by accident in the past because the vendored files already existed in my local checkout. I don't think there are many people verifying on Windows; however I think removing `configure.win` (since it seems not to run anyway) and configure on build is a better option.