### PR TITLE
chore(python): Skip buffer write lock test on PyPy

### DIFF
--- a/python/tests/test_c_buffer.py
+++ b/python/tests/test_c_buffer.py
@@ -238,10 +238,8 @@ def test_c_buffer_builder_buffer_protocol():
 
         mv[builder.size_bytes] = ord("k")
 
-    if platform.python_implementation() == "PyPy" and platform.python_version_tuple()[
-        :2
-    ] == ("3", "8"):
-        pytest.skip("memoryview() release is not guaranteed on PyPy 3.8")
+    if platform.python_implementation() == "PyPy":
+        pytest.skip("memoryview() release is not guaranteed on PyPy")
 
     builder.advance(1)
     assert bytes(builder.finish()) == b"k"


### PR DESCRIPTION
...apparently my local PyPy test was not sufficient to ensure that all the tests pass on PyPy. This seems to be specific to the `memoryview()` (not C extensions that properly release the buffer).