### PR TITLE
fix: Check for offset + length > int64_max before using the value to calculate buffer sizes

### DIFF
--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1485,11 +1485,9 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
     array.offset = INT32_MAX;
     EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),
               EINVAL);
-    EXPECT_THAT(
-        ArrowErrorMessage(&error),
-        ::testing::StartsWith(
-            "Offset + length of a run-end encoded array must fit in a value of the "
-            "run end type int32, but offset + length is"));
+    EXPECT_STREQ(ArrowErrorMessage(&error),
+                 "Offset + length of a run-end encoded array must fit in a value of the "
+                 "run end type int32 but is 2147483647 + 7");
 
     ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
         NANOARROW_TYPE_INT16;
@@ -1499,17 +1497,14 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
     EXPECT_STREQ(
         ArrowErrorMessage(&error),
         "Offset + length of a run-end encoded array must fit in a value of the run end "
-        "type int16, but offset + length is 32774");
+        "type int16 but is 32767 + 7");
 
     ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
         NANOARROW_TYPE_INT64;
     array.offset = INT64_MAX;
     EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),
               EINVAL);
-    EXPECT_THAT(
-        ArrowErrorMessage(&error),
-        ::testing::StartsWith("Offset + length of a run-end encoded array must fit in a "
-                              "value of the run end type int64, but offset + length is"));
+    EXPECT_STREQ(ArrowErrorMessage(&error), "Offset + length is > INT64_MAX");
   }
   ((struct ArrowArrayPrivateData*)(array.children[0]->private_data))->storage_type =
       NANOARROW_TYPE_INT32;

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -1574,14 +1574,6 @@ TEST(ArrayTest, ArrayTestAppendToRunEndEncodedArray) {
                "All run ends must be greater than 0 but the first run end is 0");
   run_ends[0] = 4;
 
-  // Ensure the last run end is checked for >= 0
-  run_ends[2] = 0;
-  EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),
-            EINVAL);
-  EXPECT_STREQ(ArrowErrorMessage(&error),
-               "All run ends must be greater than 0 but the last run end is 0");
-  run_ends[2] = 7;
-
   array.length = 7;
   array.offset = 0;
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_FULL, &error),

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -184,8 +184,6 @@ TEST(BufferTest, BufferTestError) {
   ArrowBufferInit(&buffer);
   EXPECT_EQ(ArrowBufferResize(&buffer, std::numeric_limits<int64_t>::max(), false),
             ENOMEM);
-  EXPECT_EQ(ArrowBufferAppend(&buffer, nullptr, std::numeric_limits<int64_t>::max()),
-            ENOMEM);
 
   ASSERT_EQ(ArrowBufferAppend(&buffer, "abcd", 4), NANOARROW_OK);
   EXPECT_EQ(ArrowBufferSetAllocator(&buffer, ArrowBufferAllocatorDefault()), EINVAL);

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -985,28 +985,8 @@ class TestingJSONWriter {
   }
 
   void WriteString(std::ostream& out, ArrowStringView value) {
-    out << R"(")";
-
-    for (int64_t i = 0; i < value.size_bytes; i++) {
-      char c = value.data[i];
-      if (c == '"') {
-        out << R"(\")";
-      } else if (c == '\\') {
-        out << R"(\\)";
-      } else if (c >= 0 && c < 32) {
-        // Control characters need to be escaped with a \uXXXX escape
-        uint16_t utf16_bytes = static_cast<uint16_t>(c);
-
-        char utf16_esc[7];
-        utf16_esc[6] = '\0';
-        snprintf(utf16_esc, sizeof(utf16_esc), R"(\u%04x)", utf16_bytes);
-        out << utf16_esc;
-      } else {
-        out << c;
-      }
-    }
-
-    out << R"(")";
+    std::string value_str(value.data, static_cast<size_t>(value.size_bytes));
+    out << nlohmann::json(value_str);
   }
 
   void WriteBytes(std::ostream& out, ArrowBufferView value) {


### PR DESCRIPTION
See https://github.com/apache/arrow-nanoarrow/pull/518#issuecomment-2161063096 . The overflow wasn't the one I'd suspected and it wasn't related to that PR (that PR/the one before it just added a test covering a case that didn't exist in our previous tests).

I also fixed some compiler warnings exposed by the meson build on linux/arm64 (where character is unsigned).