### PR TITLE
fix: Ensure ArrowDeviceArray implementation for AppleMetal passes tests on newer MacOS

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   test-c-device:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.runner }}
 
     name: ${{ matrix.config.label }}
 
@@ -43,9 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {label: default-build}
-          - {label: namespaced-build, cmake_args: "-DNANOARROW_NAMESPACE=SomeUserNamespace"}
-          - {label: bundled-build, cmake_args: "-DNANOARROW_BUNDLE=ON"}
+          - {runner: ubuntu-latest, label: default-build}
+          - {runner: ubuntu-latest, label: namespaced-build, cmake_args: "-DNANOARROW_NAMESPACE=SomeUserNamespace"}
+          - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
+          - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
 
     env:
       SUBDIR: '${{ github.workspace }}'

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -48,18 +48,9 @@ jobs:
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
 
-    env:
-      SUBDIR: '${{ github.workspace }}'
-      NANOARROW_ARROW_TESTING_DIR: '${{ github.workspace }}/arrow-testing'
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Checkout arrow-testing
-        uses: actions/checkout@v4
-        with:
-          repository: apache/arrow-testing
-          path: arrow-testing
 
       - name: Install memcheck dependencies
         if: matrix.config.label == 'default-build'
@@ -83,9 +74,6 @@ jobs:
       - name: Build
         run: |
           ARROW_PATH="$(pwd)/arrow"
-          cd $SUBDIR
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
-          sudo ldconfig
           mkdir build
           cd build
           cmake .. -DCMAKE_BUILD_TYPE=Debug -DNANOARROW_DEVICE=ON \
@@ -97,8 +85,6 @@ jobs:
       - name: Check for non-namespaced symbols in namespaced build
         if: matrix.config.label == 'namespaced-build'
         run: |
-          cd $SUBDIR
-
           # Dump all symbols
           nm --extern-only build/libnanoarrow_device.a
 
@@ -114,20 +100,12 @@ jobs:
 
       - name: Run tests
         run: |
-          cd $SUBDIR
-
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
-          sudo ldconfig
           cd build
           ctest -T test --output-on-failure .
 
       - name: Run tests with valgrind
         if: matrix.config.label == 'default-build' || matrix.config.label == 'default-noatomics'
         run: |
-          cd $SUBDIR
-
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/dist/lib
-          sudo ldconfig
           cd build
           ctest -T memcheck .
 

--- a/src/nanoarrow/nanoarrow_device.c
+++ b/src/nanoarrow/nanoarrow_device.c
@@ -494,5 +494,5 @@ ArrowErrorCode ArrowDeviceArrayMoveToDevice(struct ArrowDeviceArray* src,
     NANOARROW_RETURN_NOT_OK(device_dst->array_move(device_src, src, device_dst, dst));
   }
 
-  return ENOTSUP;
+  return NANOARROW_OK;
 }

--- a/src/nanoarrow/nanoarrow_device_metal.cc
+++ b/src/nanoarrow/nanoarrow_device_metal.cc
@@ -145,7 +145,9 @@ struct ArrowDeviceMetalArrayPrivate {
 static void ArrowDeviceMetalArrayRelease(struct ArrowArray* array) {
   struct ArrowDeviceMetalArrayPrivate* private_data =
       (struct ArrowDeviceMetalArrayPrivate*)array->private_data;
-  private_data->event->release();
+  if (private_data->event != nullptr) {
+    private_data->event->release();
+  }
   ArrowArrayRelease(&private_data->parent);
   ArrowFree(private_data);
   array->release = NULL;
@@ -163,7 +165,7 @@ static ArrowErrorCode ArrowDeviceMetalArrayInit(struct ArrowDevice* device,
   }
 
   // One can create a new event with mtl_device->newSharedEvent();
-  private_data->event = sync_event;
+  private_data->event = static_cast<MTL::SharedEvent*>(sync_event);
 
   memset(device_array, 0, sizeof(struct ArrowDeviceArray));
   device_array->array = *array;
@@ -330,7 +332,8 @@ static ArrowErrorCode ArrowDeviceMetalArrayMove(struct ArrowDevice* device_src,
       return ENOTSUP;
     }
 
-    NANOARROW_RETURN_NOT_OK(ArrowDeviceArrayInit(device_dst, dst, &src->array));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowDeviceArrayInit(device_dst, dst, &src->array, src->sync_event));
     return NANOARROW_OK;
 
   } else if (device_src->device_type == ARROW_DEVICE_METAL &&

--- a/src/nanoarrow/nanoarrow_device_metal.cc
+++ b/src/nanoarrow/nanoarrow_device_metal.cc
@@ -227,15 +227,10 @@ static ArrowErrorCode ArrowDeviceMetalBufferMove(struct ArrowDevice* device_src,
       mtl_buffer->release();
       ArrowBufferMove(src, dst);
       return NANOARROW_OK;
+    } else {
+      // Otherwise, return ENOTSUP to signal that a move is not possible
+      return ENOTSUP;
     }
-
-    // Otherwise, initialize a new buffer and copy
-    struct ArrowBuffer tmp;
-    ArrowDeviceMetalInitBuffer(&tmp);
-    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(&tmp, src->data, src->size_bytes));
-    ArrowBufferMove(&tmp, dst);
-    ArrowBufferReset(src);
-    return NANOARROW_OK;
   } else if (device_src->device_type == ARROW_DEVICE_METAL &&
              device_dst->device_type == ARROW_DEVICE_METAL) {
     // Metal -> Metal is always just a move

--- a/src/nanoarrow/nanoarrow_device_metal.h
+++ b/src/nanoarrow/nanoarrow_device_metal.h
@@ -26,10 +26,10 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalDefaultDevice)
 #define ArrowDeviceMetalInitDefaultDevice \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalInitDefaultDevice)
-#define ArrowDeviceMetalInitCpuBuffer \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalInitCpuBuffer)
-#define ArrowDeviceMetalInitCpuArrayBuffers \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalInitCpuArrayBuffers)
+#define ArrowDeviceMetalInitBuffer \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalInitBuffer)
+#define ArrowDeviceMetalAlignArrayBuffers \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDeviceMetalAlignArrayBuffers)
 
 #endif
 


### PR DESCRIPTION
This PR fixes the Metal build (which was broken after a previous change), adds it to CI (thanks to the new GitHub M1 runners!) and fixes a failure I see locally (but not on CI) whereby the Metal runtime on some (newer? different?) MacOS environments can wrap arbitrary bytes as an `MTL::Buffer()`.

If true, this is awesome! But it does mean that in some cases we can "move" CPU arrays to the GPU without a copy and in some cases we have to copy into page-aligned memory (and that this can only be tested at runtime).