### PR TITLE
fix(python): Fix use of memoryview to write fill to the buffer builder

### DIFF
--- a/python/src/nanoarrow/_lib.pyi
+++ b/python/src/nanoarrow/_lib.pyi
@@ -236,7 +236,7 @@ class CBuffer:
     data_type_id: Incomplete
     element_size_bits: Incomplete
     format: Incomplete
-    item_size: Incomplete
+    itemsize: Incomplete
     n_elements: Incomplete
     size_bytes: Incomplete
     @classmethod
@@ -264,6 +264,7 @@ class CBufferBuilder:
     __pyx_vtable__: ClassVar[PyCapsule] = ...
     capacity_bytes: Incomplete
     format: Incomplete
+    itemsize: Incomplete
     size_bytes: Incomplete
     @classmethod
     def __init__(cls, *args, **kwargs) -> None:
@@ -310,8 +311,15 @@ class CBufferBuilder:
 
         This method returns the number of elements that were written.
         """
+    def write_fill(self, *args, **kwargs):
+        """Write fill bytes to this buffer
+
+        Appends the byte ``value`` to this buffer ``size_bytes`` times.
+        """
     def __buffer__(self, *args, **kwargs):
         """Return a buffer object that exposes the underlying memory of the object."""
+    def __len__(self) -> int:
+        """Return len(self)."""
     def __reduce__(self): ...
     def __release_buffer__(self, *args, **kwargs):
         """Release the buffer object that exposes the underlying memory of the object."""
@@ -323,7 +331,7 @@ class CBufferView:
     device: Incomplete
     element_size_bits: Incomplete
     format: Incomplete
-    item_size: Incomplete
+    itemsize: Incomplete
     n_elements: Incomplete
     size_bytes: Incomplete
     @classmethod

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2311,12 +2311,10 @@ cdef class CBufferBuilder:
     """
     cdef CBuffer _buffer
     cdef bint _locked
-    cdef bint _lock_enabled
 
     def __cinit__(self):
         self._buffer = CBuffer.empty()
         self._locked = False
-        self._lock_enabled = True
 
     cdef _assert_unlocked(self):
         if self._locked:
@@ -2336,8 +2334,7 @@ cdef class CBufferBuilder:
             flags
         )
 
-        if self._lock_enabled:
-            self._locked = True
+        self._locked = True
 
     def __releasebuffer__(self, Py_buffer* buffer):
         self._locked = False

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2318,16 +2318,6 @@ cdef class CBufferBuilder:
         self._locked = False
         self._lock_enabled = True
 
-    def _disable_lock_on_aquire_writable(self):
-        """Disable buffer protocol locking
-
-        When running on PyPy, the locking causes problems because the
-        releasebuffer callback does not appear to be called promptly.
-        Often the passing of this object is done in a way where it is
-        written to in controlled ways, so allow bypassing the lock.
-        """
-        self._lock_enabled = False
-
     cdef _assert_unlocked(self):
         if self._locked:
             raise BufferError("CBufferBuilder is locked")
@@ -2407,6 +2397,15 @@ cdef class CBufferBuilder:
 
         self._buffer._ptr.size_bytes = new_size
         return self
+
+    def write_fill(self, uint8_t value, int64_t size_bytes):
+        """Write fill bytes to this buffer
+
+        Appends the byte ``value`` to this buffer ``size_bytes`` times.
+        """
+        self._assert_unlocked()
+        cdef int code = ArrowBufferAppendFill(self._buffer._ptr, value, size_bytes)
+        Error.raise_error_not_ok("ArrowBufferAppendFill", code)
 
     def write(self, content):
         """Write bytes to this buffer

--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -2333,7 +2333,6 @@ cdef class CBufferBuilder:
             0,
             flags
         )
-
         self._locked = True
 
     def __releasebuffer__(self, Py_buffer* buffer):

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -333,24 +333,19 @@ class ToPyBufferConverter(ArrayViewVisitor):
         self._builder = CBufferBuilder()
         self._builder.set_format(self._schema_view.buffer_format)
 
-        # On PyPy, the lock-on-write behaviour causes problems because the
-        # lock is not released promptly. We control all the calls here, so
-        # disable this check.
-        self._builder._disable_lock_on_aquire_writable()
-
         if total_elements is not None:
             element_size_bits = self._schema_view.layout.element_size_bits[1]
             element_size_bytes = element_size_bits // 8
             self._builder.reserve_bytes(total_elements * element_size_bytes)
 
     def visit_chunk_view(self, array_view: CArrayView) -> None:
-        converter = self._builder
+        builder = self._builder
         offset, length = array_view.offset, array_view.length
-        dst_bytes = length * converter.itemsize
+        dst_bytes = length * builder.itemsize
 
-        converter.reserve_bytes(dst_bytes)
-        array_view.buffer(1).copy_into(converter, offset, length, len(converter))
-        converter.advance(dst_bytes)
+        builder.reserve_bytes(dst_bytes)
+        array_view.buffer(1).copy_into(builder, offset, length, len(builder))
+        builder.advance(dst_bytes)
 
     def finish(self) -> Any:
         return self._builder.finish()
@@ -360,21 +355,15 @@ class ToBooleanBufferConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format("?")
-
-        # On PyPy, the lock-on-write behaviour causes problems because the
-        # lock is not released promptly. We control all the calls here, so
-        # disable this check.
-        self._builder._disable_lock_on_aquire_writable()
-
         if total_elements is not None:
             self._builder.reserve_bytes(total_elements)
 
     def visit_chunk_view(self, array_view: CArrayView) -> None:
-        converter = self._builder
+        builder = self._builder
         offset, length = array_view.offset, array_view.length
-        converter.reserve_bytes(length)
-        array_view.buffer(1).unpack_bits_into(converter, offset, length, len(converter))
-        converter.advance(length)
+        builder.reserve_bytes(length)
+        array_view.buffer(1).unpack_bits_into(builder, offset, length, len(builder))
+        builder.advance(length)
 
     def finish(self) -> Any:
         return self._builder.finish()
@@ -400,12 +389,6 @@ class ToNullableSequenceConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format("?")
-
-        # On PyPy, the lock-on-write behaviour causes problems because the
-        # lock is not released promptly. We control all the calls here, so
-        # disable this check.
-        self._builder._disable_lock_on_aquire_writable()
-
         self._length = 0
 
         self._converter.begin(total_elements)
@@ -420,7 +403,7 @@ class ToNullableSequenceConverter(ArrayViewVisitor):
         if chunk_contains_nulls:
             current_length = self._length
             if not bitmap_allocated:
-                self._fill_valid(current_length)
+                builder.write_fill(1, current_length)
 
             builder.reserve_bytes(length)
             array_view.buffer(0).unpack_bits_into(
@@ -429,7 +412,7 @@ class ToNullableSequenceConverter(ArrayViewVisitor):
             builder.advance(length)
 
         elif bitmap_allocated:
-            self._fill_valid(length)
+            builder.write_fill(1, length)
 
         self._length += length
         self._converter.visit_chunk_view(array_view)
@@ -438,13 +421,6 @@ class ToNullableSequenceConverter(ArrayViewVisitor):
         is_valid = self._builder.finish()
         data = self._converter.finish()
         return self._handle_nulls(is_valid if len(is_valid) > 0 else None, data)
-
-    def _fill_valid(self, length):
-        builder = self._builder
-        builder.reserve_bytes(length)
-        out_start = len(builder)
-        memoryview(builder)[out_start : out_start + length] = b"\x01" * length
-        builder.advance(length)
 
 
 def _resolve_converter_cls(schema, handle_nulls=None):

--- a/python/src/nanoarrow/visitor.py
+++ b/python/src/nanoarrow/visitor.py
@@ -333,6 +333,11 @@ class ToPyBufferConverter(ArrayViewVisitor):
         self._builder = CBufferBuilder()
         self._builder.set_format(self._schema_view.buffer_format)
 
+        # On PyPy, the lock-on-write behaviour causes problems because the
+        # lock is not released promptly. We control all the calls here, so
+        # disable this check.
+        self._builder._disable_lock_on_aquire_writable()
+
         if total_elements is not None:
             element_size_bits = self._schema_view.layout.element_size_bits[1]
             element_size_bytes = element_size_bits // 8
@@ -355,6 +360,11 @@ class ToBooleanBufferConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format("?")
+
+        # On PyPy, the lock-on-write behaviour causes problems because the
+        # lock is not released promptly. We control all the calls here, so
+        # disable this check.
+        self._builder._disable_lock_on_aquire_writable()
 
         if total_elements is not None:
             self._builder.reserve_bytes(total_elements)
@@ -390,6 +400,12 @@ class ToNullableSequenceConverter(ArrayViewVisitor):
     def begin(self, total_elements: Union[int, None]):
         self._builder = CBufferBuilder()
         self._builder.set_format("?")
+
+        # On PyPy, the lock-on-write behaviour causes problems because the
+        # lock is not released promptly. We control all the calls here, so
+        # disable this check.
+        self._builder._disable_lock_on_aquire_writable()
+
         self._length = 0
 
         self._converter.begin(total_elements)


### PR DESCRIPTION
At least one test is failing on pypy because of an unreleased buffer. This was due to the line:

```python
memoryview(builder)[out_start : out_start + length] = b"\x01" * length
```

...which relied on the deletion of `memoryview(builder)` to release the `builder` buffer. One solution is:

```python
with memoryview(builder) as mv:
  mv[out_start : out_start + length] = b"\x01" * length
```

However, we also have `ArrowBufferAppendFill()` in the C library, so instead, this PR wires that up and uses it (which should be faster, anyway).