### PR TITLE
chore(dev/benchmarks): Add 0.5.0 release to benchmark run + enable build with against refacotred CMake

### DIFF
--- a/dev/benchmarks/CMakeLists.txt
+++ b/dev/benchmarks/CMakeLists.txt
@@ -53,13 +53,11 @@ fetchcontent_declare(benchmark
 fetchcontent_makeavailable(benchmark)
 
 if(IS_DIRECTORY "${NANOARROW_BENCHMARK_SOURCE_URL}")
+  # In nanoarrow >= 0.6.0, optional features use NANOARROW_XXX=ON instead
+  # of being packaged as separate projects.
+  set(NANOARROW_IPC ON CACHE INTERNAL "")
   fetchcontent_declare(nanoarrow SOURCE_DIR "${NANOARROW_BENCHMARK_SOURCE_URL}")
-  fetchcontent_declare(nanoarrow_ipc
-                       SOURCE_DIR
-                       "${NANOARROW_BENCHMARK_SOURCE_URL}/extensions/nanoarrow_ipc")
-
   fetchcontent_makeavailable(nanoarrow)
-  fetchcontent_makeavailable(nanoarrow_ipc)
 elseif(NOT "${NANOARROW_BENCHMARK_SOURCE_URL}" STREQUAL "")
   fetchcontent_declare(nanoarrow URL "${NANOARROW_BENCHMARK_SOURCE_URL}")
   fetchcontent_declare(nanoarrow_ipc URL "${NANOARROW_BENCHMARK_SOURCE_URL}"

--- a/dev/benchmarks/CMakeLists.txt
+++ b/dev/benchmarks/CMakeLists.txt
@@ -55,7 +55,9 @@ fetchcontent_makeavailable(benchmark)
 if(IS_DIRECTORY "${NANOARROW_BENCHMARK_SOURCE_URL}")
   # In nanoarrow >= 0.6.0, optional features use NANOARROW_XXX=ON instead
   # of being packaged as separate projects.
-  set(NANOARROW_IPC ON CACHE INTERNAL "")
+  set(NANOARROW_IPC
+      ON
+      CACHE INTERNAL "")
   fetchcontent_declare(nanoarrow SOURCE_DIR "${NANOARROW_BENCHMARK_SOURCE_URL}")
   fetchcontent_makeavailable(nanoarrow)
 elseif(NOT "${NANOARROW_BENCHMARK_SOURCE_URL}" STREQUAL "")

--- a/dev/benchmarks/CMakePresets.json
+++ b/dev/benchmarks/CMakePresets.json
@@ -26,6 +26,17 @@
             }
         },
         {
+            "name": "v0.5.0",
+            "displayName": "v0.5.0",
+            "description": "Uses the nanoarrow C sources the 0.5.0 release.",
+            "inherits": [
+                "base"
+            ],
+            "cacheVariables": {
+                "NANOARROW_BENCHMARK_SOURCE_URL": "https://github.com/apache/arrow-nanoarrow/archive/refs/tags/apache-arrow-nanoarrow-0.5.0.zip"
+            }
+        },
+        {
             "name": "v0.4.0",
             "displayName": "v0.4.0",
             "description": "Uses the nanoarrow C sources the 0.4.0 release.",


### PR DESCRIPTION
After #511 there is a slightly different way to build the nanoarrow with IPC support (required by benchmarks).