### PR TITLE
chore: Fix compiler warnings on Windows

### DIFF
--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -2588,12 +2588,12 @@ TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
 // the "value type" that would correspond to what ArrowArrayViewGetDoubleUnsafe()
 // or ArrowArrayAppendDouble() do since they operate on the logical/represented
 // value.
-template<typename TypeClass, typename BuilderValueT>
+template <typename TypeClass, typename BuilderValueT>
 BuilderValueT logical_value_to_builder_value(int64_t value) {
   return static_cast<BuilderValueT>(value);
 }
 
-template<>
+template <>
 uint16_t logical_value_to_builder_value<HalfFloatType, uint16_t>(int64_t value) {
   return ArrowFloatToHalfFloat(static_cast<float>(value));
 }
@@ -2611,9 +2611,11 @@ void TestGetFromNumericArrayView() {
   // Array with nulls
   auto builder = NumericBuilder<TypeClass>();
 
-  ARROW_EXPECT_OK(builder.Append(logical_value_to_builder_value<TypeClass, value_type>(1)));
+  ARROW_EXPECT_OK(
+      builder.Append(logical_value_to_builder_value<TypeClass, value_type>(1)));
   ARROW_EXPECT_OK(builder.AppendNulls(2));
-  ARROW_EXPECT_OK(builder.Append(logical_value_to_builder_value<TypeClass, value_type>(4)));
+  ARROW_EXPECT_OK(
+      builder.Append(logical_value_to_builder_value<TypeClass, value_type>(4)));
 
   auto maybe_arrow_array = builder.Finish();
   ARROW_EXPECT_OK(maybe_arrow_array);
@@ -2646,8 +2648,10 @@ void TestGetFromNumericArrayView() {
   // Array without nulls (Arrow does not allocate the validity buffer)
   builder = NumericBuilder<TypeClass>();
 
-  ARROW_EXPECT_OK(builder.Append(logical_value_to_builder_value<TypeClass, value_type>(1)));
-  ARROW_EXPECT_OK(builder.Append(logical_value_to_builder_value<TypeClass, value_type>(2)));
+  ARROW_EXPECT_OK(
+      builder.Append(logical_value_to_builder_value<TypeClass, value_type>(1)));
+  ARROW_EXPECT_OK(
+      builder.Append(logical_value_to_builder_value<TypeClass, value_type>(2)));
 
   maybe_arrow_array = builder.Finish();
   ARROW_EXPECT_OK(maybe_arrow_array);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <cstdint>
-#include <type_traits>
 
 #include <arrow/array.h>
 #include <arrow/array/builder_binary.h>
@@ -821,7 +820,7 @@ TEST(ArrayTest, ArrayTestAppendToHalfFloatArray) {
   EXPECT_EQ(data_buffer[1], 0);
   EXPECT_EQ(data_buffer[2], 0);
   EXPECT_FLOAT_EQ(ArrowHalfFloatToFloat(data_buffer[3]), 3.0);
-  EXPECT_FLOAT_EQ(ArrowHalfFloatToFloat(data_buffer[4]), 3.138672);
+  EXPECT_FLOAT_EQ(ArrowHalfFloatToFloat(data_buffer[4]), static_cast<float>(3.138672));
   EXPECT_FLOAT_EQ(ArrowHalfFloatToFloat(data_buffer[5]),
                   std::numeric_limits<float>::max());
   EXPECT_TRUE(std::isnan(ArrowHalfFloatToFloat(data_buffer[6])));

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -618,7 +618,7 @@ TEST(MaybeTest, ConstructionAndConversion) {
 }
 
 TEST(RandomAccessRangeTest, ConstructionAndPrinting) {
-  auto square = [](int i) { return i * i; };
+  auto square = [](int64_t i) { return i * i; };
 
   // the range is usable as a constant
   const nanoarrow::internal::RandomAccessRange<decltype(square)> squares{square, 4};
@@ -628,8 +628,8 @@ TEST(RandomAccessRangeTest, ConstructionAndPrinting) {
 
   // since the range is usable as a constant, we can iterate through it multiple times and
   // it will work
-  int sum = 0;
-  for (int i : squares) {
+  int64_t sum = 0;
+  for (int64_t i : squares) {
     sum += i;
   }
   EXPECT_EQ(sum, 1 + 4 + 9);


### PR DESCRIPTION
Some minor changes to correct usage that resulted in compiler warnings when opening this up and doing a naive build in VSCode on Windows.