### PR TITLE
refactor(extensions/nanoarrow_device): Migrate CUDA device implementation to use the driver API

### DIFF
--- a/extensions/nanoarrow_device/CMakeLists.txt
+++ b/extensions/nanoarrow_device/CMakeLists.txt
@@ -119,7 +119,7 @@ else()
   if(NANOARROW_DEVICE_WITH_CUDA)
     find_package(CUDAToolkit REQUIRED)
     set(NANOARROW_DEVICE_SOURCES_CUDA src/nanoarrow/nanoarrow_device_cuda.c)
-    set(NANOARROW_DEVICE_LIBS_CUDA CUDA::cudart_static)
+    set(NANOARROW_DEVICE_LIBS_CUDA CUDA::cuda_driver)
     set(NANOARROW_DEVICE_DEFS_CUDA "NANOARROW_DEVICE_WITH_CUDA")
   endif()
 

--- a/extensions/nanoarrow_device/CMakeLists.txt
+++ b/extensions/nanoarrow_device/CMakeLists.txt
@@ -138,6 +138,7 @@ else()
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
   target_link_libraries(nanoarrow_device PUBLIC ${NANOARROW_DEVICE_LIBS_METAL}
                                                 ${NANOARROW_DEVICE_LIBS_CUDA})
+  target_compile_definitions(nanoarrow_device PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
   install(TARGETS nanoarrow_device DESTINATION lib)
   install(FILES src/nanoarrow/nanoarrow_device.h DESTINATION include/nanoarrow)

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <asm-generic/errno-base.h>
 #include <errno.h>
 
 #include "nanoarrow.h"
@@ -159,13 +160,18 @@ struct ArrowDevice* ArrowDeviceResolve(ArrowDeviceType device_type, int64_t devi
 
 ArrowErrorCode ArrowDeviceArrayInit(struct ArrowDevice* device,
                                     struct ArrowDeviceArray* device_array,
-                                    struct ArrowArray* array) {
+                                    struct ArrowArray* array, void* sync_event) {
   if (device->array_init != NULL) {
-    return device->array_init(device, device_array, array);
-  } else {
-    ArrowDeviceArrayInitDefault(device, device_array, array);
-    return NANOARROW_OK;
+    return device->array_init(device, device_array, array, sync_event);
   }
+
+  // Handling a sync event is not supported in the default constructor
+  if (sync_event != NULL) {
+    return EINVAL;
+  }
+
+  ArrowDeviceArrayInitDefault(device, device_array, array);
+  return NANOARROW_OK;
 }
 
 ArrowErrorCode ArrowDeviceBufferInit(struct ArrowDevice* device_src,
@@ -224,7 +230,7 @@ static int ArrowDeviceBasicArrayStreamGetNext(struct ArrowDeviceArrayStream* arr
   struct ArrowArray tmp;
   NANOARROW_RETURN_NOT_OK(
       private_data->naive_stream.get_next(&private_data->naive_stream, &tmp));
-  int result = ArrowDeviceArrayInit(private_data->device, device_array, &tmp);
+  int result = ArrowDeviceArrayInit(private_data->device, device_array, &tmp, NULL);
   if (result != NANOARROW_OK) {
     ArrowArrayRelease(&tmp);
     return result;
@@ -449,7 +455,7 @@ ArrowErrorCode ArrowDeviceArrayViewCopy(struct ArrowDeviceArrayView* src,
     return result;
   }
 
-  result = ArrowDeviceArrayInit(device_dst, dst, &tmp);
+  result = ArrowDeviceArrayInit(device_dst, dst, &tmp, NULL);
   if (result != NANOARROW_OK) {
     ArrowArrayRelease(&tmp);
     return result;

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.c
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <asm-generic/errno-base.h>
 #include <errno.h>
 
 #include "nanoarrow.h"

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.h
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device.h
@@ -177,7 +177,7 @@ struct ArrowDevice {
   /// device_array->sync_event (if sync_event applies to this device type).
   ArrowErrorCode (*array_init)(struct ArrowDevice* device,
                                struct ArrowDeviceArray* device_array,
-                               struct ArrowArray* array);
+                               struct ArrowArray* array, void* sync_event);
 
   /// \brief Move an ArrowDeviceArray between devices without copying buffers
   ///
@@ -243,7 +243,7 @@ struct ArrowDeviceArrayView {
 /// initialize an ArrowDeviceArray.
 ArrowErrorCode ArrowDeviceArrayInit(struct ArrowDevice* device,
                                     struct ArrowDeviceArray* device_array,
-                                    struct ArrowArray* array);
+                                    struct ArrowArray* array, void* sync_event);
 
 /// \brief Initialize an ArrowDeviceArrayView
 ///

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
@@ -220,6 +220,9 @@ static ArrowErrorCode ArrowDeviceCudaBufferCopyInternal(struct ArrowDevice* devi
                                                         struct ArrowBufferView dst,
                                                         int* n_pop_context,
                                                         struct ArrowError* error) {
+  // Note: the device_src/sync event must be synchronized before calling these methods,
+  // even though the cuMemcpyXXX() functions may do this automatically in some cases.
+
   if (device_src->device_type == ARROW_DEVICE_CPU &&
       device_dst->device_type == ARROW_DEVICE_CUDA) {
     struct ArrowDeviceCudaPrivate* dst_private =
@@ -275,17 +278,14 @@ static ArrowErrorCode ArrowDeviceCudaBufferCopyInternal(struct ArrowDevice* devi
 
   } else if (device_src->device_type == ARROW_DEVICE_CPU &&
              device_dst->device_type == ARROW_DEVICE_CUDA_HOST) {
-    // TODO: Synchronize device_src?
     memcpy((void*)dst.data.data, src.data.data, (size_t)src.size_bytes);
 
   } else if (device_src->device_type == ARROW_DEVICE_CUDA_HOST &&
              device_dst->device_type == ARROW_DEVICE_CUDA_HOST) {
-    // TODO: Synchronize device_src?
     memcpy((void*)dst.data.data, src.data.data, (size_t)src.size_bytes);
 
   } else if (device_src->device_type == ARROW_DEVICE_CUDA_HOST &&
              device_dst->device_type == ARROW_DEVICE_CPU) {
-    // TODO: Synchronize device_src?
     memcpy((void*)dst.data.data, src.data.data, (size_t)src.size_bytes);
 
   } else {

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda.c
@@ -18,7 +18,6 @@
 #include <cuda.h>
 
 #include "nanoarrow_device.h"
-#include "nanoarrow_types.h"
 
 static inline void ArrowDeviceCudaSetError(CUresult err, const char* op,
                                            struct ArrowError* error) {

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
@@ -46,6 +46,7 @@ class CudaTemporaryContext {
     if (initialized_) {
       CUcontext unused;
       cuCtxPopCurrent(&unused);
+      cuDevicePrimaryCtxRelease(device_);
     }
   }
 
@@ -72,6 +73,8 @@ TEST(NanoarrowDeviceCuda, GetDevice) {
 TEST(NanoarrowDeviceCuda, DeviceCudaBufferInit) {
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowDevice* gpu = ArrowDeviceCuda(ARROW_DEVICE_CUDA, 0);
+  ASSERT_NE(gpu, nullptr);
+
   struct ArrowBuffer buffer_gpu;
   struct ArrowBuffer buffer;
   uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
@@ -101,6 +104,8 @@ TEST(NanoarrowDeviceCuda, DeviceCudaBufferInit) {
 TEST(NanoarrowDeviceCuda, DeviceCudaHostBufferInit) {
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowDevice* gpu = ArrowDeviceCuda(ARROW_DEVICE_CUDA_HOST, 0);
+  ASSERT_NE(gpu, nullptr);
+
   struct ArrowBuffer buffer_gpu;
   struct ArrowBuffer buffer;
   uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
@@ -129,13 +134,15 @@ TEST(NanoarrowDeviceCuda, DeviceCudaHostBufferInit) {
 }
 
 TEST(NanoarrowDeviceCuda, DeviceCudaBufferCopy) {
-  CudaTemporaryContext ctx(0);
-  ASSERT_TRUE(ctx.valid());
-
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowDevice* gpu = ArrowDeviceCuda(ARROW_DEVICE_CUDA, 0);
+  ASSERT_NE(gpu, nullptr);
+
   uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05};
   struct ArrowBufferView cpu_view = {data, sizeof(data)};
+
+  CudaTemporaryContext ctx(0);
+  ASSERT_TRUE(ctx.valid());
 
   CUdeviceptr gpu_dest;
   CUresult result = cuMemAlloc(&gpu_dest, sizeof(data));

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_cuda_test.cc
@@ -210,7 +210,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
-  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array), NANOARROW_OK);
+  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array, nullptr), NANOARROW_OK);
 
   ArrowDeviceArrayViewInit(&device_array_view);
   ArrowArrayViewInitFromType(&device_array_view.array_view, string_type);

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal.cc
@@ -153,7 +153,8 @@ static void ArrowDeviceMetalArrayRelease(struct ArrowArray* array) {
 
 static ArrowErrorCode ArrowDeviceMetalArrayInit(struct ArrowDevice* device,
                                                 struct ArrowDeviceArray* device_array,
-                                                struct ArrowArray* array) {
+                                                struct ArrowArray* array,
+                                                void* sync_event) {
   struct ArrowDeviceMetalArrayPrivate* private_data =
       (struct ArrowDeviceMetalArrayPrivate*)ArrowMalloc(
           sizeof(struct ArrowDeviceMetalArrayPrivate));
@@ -161,8 +162,8 @@ static ArrowErrorCode ArrowDeviceMetalArrayInit(struct ArrowDevice* device,
     return ENOMEM;
   }
 
-  auto mtl_device = reinterpret_cast<MTL::Device*>(device->private_data);
-  private_data->event = mtl_device->newSharedEvent();
+  // One can create a new event with mtl_device->newSharedEvent();
+  private_data->event = sync_event;
 
   memset(device_array, 0, sizeof(struct ArrowDeviceArray));
   device_array->array = *array;

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_metal_test.cc
@@ -228,7 +228,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
-  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array), NANOARROW_OK);
+  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array, nullptr), NANOARROW_OK);
 
   ArrowDeviceArrayViewInit(&device_array_view);
   ArrowArrayViewInitFromType(&device_array_view.array_view, string_type);

--- a/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
+++ b/extensions/nanoarrow_device/src/nanoarrow/nanoarrow_device_test.cc
@@ -81,7 +81,7 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCpuArrayViewString) {
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
-  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array), NANOARROW_OK);
+  ASSERT_EQ(ArrowDeviceArrayInit(cpu, &device_array, &array, nullptr), NANOARROW_OK);
 
   ArrowDeviceArrayViewInit(&device_array_view);
   ArrowArrayViewInitFromType(&device_array_view.array_view, string_type);


### PR DESCRIPTION
Closes #246.

This PR doesn't change much about the existing implementation (and I think there are some things that need to be changed!), it just eliminates the dependency on the runtime library. The driver API is a better fit here anyway since we're doing very low-level things!

This isn't tested in CI yet (working on that here: https://github.com/apache/arrow-nanoarrow/pull/490 ).