### PR TITLE
chore(python): Add `sync_event` argument to Python .pxd header

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -717,8 +717,9 @@ cdef class Device:
     def _array_init(self, uintptr_t array_addr, CSchema schema):
         cdef ArrowArray* array_ptr = <ArrowArray*>array_addr
         cdef ArrowDeviceArray* device_array_ptr
+        cdef void* sync_event = NULL
         holder = alloc_c_device_array(&device_array_ptr)
-        cdef int code = ArrowDeviceArrayInit(self._ptr, device_array_ptr, array_ptr)
+        cdef int code = ArrowDeviceArrayInit(self._ptr, device_array_ptr, array_ptr, sync_event)
         Error.raise_error_not_ok("ArrowDevice::init_array", code)
 
         return CDeviceArray(holder, <uintptr_t>device_array_ptr, schema)

--- a/python/src/nanoarrow/nanoarrow_device_c.pxd
+++ b/python/src/nanoarrow/nanoarrow_device_c.pxd
@@ -49,7 +49,8 @@ cdef extern from "nanoarrow_device.h" nogil:
         int64_t device_id
         ArrowErrorCode (*array_init)(ArrowDevice* device,
                                      ArrowDeviceArray* device_array,
-                                     ArrowArray* array)
+                                     ArrowArray* array,
+                                     void* sync_event)
         ArrowErrorCode (*array_move)(ArrowDevice* device_src,
                                      ArrowDeviceArray* src,
                                      ArrowDevice* device_dst,
@@ -76,7 +77,8 @@ cdef extern from "nanoarrow_device.h" nogil:
 
     ArrowErrorCode ArrowDeviceArrayInit(ArrowDevice* device,
                                         ArrowDeviceArray* device_array,
-                                        ArrowArray* array)
+                                        ArrowArray* array,
+                                        void* sync_event)
 
     void ArrowDeviceArrayViewInit(ArrowDeviceArrayView* device_array_view)
 


### PR DESCRIPTION
#488 broke the Python package build (which I'd forgotten uses the device extension).