### PR TITLE
fix(python): Skip test relying on memoryview context manager on PyPy 3.8

### DIFF
--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -222,6 +222,8 @@ def test_c_buffer_builder():
 
 
 def test_c_buffer_builder_buffer_protocol():
+    import platform
+
     builder = CBufferBuilder()
     builder.reserve_bytes(1)
 
@@ -236,8 +238,12 @@ def test_c_buffer_builder_buffer_protocol():
 
         mv[builder.size_bytes] = ord("k")
 
-    builder.advance(1)
+    if platform.python_implementation() == "PyPy" and platform.python_version_tuple()[
+        :2
+    ] == ("3", "8"):
+        pytest.skip("memoryview() release is not guaranteed on PyPy 3.8")
 
+    builder.advance(1)
     assert bytes(builder.finish()) == b"k"
 
 


### PR DESCRIPTION
Apparently the context manager for the memoryview does not promptly release its source buffer in PyPy 3.8. This PR skips the one assertion where this matters on just that platform.