### PR TITLE
test: test with the `HalfFloatType` from arrow

### DIFF
--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -2493,6 +2493,76 @@ void TestGetFromNumericArrayView() {
   ArrowSchemaRelease(&schema);
 }
 
+void TestGetFromNumericArrayViewWithHalfFloatType() {
+  struct ArrowArray array;
+  struct ArrowSchema schema;
+  struct ArrowArrayView array_view;
+  struct ArrowError error;
+
+  auto type = TypeTraits<HalfFloatType>::type_singleton();
+
+  // Array with nulls
+  auto builder = NumericBuilder<HalfFloatType>();
+  ARROW_EXPECT_OK(builder.Append(ArrowFloatToHalfFloat(1.0)));
+  ARROW_EXPECT_OK(builder.AppendNulls(2));
+  ARROW_EXPECT_OK(builder.Append(ArrowFloatToHalfFloat(4)));
+  auto maybe_arrow_array = builder.Finish();
+  ARROW_EXPECT_OK(maybe_arrow_array);
+  auto arrow_array = maybe_arrow_array.ValueUnsafe();
+
+  ARROW_EXPECT_OK(ExportArray(*arrow_array, &array, &schema));
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 2), 1);
+  EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 3), 0);
+
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 3), 4);
+  EXPECT_EQ(ArrowArrayViewGetUIntUnsafe(&array_view, 3), 4);
+  EXPECT_EQ(ArrowArrayViewGetDoubleUnsafe(&array_view, 3), 4.0);
+
+  auto string_view = ArrowArrayViewGetStringUnsafe(&array_view, 0);
+  EXPECT_EQ(string_view.data, nullptr);
+  EXPECT_EQ(string_view.size_bytes, 0);
+  auto buffer_view = ArrowArrayViewGetBytesUnsafe(&array_view, 0);
+  EXPECT_EQ(buffer_view.data.data, nullptr);
+  EXPECT_EQ(buffer_view.size_bytes, 0);
+
+  ArrowArrayViewReset(&array_view);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
+
+  // Array without nulls (Arrow does not allocate the validity buffer)
+  builder = NumericBuilder<HalfFloatType>();
+  ARROW_EXPECT_OK(builder.Append(ArrowFloatToHalfFloat(1)));
+  ARROW_EXPECT_OK(builder.Append(ArrowFloatToHalfFloat(2)));
+  maybe_arrow_array = builder.Finish();
+  ARROW_EXPECT_OK(maybe_arrow_array);
+  arrow_array = maybe_arrow_array.ValueUnsafe();
+
+  ARROW_EXPECT_OK(ExportArray(*arrow_array, &array, &schema));
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK);
+
+  // We're trying to test behavior with no validity buffer, so make sure that's true
+  ASSERT_EQ(array_view.buffer_views[0].data.data, nullptr);
+
+  EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewIsNull(&array_view, 1), 0);
+
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 0), 1);
+  EXPECT_EQ(ArrowArrayViewGetUIntUnsafe(&array_view, 1), 2);
+  EXPECT_EQ(ArrowArrayViewGetDoubleUnsafe(&array_view, 1), 2);
+
+  ArrowArrayViewReset(&array_view);
+  ArrowArrayRelease(&array);
+  ArrowSchemaRelease(&schema);
+}
+
 TEST(ArrayViewTest, ArrayViewTestGetNumeric) {
   TestGetFromNumericArrayView<Int64Type>();
   TestGetFromNumericArrayView<UInt64Type>();
@@ -2504,6 +2574,7 @@ TEST(ArrayViewTest, ArrayViewTestGetNumeric) {
   TestGetFromNumericArrayView<UInt32Type>();
   TestGetFromNumericArrayView<DoubleType>();
   TestGetFromNumericArrayView<FloatType>();
+  TestGetFromNumericArrayViewWithHalfFloatType();
 }
 
 TEST(ArrayViewTest, ArrayViewTestGetFloat16) {

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -547,8 +547,8 @@ TEST(DecimalTest, DecimalRoundtripBitshiftTest) {
 // https://github.com/apache/arrow/blob/main/go/arrow/float16/float16_test.go
 TEST(HalfFloatTest, FloatAndHalfFloatRoundTrip) {
   uint16_t cases_bits[] = {
-      0x8000,  0x7c00, 0xfc00, 0x3c00, 0x4000, 0xc000,
-      +0x0000, 0x5b8f, 0xdb8f, 0x48c8, 0xc8c8,
+      0x8000, 0x7c00, 0xfc00, 0x3c00, 0x4000, 0xc000,
+      0x0000, 0x5b8f, 0xdb8f, 0x48c8, 0xc8c8,
   };
   float cases_float[] = {
       -0.0, INFINITY, -INFINITY, 1, 2, -2, 0, 241.875, -241.875, 9.5625, -9.5625,


### PR DESCRIPTION
Hi this PR adds an extra test case that tests `ArrowFloatToHalfFloat` and `ArrowArrayViewGet{Double,Int,UInt}Unsafe` with the `HalfFloatType` from arrow.

https://github.com/apache/arrow/blob/255dbf990c3d3e5fb1270a2a11efe0af2be195ab/cpp/src/arrow/type.h#L704-L713

And sorry that I didn't know there's a `HalfFloatType` in arrow-cpp when I was doing #501 🥲.

Sadly that we cannot simply append `TestGetFromNumericArrayView<HalfFloatType>();` at the end of the `ArrayViewTestGetNumeric` test suite because we have to convert floats to half-floats using `ArrowFloatToHalfFloat` before calling `builder.Append` (otherwise we'll get weird values back in the subsequent `ArrowArrayViewGet{Double,Int,UInt}Unsafe` calls).