### PR TITLE
fix(r): Avoid flatcc aligned_alloc() call when compiling R package

### DIFF
--- a/r/src/Makevars
+++ b/r/src/Makevars
@@ -15,4 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-I../inst/include -I../src
+# -DFLATCC_USE_GENERIC_ALIGNED_ALLOC is needed to support compilation on systems
+# that do not provide aligned_alloc. Allocating flatbuffers memory is not
+# performance-critical for what we do in the nanoarrow R package (and may not
+# occur at all until IPC write support is added)
+PKG_CPPFLAGS=-I../inst/include -I../src -DFLATCC_USE_GENERIC_ALIGNED_ALLOC


### PR DESCRIPTION
Closes #493.

We could be fancier and check for the presence of aligned_alloc() or guard it in a define based on the C standard; however, I don't think we use it at all right now and even when write support is added I don't think it will matter for how we use flatbuffers in the IPC format.