### PR TITLE
refactor!: More idiomatic meson usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ CMakeUserPresets.json
 __pycache__
 
 # meson subprojects
-subprojects
+subprojects/*
+!subprojects/*.wrap
 
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ CMakeUserPresets.json
 *.swp
 __pycache__
 
-# meson subprojects
+# meson subprojects - wrap files need to be kept to let meson download
+# dependencies as needed, but dependencies themselves should not be versioned
 subprojects/*
 !subprojects/*.wrap
 

--- a/README.md
+++ b/README.md
@@ -100,35 +100,23 @@ Tests can be run with `ctest`.
 
 ### Building with Meson
 
-CMake is the officially supported build system for nanoarrow. However, the Meson backend is an experimental feature you may also wish to try.
-
-To run the test suite with Meson, you will want to first install the testing dependencies via the wrap database (n.b. no wrap database entry exists for Arrow - that must be installed separately).
-
-```sh
-mkdir subprojects
-meson wrap install gtest
-meson wrap install google-benchmark
-meson wrap install nlohmann_json
-```
-
-The Arrow C++ library must also be discoverable via pkg-config build tests.
-
-You can then set up your build directory:
+CMake is the officially supported build system for nanoarrow. However, the Meson
+backend is an experimental feature you may also wish to try.
 
 ```sh
 meson setup builddir
 cd builddir
 ```
 
-And configure your project (this could have also been done inline with `setup`)
+After setting up your project, be sure to enable the options you want:
 
 ```sh
-meson configure -DNANOARROW_BUILD_TESTS=true -DNANOARROW_BUILD_BENCHMARKS=true
+meson configure -Dtests=true -Dbenchmarks=true
 ```
 
-Note that if your Arrow pkg-config profile is installed in a non-standard location
-on your system, you may pass the `--pkg-config-path <path to directory with arrow.pc>`
-to either the setup or configure steps above.
+If Arrow is installed in a non-standard location on your system, you may need to
+pass the `--pkg-config-path <path to directory with arrow.pc>` argument to either
+the setup or configure steps above.
 
 With the above out of the way, the `compile` command should take care of the rest:
 
@@ -136,7 +124,8 @@ With the above out of the way, the `compile` command should take care of the res
 meson compile
 ```
 
-Upon a successful build you can execute the test suite and benchmarks with the following commands:
+Upon a successful build you can execute the test suite and benchmarks with the
+following commands:
 
 ```sh
 meson test nanoarrow:  # default test run

--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -67,9 +67,6 @@ function main() {
     mkdir "${SUBPROJ_DIR}"
 
     show_header "Install subprojects"
-    meson wrap install gtest
-    meson wrap install google-benchmark
-    meson wrap install nlohmann_json
 
     show_header "Compile project with meson"
     meson setup "${SANDBOX_DIR}" --pkg-config-path $PKG_CONFIG_PATH
@@ -77,13 +74,12 @@ function main() {
     pushd "${SANDBOX_DIR}"
 
     show_header "Run test suite"
-    meson configure -DNANOARROW_BUILD_TESTS=true \
-          -Db_coverage=true
+    meson configure -Dtests=true -Db_coverage=true
     meson compile
     meson test --wrap valgrind
 
     show_header "Run benchmarks"
-    meson configure -DNANOARROW_BUILD_BENCHMARKS=true
+    meson configure -Dbenchmarks=true
     meson compile
     meson test --benchmark
 

--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -60,14 +60,6 @@ function main() {
     fi
     mkdir "${SANDBOX_DIR}"
 
-    SUBPROJ_DIR="subprojects"
-    if [ -d "${SUBPROJ_DIR}" ]; then
-        rm -rf "${SUBPROJ_DIR}"
-    fi
-    mkdir "${SUBPROJ_DIR}"
-
-    show_header "Install subprojects"
-
     show_header "Compile project with meson"
     meson setup "${SANDBOX_DIR}" --pkg-config-path $PKG_CONFIG_PATH
 

--- a/dev/benchmarks/c/array_benchmark.cc
+++ b/dev/benchmarks/c/array_benchmark.cc
@@ -415,3 +415,5 @@ BENCHMARK(BenchmarkArrayAppendInt16);
 BENCHMARK(BenchmarkArrayAppendInt32);
 BENCHMARK(BenchmarkArrayAppendInt64);
 BENCHMARK(BenchmarkArrayAppendNulls);
+
+BENCHMARK_MAIN();

--- a/dev/benchmarks/c/schema_benchmark.cc
+++ b/dev/benchmarks/c/schema_benchmark.cc
@@ -93,3 +93,4 @@ static void BenchmarkSchemaViewInitWideStruct(benchmark::State& state) {
 BENCHMARK(BenchmarkSchemaViewInitWideStruct);
 
 /// @}
+BENCHMARK_MAIN();

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -15,4 +15,6 @@ dist/flatcc.c
 extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_flatcc_generated.h
 extensions/nanoarrow_ipc/thirdparty/*
 python/src/nanoarrow/dlpack_abi.h
-subprojects/*
+subprojects/google-benchmark.wrap
+subprojects/gtest.wrap
+subprojects/nlohmann_json.wrap

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -15,3 +15,4 @@ dist/flatcc.c
 extensions/nanoarrow_ipc/src/nanoarrow/nanoarrow_ipc_flatcc_generated.h
 extensions/nanoarrow_ipc/thirdparty/*
 python/src/nanoarrow/dlpack_abi.h
+subprojects/*

--- a/meson.build
+++ b/meson.build
@@ -29,22 +29,8 @@ project(
     ]
 )
 
-if get_option('NANOARROW_CODE_COVERAGE')
-  error(
-      '''For meson builds, please use '-Db_coverage=true' flag
-      instead of -DNANOARROW_CODE_COVERAGE=true''')
-endif
-
-if get_option('NANOARROW_BUNDLE')
-  error('NANOARROW_BUNDLE not implemented in meson configuration - try CMake instead')
-endif
-
-if get_option('NANOARROW_BUNDLE_AS_CPP')
-  error('NANOARROW_BUNDLE_AS_CPP not implemented in meson configuration - try CMake instead')
-endif
-
 subdir('src/nanoarrow')
 
-if get_option('NANOARROW_BUILD_BENCHMARKS')
+if get_option('benchmarks')
   subdir('dev/benchmarks')
 endif

--- a/meson.options
+++ b/meson.options
@@ -15,19 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('NANOARROW_BUILD_TESTS', type: 'boolean', description: 'Build tests', value: false)
-option('NANOARROW_BUILD_BENCHMARKS', type: 'boolean', description: 'Build benchmarks', value: false)
-option('NANOARROW_BUILD_INTEGRATION_TESTS', type: 'boolean',
+option('tests', type: 'boolean', description: 'Build tests', value: false)
+option('benchmarks', type: 'boolean', description: 'Build benchmarks', value: false)
+option('integration_tests', type: 'boolean',
        description: 'Build cross-implementation Arrow integration tests',
        value: false)
-option('NANOARROW_BUNDLE', type: 'boolean',
-       description: 'Create bundled nanoarrow.h and nanoarrow.c',
-       value: false)
-option('NANOARROW_BUNDLE_AS_CPP', type: 'boolean',
-       description: 'Create bundled nanoarrow.h and nanoarrow.cc',
-       value: false)
-option('NANOARROW_NAMESPACE', type: 'string',
+option('namespace', type: 'string',
        description: 'A prefix for exported symbols')
-option('NANOARROW_CODE_COVERAGE', type: 'boolean',
-       description: 'Enable coverage reporting',
-       value: false)

--- a/src/nanoarrow/meson.build
+++ b/src/nanoarrow/meson.build
@@ -17,7 +17,7 @@
 
 conf_data = configuration_data()
 
-ns = get_option('NANOARROW_NAMESPACE')
+ns = get_option('namespace')
 conf_data.set('NANOARROW_NAMESPACE_DEFINE', '#define NANOARROW_NAMESPACE ' + ns)
 
 version = meson.project_version()
@@ -64,7 +64,7 @@ incdir = include_directories('..')
 nanoarrow_dep = declare_dependency(include_directories: [curdir, incdir],
                                    link_with: nanoarrow_lib)
 
-if get_option('NANOARROW_BUILD_TESTS') or get_option('NANOARROW_BUILD_INTEGRATION_TESTS')
+if get_option('tests') or get_option('integration_tests')
   nlohmann_json_dep = dependency('nlohmann_json')
 
   c_data_integration_lib = library('nanoarrow_c_data_integration',
@@ -75,7 +75,7 @@ if get_option('NANOARROW_BUILD_TESTS') or get_option('NANOARROW_BUILD_INTEGRATIO
 
 endif
 
-if get_option('NANOARROW_BUILD_TESTS')
+if get_option('tests')
   # CMake configuration sets MEMORYCHECK_COMMAND_OPTIONS but with meson you instead
   # wrap the tests with valgrind via `meson test --wrap=valgrind`. See
   # https://mesonbuild.com/Unit-tests.html

--- a/subprojects/google-benchmark.wrap
+++ b/subprojects/google-benchmark.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = benchmark-1.8.4
+source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
+source_filename = benchmark-1.8.4.tar.gz
+source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
+patch_filename = google-benchmark_1.8.4-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-1/get_patch
+patch_hash = 77cdae534fe12b6783c1267de3673d3462b229054519034710d581b419e73cca
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-1/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-1
+
+[provide]
+benchmark = google_benchmark_dep
+benchmark-main = google_benchmark_main_dep

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,16 @@
+[wrap-file]
+directory = googletest-1.14.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+source_filename = gtest-1.14.0.tar.gz
+source_hash = 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+patch_filename = gtest_1.14.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.14.0-2/get_patch
+patch_hash = 4ec7f767364386a99f7b2d61678287a73ad6ba0f9998be43b51794c464a63732
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.14.0-2/gtest-1.14.0.tar.gz
+wrapdb_version = 1.14.0-2
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = nlohmann_json-3.11.2
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
+source_filename = nlohmann_json-3.11.2.zip
+source_hash = e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed
+wrapdb_version = 3.11.2-1
+
+[provide]
+nlohmann_json = nlohmann_json_dep


### PR DESCRIPTION
Two main changes here:

1. Changed options like `NANOARROW_BUILD_TESTS` to just `tests`
2. Included wrap files into repository, rather than requiring user to install

Point 1 was inspired by looking at other projects in the wrap database. Note that if multiple projects were being compiled at once and there was some ambiguity between options, you can namespace providing them on the command line by using the form `<project>:<option>`, ex: `meson configure -Darrow:tests=true`