### PR TITLE
feat: Add support for run-end encoded array

### DIFF
--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -815,9 +815,9 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
       break;
     case NANOARROW_TYPE_RUN_END_ENCODED:
       if (array_view->n_children != 2) {
-        ArrowErrorSet(error, "Expected 2 children of %s array but found %ld child arrays",
-                      ArrowTypeString(array_view->storage_type),
-                      (long)array_view->n_children);
+        ArrowErrorSet(
+            error, "Expected 2 children for %s array but found %ld child arrays",
+            ArrowTypeString(array_view->storage_type), (long)array_view->n_children);
         return EINVAL;
       }
       break;
@@ -907,7 +907,7 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
       if (run_ends_view->length == 0 && values_view->length != 0) {
         ArrowErrorSet(error,
                       "Run-end encoded array has zero length %ld, but values array has "
-                      "non-zero length ",
+                      "non-zero length",
                       (long)values_view->length);
         return EINVAL;
       }
@@ -1257,7 +1257,7 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
       last_run_end = run_end;
     }
     last_run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, run_ends_view->length - 1);
-    if (last_run_end < array_view->offset + array_view->length) {
+    if (last_run_end < (array_view->offset + array_view->length)) {
       ArrowErrorSet(error,
                     "Last run end is %ld but it should >= %ld (offset: %ld, length: %ld)",
                     (long)last_run_end, (long)(array_view->offset + array_view->length),

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -1068,6 +1068,17 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       }
       break;
 
+    case NANOARROW_TYPE_RUN_END_ENCODED: {
+      struct ArrowArrayView* run_ends_view = array_view->children[0];
+      int64_t last_run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, 0);
+      if (last_run_end < 1) {
+        ArrowErrorSet(error,
+                      "All run ends must be greater than 0 but the first run end is %ld",
+                      (long)last_run_end);
+        return EINVAL;
+      }
+      break;
+    }
     default:
       break;
   }
@@ -1239,12 +1250,6 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
   if (array_view->storage_type == NANOARROW_TYPE_RUN_END_ENCODED) {
     struct ArrowArrayView* run_ends_view = array_view->children[0];
     int64_t last_run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, 0);
-    if (last_run_end < 1) {
-      ArrowErrorSet(error,
-                    "All run ends must be greater than 0 but the first run end is %ld",
-                    (long)last_run_end);
-      return EINVAL;
-    }
     for (int64_t i = 1; i < run_ends_view->length; i++) {
       const int64_t run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, i);
       if (run_end <= last_run_end) {

--- a/src/nanoarrow/array_inline.h
+++ b/src/nanoarrow/array_inline.h
@@ -718,34 +718,6 @@ static inline ArrowErrorCode ArrowArrayFinishUnionElement(struct ArrowArray* arr
   return NANOARROW_OK;
 }
 
-static inline ArrowErrorCode ArrowArrayFinishRunEndEncoded(struct ArrowArray* array,
-                                                           int64_t logical_length,
-                                                           int64_t offset) {
-  if (logical_length < 0 || offset < 0) return EINVAL;
-  int64_t max_length;
-  struct ArrowArrayPrivateData* run_ends_private_data =
-      (struct ArrowArrayPrivateData*)array->children[0]->private_data;
-  switch (run_ends_private_data->storage_type) {
-    case NANOARROW_TYPE_INT16:
-      max_length = INT16_MAX;
-      break;
-    case NANOARROW_TYPE_INT32:
-      max_length = INT32_MAX;
-      break;
-    case NANOARROW_TYPE_INT64:
-      max_length = INT64_MAX;
-      break;
-    default:
-      return EINVAL;
-  }
-  if ((uint64_t)offset + (uint64_t)logical_length > (uint64_t)max_length) {
-    return EINVAL;
-  }
-  array->length = logical_length;
-  array->offset = offset;
-  return NANOARROW_OK;
-}
-
 static inline void ArrowArrayViewMove(struct ArrowArrayView* src,
                                       struct ArrowArrayView* dst) {
   memcpy(dst, src, sizeof(struct ArrowArrayView));

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1469,7 +1469,7 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
   ASSERT_EQ(ArrowArrayAppendDouble(array.children[1], 1.0), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(array.children[1], 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendDouble(array.children[1], 2.0), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayFinishRunEndEncoded(&array, 7, 0), NANOARROW_OK);
+  array.length = 7;
 
   // Make sure number of children is checked at finish
   array.n_children = 0;

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -379,9 +379,9 @@ ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowT
 /// Returns EINVAL for scale <= 0 or for run_end_type that is not
 /// NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32 or NANOARROW_TYPE_INT64.
 /// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
+/// The run-end encoded array must be finished using ArrowArrayFinishAppending()
 ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
-                                               enum ArrowType run_end_type,
-                                               enum ArrowType value_type);
+                                               enum ArrowType run_end_type);
 
 /// \brief Set the format field of a time, timestamp, or duration schema
 ///
@@ -976,6 +976,15 @@ static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array);
 /// or if child sizes after appending are inconsistent.
 static inline ArrowErrorCode ArrowArrayFinishUnionElement(struct ArrowArray* array,
                                                           int8_t type_id);
+
+/// \brief Finish a run-end encoded array
+///
+/// Finishes a run-end encoded array and set its logicial length and offset.
+/// EINVAL if the logical length + offset exceeds the maximum allowed length
+/// of the run-ends buffer.
+static inline ArrowErrorCode ArrowArrayFinishRunEndEncoded(struct ArrowArray* array,
+                                                           int64_t logical_length,
+                                                           int64_t offset);
 
 /// \brief Shrink buffer capacity to the size required
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -376,10 +376,12 @@ ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowT
 
 /// \brief Set the format field of a run-end encoded schema
 ///
-/// Returns EINVAL for scale <= 0 or for run_end_type that is not
+/// Returns EINVAL for run_end_type that is not
 /// NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32 or NANOARROW_TYPE_INT64.
 /// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-/// The run-end encoded array's logical length must be updated manually.
+/// The caller must call `ArrowSchemaSetTypeXXX(schema->children[1])` to
+/// set the value type. Note that when building arrays using the `ArrowArrayAppendXXX()`
+/// functions, the run-end encoded array's logical length must be updated manually.
 ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
                                                enum ArrowType run_end_type);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -379,7 +379,7 @@ ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowT
 /// Returns EINVAL for scale <= 0 or for run_end_type that is not
 /// NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32 or NANOARROW_TYPE_INT64.
 /// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
-/// The run-end encoded array must be finished using ArrowArrayFinishAppending()
+/// The run-end encoded array's logical length must be updated manually.
 ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
                                                enum ArrowType run_end_type);
 
@@ -976,15 +976,6 @@ static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array);
 /// or if child sizes after appending are inconsistent.
 static inline ArrowErrorCode ArrowArrayFinishUnionElement(struct ArrowArray* array,
                                                           int8_t type_id);
-
-/// \brief Finish a run-end encoded array
-///
-/// Finishes a run-end encoded array and set its logicial length and offset.
-/// EINVAL if the logical length + offset exceeds the maximum allowed length
-/// of the run-ends buffer.
-static inline ArrowErrorCode ArrowArrayFinishRunEndEncoded(struct ArrowArray* array,
-                                                           int64_t logical_length,
-                                                           int64_t offset);
 
 /// \brief Shrink buffer capacity to the size required
 ///

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -60,6 +60,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaSetTypeFixedSize)
 #define ArrowSchemaSetTypeDecimal \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaSetTypeDecimal)
+#define ArrowSchemaSetTypeRunEndEncoded \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaSetTypeRunEndEncoded)
 #define ArrowSchemaSetTypeDateTime \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaSetTypeDateTime)
 #define ArrowSchemaSetTypeUnion \
@@ -371,6 +373,15 @@ ArrowErrorCode ArrowSchemaSetTypeFixedSize(struct ArrowSchema* schema,
 ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowType type,
                                          int32_t decimal_precision,
                                          int32_t decimal_scale);
+
+/// \brief Set the format field of a run-end encoded schema
+///
+/// Returns EINVAL for scale <= 0 or for run_end_type that is not
+/// NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32 or NANOARROW_TYPE_INT64.
+/// Schema must have been initialized using ArrowSchemaInit() or ArrowSchemaDeepCopy().
+ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
+                                               enum ArrowType run_end_type,
+                                               enum ArrowType value_type);
 
 /// \brief Set the format field of a time, timestamp, or duration schema
 ///

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -450,7 +450,8 @@ enum ArrowType {
   NANOARROW_TYPE_LARGE_STRING,
   NANOARROW_TYPE_LARGE_BINARY,
   NANOARROW_TYPE_LARGE_LIST,
-  NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO
+  NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO,
+  NANOARROW_TYPE_RUN_END_ENCODED
 };
 
 /// \brief Get a string value of an enum ArrowType value
@@ -537,6 +538,8 @@ static inline const char* ArrowTypeString(enum ArrowType type) {
       return "large_list";
     case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
       return "interval_month_day_nano";
+    case NANOARROW_TYPE_RUN_END_ENCODED:
+      return "run_end_encoded";
     default:
       return NULL;
   }
@@ -952,6 +955,16 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
                                         const uint8_t* value) {
   memcpy(decimal->words, value, decimal->n_words * sizeof(uint64_t));
 }
+
+/// \brief A representation of a run of the run end encoded array
+/// \ingroup nanoarrow-utils
+///
+struct ArrowRunEndEncoded {
+  /// \brief The length of this run
+  int64_t length;
+
+  /// \brief The value of this run
+};
 
 #ifdef __cplusplus
 }

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -956,16 +956,6 @@ static inline void ArrowDecimalSetBytes(struct ArrowDecimal* decimal,
   memcpy(decimal->words, value, decimal->n_words * sizeof(uint64_t));
 }
 
-/// \brief A representation of a run of the run end encoded array
-/// \ingroup nanoarrow-utils
-///
-struct ArrowRunEndEncoded {
-  /// \brief The length of this run
-  int64_t length;
-
-  /// \brief The value of this run
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -287,8 +287,7 @@ ArrowErrorCode ArrowSchemaSetTypeDecimal(struct ArrowSchema* schema, enum ArrowT
 }
 
 ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
-                                               enum ArrowType run_end_type,
-                                               enum ArrowType value_type) {
+                                               enum ArrowType run_end_type) {
   switch (run_end_type) {
     case NANOARROW_TYPE_INT16:
     case NANOARROW_TYPE_INT32:
@@ -303,7 +302,8 @@ ArrowErrorCode ArrowSchemaSetTypeRunEndEncoded(struct ArrowSchema* schema,
   NANOARROW_RETURN_NOT_OK(
       ArrowSchemaInitChildrenIfNeeded(schema, NANOARROW_TYPE_RUN_END_ENCODED));
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema->children[0], run_end_type));
-  NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema->children[1], value_type));
+  NANOARROW_RETURN_NOT_OK(
+      ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_UNINITIALIZED));
 
   return NANOARROW_OK;
 }

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -222,16 +222,24 @@ TEST(SchemaTest, SchemaInitDecimal) {
 TEST(SchemaTest, SchemaInitRunEndEncoded) {
   struct ArrowSchema schema;
   struct ArrowArray array;
-  ArrowSchemaInit(&schema);
 
   // run-ends type has to be one of INT16, INT32, INT64
+  ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_DOUBLE), EINVAL);
+  ArrowSchemaRelease(&schema);
+
+  ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_UINT16), EINVAL);
+  ArrowSchemaRelease(&schema);
+
+  ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
   ArrowSchemaRelease(&schema);
+
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
   ArrowSchemaRelease(&schema);
+
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -221,7 +221,6 @@ TEST(SchemaTest, SchemaInitDecimal) {
 
 TEST(SchemaTest, SchemaInitRunEndEncoded) {
   struct ArrowSchema schema;
-  struct ArrowArray array;
 
   // run-ends type has to be one of INT16, INT32, INT64
   ArrowSchemaInit(&schema);
@@ -234,9 +233,7 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");
 
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
 
   auto arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
@@ -246,9 +243,7 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");
 
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
 
   arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
@@ -258,9 +253,7 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");
 
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
 
   arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -228,7 +228,11 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_DOUBLE), EINVAL);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_UINT16), EINVAL);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
+  ArrowSchemaRelease(&schema);
+  ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ArrowSchemaRelease(&schema);
+  ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");
 
@@ -239,7 +243,7 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
 
   auto arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
-  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int32(), float32())));
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int64(), float32())));
 }
 
 TEST(SchemaTest, SchemaInitDateTime) {

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -226,30 +226,43 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   // run-ends type has to be one of INT16, INT32, INT64
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_DOUBLE), EINVAL);
-  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_UINT16), EINVAL);
-  ArrowSchemaRelease(&schema);
 
   ArrowSchemaInit(&schema);
   EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
-  ArrowSchemaRelease(&schema);
-
-  ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
-  ArrowSchemaRelease(&schema);
-
-  ArrowSchemaInit(&schema);
-  EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
   EXPECT_STREQ(schema.format, "+r");
 
-  // values type has to be set to something
   EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
 
   auto arrow_type = ImportType(&schema);
+  ARROW_EXPECT_OK(arrow_type);
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int16(), float32())));
+
+  ArrowSchemaInit(&schema);
+  EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  EXPECT_STREQ(schema.format, "+r");
+
+  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+
+  arrow_type = ImportType(&schema);
+  ARROW_EXPECT_OK(arrow_type);
+  EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int32(), float32())));
+
+  ArrowSchemaInit(&schema);
+  EXPECT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
+  EXPECT_STREQ(schema.format, "+r");
+
+  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), EINVAL);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
+
+  arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
   EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int64(), float32())));
 }

--- a/src/nanoarrow/utils.c
+++ b/src/nanoarrow/utils.c
@@ -66,6 +66,7 @@ void ArrowLayoutInit(struct ArrowLayout* layout, enum ArrowType storage_type) {
   switch (storage_type) {
     case NANOARROW_TYPE_UNINITIALIZED:
     case NANOARROW_TYPE_NA:
+    case NANOARROW_TYPE_RUN_END_ENCODED:
       layout->buffer_type[0] = NANOARROW_BUFFER_TYPE_NONE;
       layout->buffer_data_type[0] = NANOARROW_TYPE_UNINITIALIZED;
       layout->buffer_type[1] = NANOARROW_BUFFER_TYPE_NONE;


### PR DESCRIPTION
Hi this PR tries to add support for run-end encoded array based on the arrow spec here, https://arrow.apache.org/docs/format/Columnar.html#run-end-encoded-layout. 