### PR TITLE
chore(r): Bump minimum supported R version to 4.0

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: '3.6'}
+          - {os: windows-latest, r: '4.0'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}


### PR DESCRIPTION
We (vaguely) follow the [tidyverse R version support policy](https://www.tidyverse.org/blog/2019/04/r-version-support/) and support the current release plus the last four releases. Relatedly, our test dependencies no longer support R 3.6 and this CI job is failing.