### PR TITLE
refactor: Use inttypes.h macros instead of casts to print fixed-width integers

### DIFF
--- a/src/apps/dump_stream.c
+++ b/src/apps/dump_stream.c
@@ -17,6 +17,7 @@
 
 #include "nanoarrow/nanoarrow_ipc.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -121,8 +122,8 @@ int main(int argc, char* argv[]) {
 
   end = clock();
   elapsed = (end - begin) / ((double)CLOCKS_PER_SEC);
-  fprintf(stdout, "Read %ld rows in %ld batch(es) <%.06f seconds>\n", (long)row_count,
-          (long)batch_count, elapsed);
+  fprintf(stdout, "Read %l" PRId64 " rows in %" PRId64 " batch(es) <%.06f seconds>\n",
+          row_count, batch_count, elapsed);
 
   ArrowArrayStreamRelease(&stream);
   fclose(file_ptr);

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -1255,18 +1256,20 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
           ArrowErrorSet(
               error,
               "Every run end must be strictly greater than the previous run end, "
-              "but run_ends[%ld] is %ld and run_ends[%ld] is %ld",
-              (long)i, (long)run_end, (long)i - 1, (long)last_run_end);
+              "but run_ends[%" PRId64 " is %" PRId64 " and run_ends[%" PRId64
+              "] is %" PRId64,
+              i, run_end, i - 1, last_run_end);
           return EINVAL;
         }
         last_run_end = run_end;
       }
       last_run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, run_ends_view->length - 1);
       if (last_run_end < (array_view->offset + array_view->length)) {
-        ArrowErrorSet(
-            error, "Last run end is %ld but it should >= %ld (offset: %ld, length: %ld)",
-            (long)last_run_end, (long)(array_view->offset + array_view->length),
-            (long)array_view->offset, (long)array_view->length);
+        ArrowErrorSet(error,
+                      "Last run end is %" PRId64 " but it should >= %" PRId64
+                      " (offset: %" PRId64 ", length: %" PRId64 ")",
+                      last_run_end, array_view->offset + array_view->length,
+                      array_view->offset, array_view->length);
         return EINVAL;
       }
     }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -1152,7 +1152,7 @@ static int ArrowAssertIncreasingInt64(struct ArrowBufferView view,
 
   for (int64_t i = 1; i < view.size_bytes / (int64_t)sizeof(int64_t); i++) {
     if (view.data.as_int64[i] < view.data.as_int64[i - 1]) {
-      ArrowErrorSet(error, "[%" PRId64 "] Expected element size >= 0", (long)i);
+      ArrowErrorSet(error, "[%" PRId64 "] Expected element size >= 0", i);
       return EINVAL;
     }
   }

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -697,15 +697,17 @@ static int ArrowArrayViewSetArrayInternal(struct ArrowArrayView* array_view,
 
   // Check the number of buffers
   if (buffers_required != array->n_buffers) {
-    ArrowErrorSet(error, "Expected array with %d buffer(s) but found %d buffer(s)",
-                  (int)buffers_required, (int)array->n_buffers);
+    ArrowErrorSet(error,
+                  "Expected array with %" PRId64 " buffer(s) but found %" PRId64
+                  " buffer(s)",
+                  buffers_required, array->n_buffers);
     return EINVAL;
   }
 
   // Check number of children
   if (array_view->n_children != array->n_children) {
-    ArrowErrorSet(error, "Expected %ld children but found %ld children",
-                  (long)array_view->n_children, (long)array->n_children);
+    ArrowErrorSet(error, "Expected %" PRId64 " children but found %" PRId64 " children",
+                  array_view->n_children, array->n_children);
     return EINVAL;
   }
 
@@ -737,14 +739,14 @@ static int ArrowArrayViewSetArrayInternal(struct ArrowArrayView* array_view,
 static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
                                          struct ArrowError* error) {
   if (array_view->length < 0) {
-    ArrowErrorSet(error, "Expected length >= 0 but found length %ld",
-                  (long)array_view->length);
+    ArrowErrorSet(error, "Expected length >= 0 but found length %" PRId64,
+                  array_view->length);
     return EINVAL;
   }
 
   if (array_view->offset < 0) {
-    ArrowErrorSet(error, "Expected offset >= 0 but found offset %ld",
-                  (long)array_view->offset);
+    ArrowErrorSet(error, "Expected offset >= 0 but found offset %" PRId64,
+                  array_view->offset);
     return EINVAL;
   }
 
@@ -792,11 +794,11 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
       array_view->buffer_views[i].size_bytes = min_buffer_size_bytes;
     } else if (array_view->buffer_views[i].size_bytes < min_buffer_size_bytes) {
       ArrowErrorSet(error,
-                    "Expected %s array buffer %d to have size >= %ld bytes but found "
-                    "buffer with %ld bytes",
-                    ArrowTypeString(array_view->storage_type), (int)i,
-                    (long)min_buffer_size_bytes,
-                    (long)array_view->buffer_views[i].size_bytes);
+                    "Expected %s array buffer %d to have size >= %" PRId64
+                    " bytes but found "
+                    "buffer with %" PRId64 " bytes",
+                    ArrowTypeString(array_view->storage_type), i, min_buffer_size_bytes,
+                    array_view->buffer_views[i].size_bytes);
       return EINVAL;
     }
   }
@@ -808,17 +810,17 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_FIXED_SIZE_LIST:
     case NANOARROW_TYPE_MAP:
       if (array_view->n_children != 1) {
-        ArrowErrorSet(error, "Expected 1 child of %s array but found %ld child arrays",
-                      ArrowTypeString(array_view->storage_type),
-                      (long)array_view->n_children);
+        ArrowErrorSet(error,
+                      "Expected 1 child of %s array but found %" PRId64 " child arrays",
+                      ArrowTypeString(array_view->storage_type), array_view->n_children);
         return EINVAL;
       }
       break;
     case NANOARROW_TYPE_RUN_END_ENCODED:
       if (array_view->n_children != 2) {
         ArrowErrorSet(
-            error, "Expected 2 children for %s array but found %ld child arrays",
-            ArrowTypeString(array_view->storage_type), (long)array_view->n_children);
+            error, "Expected 2 children for %s array but found %" PRId64 " child arrays",
+            ArrowTypeString(array_view->storage_type), array_view->n_children);
         return EINVAL;
       }
       break;
@@ -835,12 +837,11 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
       child_min_length = (array_view->offset + array_view->length);
       for (int64_t i = 0; i < array_view->n_children; i++) {
         if (array_view->children[i]->length < child_min_length) {
-          ArrowErrorSet(
-              error,
-              "Expected struct child %d to have length >= %ld but found child with "
-              "length %ld",
-              (int)(i + 1), (long)(child_min_length),
-              (long)array_view->children[i]->length);
+          ArrowErrorSet(error,
+                        "Expected struct child %" PRId64 " to have length >= %" PRId64
+                        " but found child with "
+                        "length %" PRId64,
+                        i + 1, child_min_length, array_view->children[i]->length);
           return EINVAL;
         }
       }
@@ -851,9 +852,10 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
                          array_view->layout.child_size_elements;
       if (array_view->children[0]->length < child_min_length) {
         ArrowErrorSet(error,
-                      "Expected child of fixed_size_list array to have length >= %ld but "
-                      "found array with length %ld",
-                      (long)child_min_length, (long)array_view->children[0]->length);
+                      "Expected child of fixed_size_list array to have length >= %" PRId64
+                      " but "
+                      "found array with length %" PRId64,
+                      child_min_length, array_view->children[0]->length);
         return EINVAL;
       }
       break;
@@ -861,8 +863,8 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_RUN_END_ENCODED: {
       if (array_view->n_children != 2) {
         ArrowErrorSet(error,
-                      "Expected 2 children for run-end encoded array but found %ld",
-                      (long)array_view->n_children);
+                      "Expected 2 children for run-end encoded array but found %" PRId64,
+                      array_view->n_children);
         return EINVAL;
       }
       struct ArrowArrayView* run_ends_view = array_view->children[0];
@@ -891,27 +893,29 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
           (uint64_t)max_length) {
         ArrowErrorSet(error,
                       "Offset + length of a run-end encoded array must fit in a value"
-                      " of the run end type %s, but offset + length is %ld",
+                      " of the run end type %s, but offset + length is %" PRId64,
                       ArrowTypeString(run_ends_view->storage_type),
-                      (long)array_view->offset + (long)array_view->length);
+                      array_view->offset + array_view->length);
         return EINVAL;
       }
       if (run_ends_view->length > values_view->length) {
-        ArrowErrorSet(
-            error, "Length of run_ends is greater than the length of values: %ld > %ld",
-            (long)run_ends_view->length, (long)values_view->length);
+        ArrowErrorSet(error,
+                      "Length of run_ends is greater than the length of values: %" PRId64
+                      " > %" PRId64,
+                      run_ends_view->length, values_view->length);
         return EINVAL;
       }
       if (run_ends_view->length == 0 && values_view->length != 0) {
         ArrowErrorSet(error,
-                      "Run-end encoded array has zero length %ld, but values array has "
+                      "Run-end encoded array has zero length %" PRId64
+                      ", but values array has "
                       "non-zero length",
-                      (long)values_view->length);
+                      values_view->length);
         return EINVAL;
       }
       if (run_ends_view->null_count != 0) {
-        ArrowErrorSet(error, "Null count must be 0 for run ends array, but is %ld",
-                      (long)run_ends_view->null_count);
+        ArrowErrorSet(error, "Null count must be 0 for run ends array, but is %" PRId64,
+                      run_ends_view->null_count);
         return EINVAL;
       }
       break;
@@ -953,8 +957,8 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int32[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
-                        (long)first_offset);
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
+                        first_offset);
           return EINVAL;
         }
 
@@ -965,10 +969,11 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
           array_view->buffer_views[2].size_bytes = last_offset;
         } else if (array_view->buffer_views[2].size_bytes < last_offset) {
           ArrowErrorSet(error,
-                        "Expected %s array buffer 2 to have size >= %ld bytes but found "
-                        "buffer with %ld bytes",
-                        ArrowTypeString(array_view->storage_type), (long)last_offset,
-                        (long)array_view->buffer_views[2].size_bytes);
+                        "Expected %s array buffer 2 to have size >= %" PRId64
+                        " bytes but found "
+                        "buffer with %" PRId64 " bytes",
+                        ArrowTypeString(array_view->storage_type), last_offset,
+                        array_view->buffer_views[2].size_bytes);
           return EINVAL;
         }
       } else if (array_view->buffer_views[2].size_bytes == -1) {
@@ -983,8 +988,8 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int64[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
-                        (long)first_offset);
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
+                        first_offset);
           return EINVAL;
         }
 
@@ -995,10 +1000,11 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
           array_view->buffer_views[2].size_bytes = last_offset;
         } else if (array_view->buffer_views[2].size_bytes < last_offset) {
           ArrowErrorSet(error,
-                        "Expected %s array buffer 2 to have size >= %ld bytes but found "
-                        "buffer with %ld bytes",
-                        ArrowTypeString(array_view->storage_type), (long)last_offset,
-                        (long)array_view->buffer_views[2].size_bytes);
+                        "Expected %s array buffer 2 to have size >= %" PRId64
+                        " bytes but found "
+                        "buffer with %" PRId64 " bytes",
+                        ArrowTypeString(array_view->storage_type), last_offset,
+                        array_view->buffer_views[2].size_bytes);
           return EINVAL;
         }
       } else if (array_view->buffer_views[2].size_bytes == -1) {
@@ -1011,12 +1017,11 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_STRUCT:
       for (int64_t i = 0; i < array_view->n_children; i++) {
         if (array_view->children[i]->length < offset_plus_length) {
-          ArrowErrorSet(
-              error,
-              "Expected struct child %d to have length >= %ld but found child with "
-              "length %ld",
-              (int)(i + 1), (long)offset_plus_length,
-              (long)array_view->children[i]->length);
+          ArrowErrorSet(error,
+                        "Expected struct child %" PRId64 " to have length >= %" PRId64
+                        " but found child with "
+                        "length %" PRId64,
+                        i + 1, offset_plus_length, array_view->children[i]->length);
           return EINVAL;
         }
       }
@@ -1027,19 +1032,19 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int32[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
-                        (long)first_offset);
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
+                        first_offset);
           return EINVAL;
         }
 
         last_offset = array_view->buffer_views[1].data.as_int32[offset_plus_length];
         if (array_view->children[0]->length < last_offset) {
-          ArrowErrorSet(
-              error,
-              "Expected child of %s array to have length >= %ld but found array with "
-              "length %ld",
-              ArrowTypeString(array_view->storage_type), (long)last_offset,
-              (long)array_view->children[0]->length);
+          ArrowErrorSet(error,
+                        "Expected child of %s array to have length >= %" PRId64
+                        " but found array with "
+                        "length %" PRId64,
+                        ArrowTypeString(array_view->storage_type), last_offset,
+                        array_view->children[0]->length);
           return EINVAL;
         }
       }
@@ -1049,18 +1054,18 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       if (array_view->buffer_views[1].size_bytes != 0) {
         first_offset = array_view->buffer_views[1].data.as_int64[0];
         if (first_offset < 0) {
-          ArrowErrorSet(error, "Expected first offset >= 0 but found %ld",
-                        (long)first_offset);
+          ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
+                        first_offset);
           return EINVAL;
         }
 
         last_offset = array_view->buffer_views[1].data.as_int64[offset_plus_length];
         if (array_view->children[0]->length < last_offset) {
-          ArrowErrorSet(
-              error,
-              "Expected child of large list array to have length >= %ld but found array "
-              "with length %ld",
-              (long)last_offset, (long)array_view->children[0]->length);
+          ArrowErrorSet(error,
+                        "Expected child of large list array to have length >= %" PRId64
+                        " but found array "
+                        "with length %" PRId64,
+                        last_offset, array_view->children[0]->length);
           return EINVAL;
         }
       }
@@ -1071,9 +1076,10 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
       if (run_ends_view->length == 0) break;
       int64_t last_run_end = ArrowArrayViewGetIntUnsafe(run_ends_view, 0);
       if (last_run_end < 1) {
-        ArrowErrorSet(error,
-                      "All run ends must be greater than 0 but the first run end is %ld",
-                      (long)last_run_end);
+        ArrowErrorSet(
+            error,
+            "All run ends must be greater than 0 but the first run end is %" PRId64,
+            last_run_end);
         return EINVAL;
       }
       break;
@@ -1130,7 +1136,7 @@ static int ArrowAssertIncreasingInt32(struct ArrowBufferView view,
 
   for (int64_t i = 1; i < view.size_bytes / (int64_t)sizeof(int32_t); i++) {
     if (view.data.as_int32[i] < view.data.as_int32[i - 1]) {
-      ArrowErrorSet(error, "[%ld] Expected element size >= 0", (long)i);
+      ArrowErrorSet(error, "[%" PRId64 "] Expected element size >= 0", i);
       return EINVAL;
     }
   }
@@ -1146,7 +1152,7 @@ static int ArrowAssertIncreasingInt64(struct ArrowBufferView view,
 
   for (int64_t i = 1; i < view.size_bytes / (int64_t)sizeof(int64_t); i++) {
     if (view.data.as_int64[i] < view.data.as_int64[i - 1]) {
-      ArrowErrorSet(error, "[%ld] Expected element size >= 0", (long)i);
+      ArrowErrorSet(error, "[%" PRId64 "] Expected element size >= 0", (long)i);
       return EINVAL;
     }
   }
@@ -1159,8 +1165,9 @@ static int ArrowAssertRangeInt8(struct ArrowBufferView view, int8_t min_value,
   for (int64_t i = 0; i < view.size_bytes; i++) {
     if (view.data.as_int8[i] < min_value || view.data.as_int8[i] > max_value) {
       ArrowErrorSet(error,
-                    "[%ld] Expected buffer value between %d and %d but found value %d",
-                    (long)i, (int)min_value, (int)max_value, (int)view.data.as_int8[i]);
+                    "[%" PRId64 "] Expected buffer value between %" PRId8 " and %" PRId8
+                    " but found value %" PRId8,
+                    i, min_value, max_value, view.data.as_int8[i]);
       return EINVAL;
     }
   }
@@ -1180,8 +1187,8 @@ static int ArrowAssertInt8In(struct ArrowBufferView view, const int8_t* values,
     }
 
     if (!item_found) {
-      ArrowErrorSet(error, "[%ld] Unexpected buffer value %d", (long)i,
-                    (int)view.data.as_int8[i]);
+      ArrowErrorSet(error, "[%" PRId64 "] Unexpected buffer value %" PRId8, i,
+                    view.data.as_int8[i]);
       return EINVAL;
     }
   }
@@ -1236,11 +1243,12 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
       int64_t offset = ArrowArrayViewUnionChildOffset(array_view, i);
       int64_t child_length = array_view->children[child_id]->length;
       if (offset < 0 || offset > child_length) {
-        ArrowErrorSet(
-            error,
-            "[%ld] Expected union offset for child id %d to be between 0 and %ld but "
-            "found offset value %ld",
-            (long)i, (int)child_id, (long)child_length, (long)offset);
+        ArrowErrorSet(error,
+                      "[%" PRId64 "] Expected union offset for child id %" PRId8
+                      " to be between 0 and %" PRId64
+                      " but "
+                      "found offset value %" PRId64,
+                      i, child_id, child_length, offset);
         return EINVAL;
       }
     }

--- a/src/nanoarrow/nanoarrow_device.c
+++ b/src/nanoarrow/nanoarrow_device.c
@@ -367,7 +367,7 @@ ArrowErrorCode ArrowDeviceArrayViewSetArrayMinimal(
       ArrowDeviceResolve(device_array->device_type, device_array->device_id);
   if (device == NULL) {
     ArrowErrorSet(error,
-                  "Can't resolve device with type %" PRId32 " and identifier %l" PRId64,
+                  "Can't resolve device with type %" PRId32 " and identifier %" PRId64,
                   device_array->device_type, device_array->device_id);
     return EINVAL;
   }

--- a/src/nanoarrow/nanoarrow_device.c
+++ b/src/nanoarrow/nanoarrow_device.c
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <errno.h>
+#include <inttypes.h>
 
 #include "nanoarrow.h"
 
@@ -365,8 +366,9 @@ ArrowErrorCode ArrowDeviceArrayViewSetArrayMinimal(
   struct ArrowDevice* device =
       ArrowDeviceResolve(device_array->device_type, device_array->device_id);
   if (device == NULL) {
-    ArrowErrorSet(error, "Can't resolve device with type %d and identifier %ld",
-                  (int)device_array->device_type, (long)device_array->device_id);
+    ArrowErrorSet(error,
+                  "Can't resolve device with type %" PRId32 " and identifier %l" PRId64,
+                  device_array->device_type, device_array->device_id);
     return EINVAL;
   }
 

--- a/src/nanoarrow/nanoarrow_device_cuda.c
+++ b/src/nanoarrow/nanoarrow_device_cuda.c
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <inttypes.h>
+
 #include <cuda.h>
 
 #include "nanoarrow_device.h"
@@ -409,7 +411,7 @@ static ArrowErrorCode ArrowDeviceCudaInitDevice(struct ArrowDevice* device,
     case ARROW_DEVICE_CUDA_HOST:
       break;
     default:
-      ArrowErrorSet(error, "Device type code %d not supported", (int)device_type);
+      ArrowErrorSet(error, "Device type code %" PRId32 " not supported", device_type);
       return EINVAL;
   }
 

--- a/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -382,7 +382,7 @@ static int ArrowIpcDecoderSetTypeInt(struct ArrowSchema* schema,
       default:
         ArrowErrorSet(error,
                       "Expected signed int bitwidth of 8, 16, 32, or 64 but got %d",
-                      (int)bitwidth);
+                      bitwidth);
         return EINVAL;
     }
   } else {
@@ -402,7 +402,7 @@ static int ArrowIpcDecoderSetTypeInt(struct ArrowSchema* schema,
       default:
         ArrowErrorSet(error,
                       "Expected unsigned int bitwidth of 8, 16, 32, or 64 but got %d",
-                      (int)bitwidth);
+                      bitwidth);
         return EINVAL;
     }
   }
@@ -423,8 +423,7 @@ static int ArrowIpcDecoderSetTypeFloatingPoint(struct ArrowSchema* schema,
     case ns(Precision_DOUBLE):
       return ArrowIpcDecoderSetTypeSimple(schema, NANOARROW_TYPE_DOUBLE, error);
     default:
-      ArrowErrorSet(error, "Unexpected FloatingPoint Precision value: %d",
-                    (int)precision);
+      ArrowErrorSet(error, "Unexpected FloatingPoint Precision value: %d", precision);
       return EINVAL;
   }
 }
@@ -448,7 +447,7 @@ static int ArrowIpcDecoderSetTypeDecimal(struct ArrowSchema* schema,
           ArrowSchemaSetTypeDecimal(schema, NANOARROW_TYPE_DECIMAL256, precision, scale);
       break;
     default:
-      ArrowErrorSet(error, "Unexpected Decimal bitwidth value: %d", (int)bitwidth);
+      ArrowErrorSet(error, "Unexpected Decimal bitwidth value: %d", bitwidth);
       return EINVAL;
   }
 
@@ -519,7 +518,7 @@ static int ArrowIpcDecoderSetTypeTime(struct ArrowSchema* schema,
       break;
 
     default:
-      ArrowErrorSet(error, "Unexpected Time TimeUnit value: %d", (int)time_unit);
+      ArrowErrorSet(error, "Unexpected Time TimeUnit value: %d", time_unit);
       return EINVAL;
   }
 
@@ -585,7 +584,7 @@ static int ArrowIpcDecoderSetTypeInterval(struct ArrowSchema* schema,
       return ArrowIpcDecoderSetTypeSimple(schema, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO,
                                           error);
     default:
-      ArrowErrorSet(error, "Unexpected Interval unit value: %d", (int)interval_unit);
+      ArrowErrorSet(error, "Unexpected Interval unit value: %d", interval_unit);
       return EINVAL;
   }
 }
@@ -673,7 +672,7 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
       format_out_size -= n_chars;
       break;
     default:
-      ArrowErrorSet(error, "Unexpected Union UnionMode value: %d", (int)union_mode);
+      ArrowErrorSet(error, "Unexpected Union UnionMode value: %d", union_mode);
       return EINVAL;
   }
 
@@ -706,8 +705,8 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
       }
 
       for (int64_t i = 1; i < n_type_ids; i++) {
-        n_chars = snprintf(format_cursor, format_out_size, ",%d",
-                           (int)flatbuffers_int32_vec_at(type_ids, i));
+        n_chars = snprintf(format_cursor, format_out_size, ",%" PRId32,
+                           flatbuffers_int32_vec_at(type_ids, i));
         format_cursor += n_chars;
         format_out_size -= n_chars;
 
@@ -728,7 +727,7 @@ static int ArrowIpcDecoderSetTypeUnion(struct ArrowSchema* schema,
     }
 
     for (int64_t i = 1; i < n_children; i++) {
-      n_chars = snprintf(format_cursor, format_out_size, ",%d", (int)i);
+      n_chars = snprintf(format_cursor, format_out_size, ",%" PRId64, i);
       format_cursor += n_chars;
       format_out_size -= n_chars;
 
@@ -793,7 +792,7 @@ static int ArrowIpcDecoderSetType(struct ArrowSchema* schema, ns(Field_table_t) 
       return ArrowIpcDecoderSetTypeUnion(schema, ns(Field_type_get(field)), n_children,
                                          error);
     default:
-      ArrowErrorSet(error, "Unrecognized Field type with value %d", (int)type_type);
+      ArrowErrorSet(error, "Unrecognized Field type with value %d", type_type);
       return EINVAL;
   }
 }
@@ -879,7 +878,7 @@ static int ArrowIpcDecoderDecodeSchemaHeader(struct ArrowIpcDecoder* decoder,
     default:
       ArrowErrorSet(error,
                     "Expected Schema endianness of 0 (little) or 1 (big) but got %d",
-                    (int)endianness);
+                    endianness);
       return EINVAL;
   }
 
@@ -1467,8 +1466,9 @@ static int ArrowIpcDecoderSwapEndian(struct ArrowIpcBufferSource* src,
           break;
         }
         default:
-          ArrowErrorSet(error, "Endian swapping for element bitwidth %d is not supported",
-                        (int)src->element_size_bits);
+          ArrowErrorSet(
+              error, "Endian swapping for element bitwidth %" PRId64 " is not supported",
+              src->element_size_bits);
           return ENOTSUP;
       }
       break;

--- a/src/nanoarrow/nanoarrow_ipc_decoder.c
+++ b/src/nanoarrow/nanoarrow_ipc_decoder.c
@@ -1000,7 +1000,7 @@ static inline int ArrowIpcDecoderReadHeaderPrefix(struct ArrowIpcDecoder* decode
   *message_size_bytes = header_body_size_bytes + kMessageHeaderPrefixSize;
   if (header_body_size_bytes < 0) {
     ArrowErrorSet(error,
-                  "Expected message body size > 0 but found message body size of %" PRId64
+                  "Expected message body size > 0 but found message body size of %" PRId32
                   " bytes",
                   header_body_size_bytes);
     return EINVAL;

--- a/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -283,8 +283,9 @@ static int ArrowIpcArrayStreamReaderNextBody(
 
   if (bytes_read != bytes_to_read) {
     ArrowErrorSet(&private_data->error,
-                  "Expected to be able to read %ld bytes for message body but got %ld",
-                  (long)bytes_to_read, bytes_read);
+                  "Expected to be able to read %l" PRId64
+                  " bytes for message body but got %" PRId64,
+                  bytes_to_read, bytes_read);
     return ESPIPE;
   } else {
     return NANOARROW_OK;

--- a/src/nanoarrow/nanoarrow_ipc_reader.c
+++ b/src/nanoarrow/nanoarrow_ipc_reader.c
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -283,7 +284,7 @@ static int ArrowIpcArrayStreamReaderNextBody(
 
   if (bytes_read != bytes_to_read) {
     ArrowErrorSet(&private_data->error,
-                  "Expected to be able to read %l" PRId64
+                  "Expected to be able to read %" PRId64
                   " bytes for message body but got %" PRId64,
                   bytes_to_read, bytes_read);
     return ESPIPE;

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1234,7 +1234,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
   if ((format + format_len) != format_end_out) {
     ArrowErrorSet(error, "Error parsing schema->format '%s': parsed %d/%zu characters",
-                  format, format_end_out - format, format_len);
+                  format, int(format_end_out - format), format_len);
     return EINVAL;
   }
 

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -835,11 +836,10 @@ static ArrowErrorCode ArrowSchemaViewParse(struct ArrowSchemaView* schema_view,
             int64_t n_type_ids =
                 _ArrowParseUnionTypeIds(schema_view->union_type_ids, NULL);
             if (n_type_ids != schema_view->schema->n_children) {
-              ArrowErrorSet(
-                  error,
-                  "Expected union type_ids parameter to be a comma-separated list of %ld "
-                  "values between 0 and 127 but found '%s'",
-                  (long)schema_view->schema->n_children, schema_view->union_type_ids);
+              ArrowErrorSet(error,
+                            "Expected union type_ids parameter to be a comma-separated "
+                            "list of %" PRId64 " values between 0 and 127 but found '%s'",
+                            schema_view->schema->n_children, schema_view->union_type_ids);
               return EINVAL;
             }
             *format_end_out = format + strlen(format);
@@ -1038,15 +1038,15 @@ static ArrowErrorCode ArrowSchemaViewValidateNChildren(
   for (int64_t i = 0; i < schema_view->schema->n_children; i++) {
     child = schema_view->schema->children[i];
     if (child == NULL) {
-      ArrowErrorSet(error,
-                    "Expected valid schema at schema->children[%ld] but found NULL",
-                    (long)i);
+      ArrowErrorSet(
+          error, "Expected valid schema at schema->children[%" PRId64 "] but found NULL",
+          i);
       return EINVAL;
     } else if (child->release == NULL) {
-      ArrowErrorSet(
-          error,
-          "Expected valid schema at schema->children[%ld] but found a released schema",
-          (long)i);
+      ArrowErrorSet(error,
+                    "Expected valid schema at schema->children[%" PRId64
+                    "] but found a released schema",
+                    i);
       return EINVAL;
     }
   }
@@ -1304,7 +1304,7 @@ static int64_t ArrowSchemaTypeToStringInternal(struct ArrowSchemaView* schema_vi
                       ArrowTimeUnitString(schema_view->time_unit));
     case NANOARROW_TYPE_FIXED_SIZE_BINARY:
     case NANOARROW_TYPE_FIXED_SIZE_LIST:
-      return snprintf(out, n, "%s(%ld)", type_string, (long)schema_view->fixed_size);
+      return snprintf(out, n, "%s(%" PRId32 ")", type_string, schema_view->fixed_size);
     case NANOARROW_TYPE_SPARSE_UNION:
     case NANOARROW_TYPE_DENSE_UNION:
       return snprintf(out, n, "%s([%s])", type_string, schema_view->union_type_ids);

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1234,7 +1234,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
   if ((format + format_len) != format_end_out) {
     ArrowErrorSet(error, "Error parsing schema->format '%s': parsed %d/%zu characters",
-                  format, int(format_end_out - format), format_len);
+                  format, (int)(format_end_out - format), format_len);
     return EINVAL;
   }
 

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -234,10 +234,10 @@ ArrowErrorCode ArrowSchemaSetTypeFixedSize(struct ArrowSchema* schema,
   int n_chars;
   switch (type) {
     case NANOARROW_TYPE_FIXED_SIZE_BINARY:
-      n_chars = snprintf(buffer, sizeof(buffer), "w:%d", (int)fixed_size);
+      n_chars = snprintf(buffer, sizeof(buffer), "w:%" PRId32, fixed_size);
       break;
     case NANOARROW_TYPE_FIXED_SIZE_LIST:
-      n_chars = snprintf(buffer, sizeof(buffer), "+w:%d", (int)fixed_size);
+      n_chars = snprintf(buffer, sizeof(buffer), "+w:%" PRId32, fixed_size);
       break;
     default:
       return EINVAL;
@@ -430,7 +430,7 @@ ArrowErrorCode ArrowSchemaSetTypeUnion(struct ArrowSchema* schema, enum ArrowTyp
     format_out_size -= n_chars;
 
     for (int64_t i = 1; i < n_children; i++) {
-      n_chars = snprintf(format_cursor, format_out_size, ",%d", (int)i);
+      n_chars = snprintf(format_cursor, format_out_size, ",%" PRId64, i);
       format_cursor += n_chars;
       format_out_size -= n_chars;
     }
@@ -724,8 +724,9 @@ static ArrowErrorCode ArrowSchemaViewParse(struct ArrowSchemaView* schema_view,
           ArrowSchemaViewSetPrimitive(schema_view, NANOARROW_TYPE_DECIMAL256);
           return NANOARROW_OK;
         default:
-          ArrowErrorSet(error, "Expected decimal bitwidth of 128 or 256 but found %d",
-                        (int)schema_view->decimal_bitwidth);
+          ArrowErrorSet(error,
+                        "Expected decimal bitwidth of 128 or 256 but found %" PRId32,
+                        schema_view->decimal_bitwidth);
           return EINVAL;
       }
 
@@ -1027,8 +1028,9 @@ static ArrowErrorCode ArrowSchemaViewParse(struct ArrowSchemaView* schema_view,
 static ArrowErrorCode ArrowSchemaViewValidateNChildren(
     struct ArrowSchemaView* schema_view, int64_t n_children, struct ArrowError* error) {
   if (n_children != -1 && schema_view->schema->n_children != n_children) {
-    ArrowErrorSet(error, "Expected schema with %d children but found %d children",
-                  (int)n_children, (int)schema_view->schema->n_children);
+    ArrowErrorSet(
+        error, "Expected schema with %" PRId64 " children but found %" PRId64 " children",
+        n_children, schema_view->schema->n_children);
     return EINVAL;
   }
 
@@ -1064,8 +1066,9 @@ static ArrowErrorCode ArrowSchemaViewValidateMap(struct ArrowSchemaView* schema_
   NANOARROW_RETURN_NOT_OK(ArrowSchemaViewValidateNChildren(schema_view, 1, error));
 
   if (schema_view->schema->children[0]->n_children != 2) {
-    ArrowErrorSet(error, "Expected child of map type to have 2 children but found %d",
-                  (int)schema_view->schema->children[0]->n_children);
+    ArrowErrorSet(error,
+                  "Expected child of map type to have 2 children but found %" PRId64,
+                  schema_view->schema->children[0]->n_children);
     return EINVAL;
   }
 
@@ -1180,7 +1183,7 @@ static ArrowErrorCode ArrowSchemaViewValidate(struct ArrowSchemaView* schema_vie
 
     default:
       ArrowErrorSet(error, "Expected a valid enum ArrowType value but found %d",
-                    (int)schema_view->type);
+                    schema_view->type);
       return EINVAL;
   }
 
@@ -1230,8 +1233,8 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
   }
 
   if ((format + format_len) != format_end_out) {
-    ArrowErrorSet(error, "Error parsing schema->format '%s': parsed %d/%d characters",
-                  format, (int)(format_end_out - format), (int)(format_len));
+    ArrowErrorSet(error, "Error parsing schema->format '%s': parsed %d/%zu characters",
+                  format, format_end_out - format, format_len);
     return EINVAL;
   }
 
@@ -1291,9 +1294,8 @@ static int64_t ArrowSchemaTypeToStringInternal(struct ArrowSchemaView* schema_vi
   switch (schema_view->type) {
     case NANOARROW_TYPE_DECIMAL128:
     case NANOARROW_TYPE_DECIMAL256:
-      return snprintf(out, n, "%s(%d, %d)", type_string,
-                      (int)schema_view->decimal_precision,
-                      (int)schema_view->decimal_scale);
+      return snprintf(out, n, "%s(%" PRId32 ", %" PRId32 ")", type_string,
+                      schema_view->decimal_precision, schema_view->decimal_scale);
     case NANOARROW_TYPE_TIMESTAMP:
       return snprintf(out, n, "%s('%s', '%s')", type_string,
                       ArrowTimeUnitString(schema_view->time_unit), schema_view->timezone);


### PR DESCRIPTION
Very pedantic change to the great work done in https://github.com/apache/arrow-nanoarrow/pull/507 just to prevent any issues on LLP64 systems