### PR TITLE
refactor: Remove CMake requirement from Meson IPC config

### DIFF
--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -66,7 +66,7 @@ function main() {
     pushd "${SANDBOX_DIR}"
 
     show_header "Run test suite"
-    meson configure -Dtests=true -Db_coverage=true
+    meson configure -Dtests=true -Db_coverage=true -Dipc=true
     meson compile
     meson test --wrap='valgrind --track-origins=yes --leak-check=full' --print-errorlogs
 

--- a/src/nanoarrow/meson.build
+++ b/src/nanoarrow/meson.build
@@ -168,13 +168,13 @@ if get_option('tests')
       ipc_test_files = {
           'nanoarrow-ipc-decoder': {
               'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep],
-              "timeout": 30,
+              'timeout': 30,
           },
           'nanoarrow-ipc-reader': {
               'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep],
               # the ipc reader test can take longer when executed
               # under valgrind, hence the increased timeout
-              "timeout": 90,
+              'timeout': 90,
 
           },
           'nanoarrow-ipc-files': {
@@ -185,11 +185,11 @@ if get_option('tests')
                   gtest_dep,
                   nlohmann_json_dep
               ],
-              "timeout": 30,
+              'timeout': 30,
           },
           'nanoarrow-ipc-hpp': {
               'deps': [nanoarrow_ipc_dep, gtest_dep],
-              "timeout": 30,
+              'timeout': 30,
           },
       }
 

--- a/src/nanoarrow/meson.build
+++ b/src/nanoarrow/meson.build
@@ -168,9 +168,14 @@ if get_option('tests')
       ipc_test_files = {
           'nanoarrow-ipc-decoder': {
               'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep],
+              "timeout": 30,
           },
           'nanoarrow-ipc-reader': {
               'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep],
+              # the ipc reader test can take longer when executed
+              # under valgrind, hence the increased timeout
+              "timeout": 90,
+
           },
           'nanoarrow-ipc-files': {
               'deps': [
@@ -180,9 +185,11 @@ if get_option('tests')
                   gtest_dep,
                   nlohmann_json_dep
               ],
+              "timeout": 30,
           },
           'nanoarrow-ipc-hpp': {
               'deps': [nanoarrow_ipc_dep, gtest_dep],
+              "timeout": 30,
           },
       }
 
@@ -192,7 +199,7 @@ if get_option('tests')
               name.replace('-', '_') + '_test.cc',
               dependencies: config['deps']
           )
-          test(name, exc)
+          test(name, exc, timeout: config['timeout'])
       endforeach
   endif
 endif

--- a/src/nanoarrow/meson.build
+++ b/src/nanoarrow/meson.build
@@ -65,11 +65,7 @@ nanoarrow_dep = declare_dependency(include_directories: [curdir, incdir],
                                    link_with: nanoarrow_lib)
 
 if get_option('ipc')
-    cmake = import('cmake')
-    cmake_opts = cmake.subproject_options()
-    cmake_opts.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
-    flatcc_subproj = cmake.subproject('flatcc', options: cmake_opts)
-    flatcc_dep = flatcc_subproj.dependency('flatccrt')
+    flatcc_dep = dependency('flatcc')
 
     nanoarrow_ipc_lib = build_target(
         'nanoarrow_ipc',

--- a/subprojects/flatcc.wrap
+++ b/subprojects/flatcc.wrap
@@ -21,3 +21,6 @@ source_url = https://github.com/dvidelabs/flatcc/archive/refs/tags/v0.6.1.tar.gz
 source_filename = flatcc-0.6.1.tar.gz
 source_hash = 2533c2f1061498499f15acc7e0937dcf35bc68e685d237325124ae0d6c600c2b
 patch_directory = flatcc
+
+[provide]
+flatcc = flatcc_dep


### PR DESCRIPTION
Follow up to https://github.com/apache/arrow-nanoarrow/pull/483