### PR TITLE
chore: Enable extensions to be built from the main CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,5 @@ if(NANOARROW_DEVICE)
 endif()
 
 if(NANOARROW_BUILD_BENCHMARKS)
-  add_subdirectory(extensions/nanoarrow_ipc)
   add_subdirectory(dev/benchmarks)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ set(NANOARROW_VERSION_MAJOR "${nanoarrow_VERSION_MAJOR}")
 set(NANOARROW_VERSION_MINOR "${nanoarrow_VERSION_MINOR}")
 set(NANOARROW_VERSION_PATCH "${nanoarrow_VERSION_PATCH}")
 
+# Feature options
+option(NANOARROW_IPC "Build IPC extension" OFF)
+option(NANOARROW_DEVICE "Build device extension" OFF)
+
+# Development options
 option(NANOARROW_BUILD_TESTS "Build tests" OFF)
 option(NANOARROW_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(NANOARROW_BUILD_INTEGRATION_TESTS
@@ -305,6 +310,14 @@ if(NANOARROW_BUILD_TESTS)
   gtest_discover_tests(nanoarrow_hpp_test DISCOVERY_TIMEOUT 10)
   gtest_discover_tests(nanoarrow_testing_test DISCOVERY_TIMEOUT 10)
   gtest_discover_tests(c_data_integration_test DISCOVERY_TIMEOUT 10)
+endif()
+
+if(NANOARROW_BUILD_BENCHMARKS OR NANOARROW_IPC)
+  add_subdirectory(extensions/nanoarrow_ipc)
+endif()
+
+if(NANOARROW_DEVICE)
+  add_subdirectory(extensions/nanoarrow_device)
 endif()
 
 if(NANOARROW_BUILD_BENCHMARKS)

--- a/extensions/nanoarrow_device/CMakeLists.txt
+++ b/extensions/nanoarrow_device/CMakeLists.txt
@@ -35,8 +35,8 @@ option(NANOARROW_DEVICE_CODE_COVERAGE "Enable coverage reporting" OFF)
 add_library(device_coverage_config INTERFACE)
 
 if(NANOARROW_DEVICE_BUILD_TESTS OR NOT NANOARROW_DEVICE_BUNDLE)
-   # Lazily add the nanoarrow dependency
-   if(NOT TARGET nanoarrow)
+  # Lazily add the nanoarrow dependency
+  if(NOT TARGET nanoarrow)
     fetchcontent_declare(nanoarrow SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 
     # Don't install nanoarrow because of this configuration

--- a/extensions/nanoarrow_device/CMakeLists.txt
+++ b/extensions/nanoarrow_device/CMakeLists.txt
@@ -35,16 +35,16 @@ option(NANOARROW_DEVICE_CODE_COVERAGE "Enable coverage reporting" OFF)
 add_library(device_coverage_config INTERFACE)
 
 if(NANOARROW_DEVICE_BUILD_TESTS OR NOT NANOARROW_DEVICE_BUNDLE)
-  # Add the nanoarrow dependency. nanoarrow is not linked into the
-  # nanoarrow_device library (the caller must link this themselves);
-  # however, we need nanoarrow.h to build nanoarrow_device.c.
-  fetchcontent_declare(nanoarrow SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
+   # Lazily add the nanoarrow dependency
+   if(NOT TARGET nanoarrow)
+    fetchcontent_declare(nanoarrow SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 
-  # Don't install nanoarrow because of this configuration
-  fetchcontent_getproperties(nanoarrow)
-  if(NOT nanoarrow_POPULATED)
-    fetchcontent_populate(nanoarrow)
-    add_subdirectory(${nanoarrow_SOURCE_DIR} ${nanoarrow_BINARY_DIR} EXCLUDE_FROM_ALL)
+    # Don't install nanoarrow because of this configuration
+    fetchcontent_getproperties(nanoarrow)
+    if(NOT nanoarrow_POPULATED)
+      fetchcontent_populate(nanoarrow)
+      add_subdirectory(${nanoarrow_SOURCE_DIR} ${nanoarrow_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This is part of a solution to #407 in that it enables `cmake . -DNANOARROW_IPC=ON`; however, I don't think it completely solves it since I am not sure that the full suite of bundle/install/fetchcontent will work here yet.

The motivation for this is to make it easier to move pieces of the extensions into the main nanoarrow library that make sense (e.g., the definitions for the device structs), and eventually eliminate the extensions folder. I am planning in the next month or so to clean up the device extension and after that to work on the write component of the IPC extension. In combination with the testing utilities that were recently added, I think it makes the most sense for these to live at the top level and be developed together.