### PR TITLE
chore(ci): Ensure tests pass for Arrow C++ <12 and on C++11

### DIFF
--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -888,12 +888,11 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
       // uint64_t is used here to avoid overflow when adding the offset and length
       if ((uint64_t)array_view->offset + (uint64_t)array_view->length >
           (uint64_t)max_length) {
-        ArrowErrorSet(
-            error,
-            "Offset + length of a run-end encoded array must fit in a value"
-            " of the run end type %s, but offset + length is %ld",
-            ArrowTypeString(run_ends_view->storage_type),
-            (long)array_view->offset + (long)array_view->length);
+        ArrowErrorSet(error,
+                      "Offset + length of a run-end encoded array must fit in a value"
+                      " of the run end type %s, but offset + length is %ld",
+                      ArrowTypeString(run_ends_view->storage_type),
+                      (long)array_view->offset + (long)array_view->length);
         return EINVAL;
       }
       if (run_ends_view->length > values_view->length) {

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -891,11 +891,9 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
         ArrowErrorSet(
             error,
             "Offset + length of a run-end encoded array must fit in a value"
-            " of the run end type %s, but offset + length is %lu while the "
-            "allowed maximum is %lu",
+            " of the run end type %s, but offset + length is %ld",
             ArrowTypeString(run_ends_view->storage_type),
-            (unsigned long)array_view->offset + (unsigned long)array_view->length,
-            (unsigned long)max_length);
+            (long)array_view->offset + (long)array_view->length);
         return EINVAL;
       }
       if (run_ends_view->length > values_view->length) {

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1482,11 +1482,9 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
     array.offset = INT32_MAX;
     EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),
               EINVAL);
-    EXPECT_STREQ(
-        ArrowErrorMessage(&error),
-        "Offset + length of a run-end encoded array must fit in a value of the "
-        "run end type int32, but offset + length is 2147483654 while the allowed "
-        "maximum is 2147483647");
+    EXPECT_STREQ(ArrowErrorMessage(&error),
+                 "Offset + length of a run-end encoded array must fit in a value of the "
+                 "run end type int32, but offset + length is 2147483654");
 
     ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
         NANOARROW_TYPE_INT16;
@@ -1496,18 +1494,17 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
     EXPECT_STREQ(
         ArrowErrorMessage(&error),
         "Offset + length of a run-end encoded array must fit in a value of the run end "
-        "type int16, but offset + length is 32774 while the allowed maximum is 32767");
+        "type int16, but offset + length is 32774");
 
     ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
         NANOARROW_TYPE_INT64;
     array.offset = INT64_MAX;
     EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),
               EINVAL);
-    EXPECT_STREQ(ArrowErrorMessage(&error),
-                 "Offset + length of a run-end encoded array must fit in a value of the "
-                 "run end type int64, but offset + length is 9223372036854775814 while "
-                 "the allowed "
-                 "maximum is 9223372036854775807");
+    EXPECT_THAT(
+        ArrowErrorMessage(&error),
+        ::testing::StartsWith("Offset + length of a run-end encoded array must fit in a "
+                              "value of the run end type int64, but offset + length is"));
   }
   ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
       NANOARROW_TYPE_INT32;

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <arrow/c/bridge.h>
+#include <arrow/config.h>
 #include <arrow/testing/gtest_util.h>
 #include <arrow/util/key_value_metadata.h>
 
@@ -235,6 +236,9 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
 
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_FLOAT), NANOARROW_OK);
 
+#if !defined(ARROW_VERSION_MAJOR) || ARROW_VERSION_MAJOR < 12
+  ArrowSchemaRelease(&schema);
+#else
   auto arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
   EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int16(), float32())));
@@ -258,6 +262,7 @@ TEST(SchemaTest, SchemaInitRunEndEncoded) {
   arrow_type = ImportType(&schema);
   ARROW_EXPECT_OK(arrow_type);
   EXPECT_TRUE(arrow_type.ValueUnsafe()->Equals(run_end_encoded(int64(), float32())));
+#endif
 }
 
 TEST(SchemaTest, SchemaInitDateTime) {

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -548,6 +548,9 @@ TEST(SchemaTest, SchemaCopyDictType) {
 }
 
 TEST(SchemaTest, SchemaCopyRunEndEncodedType) {
+#if !defined(ARROW_VERSION_MAJOR) || ARROW_VERSION_MAJOR < 12
+  GTEST_SKIP() << "Arrow C++ REE integration test requires ARROW_VERSION_MAJOR >= 12";
+#else
   struct ArrowSchema schema;
   auto struct_type = run_end_encoded(int32(), float32());
   ARROW_EXPECT_OK(ExportType(*struct_type, &schema));
@@ -565,6 +568,7 @@ TEST(SchemaTest, SchemaCopyRunEndEncodedType) {
 
   ArrowSchemaRelease(&schema);
   ArrowSchemaRelease(&schema_copy);
+#endif
 }
 
 TEST(SchemaTest, SchemaCopyFlags) {


### PR DESCRIPTION
Tests for https://github.com/apache/arrow-nanoarrow/pull/507 and https://github.com/apache/arrow-nanoarrow/pull/501 and/or https://github.com/apache/arrow-nanoarrow/pull/503 either used C++17 or features from Arrow C++ > 12. Our test suite still supports these (although perhaps parts of this support should be dropped soon).

On Windows, formatting with `%lu` was doing some unexpected formatting. We could do a better job formatting 64-bit integers in error messages (e.g., using `PRId64` and the requisite defines to ensure it works on mingw); however, we probably won't ever be able to support properly formatting an unsigned 64-bit integer on every platform we support. I changed the error message (and its test) slightly to reflect that.