### PR TITLE
refactor: Use ArrowStringView C++ literal in tests

### DIFF
--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -39,6 +39,7 @@
 #include "nanoarrow/nanoarrow.hpp"
 
 using namespace arrow;
+using namespace nanoarrow::literals;
 using nanoarrow::NA;
 using testing::ElementsAre;
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -879,7 +879,7 @@ TEST(ArrayTest, ArrayTestAppendToLargeStringArray) {
   EXPECT_EQ(memcmp(data_buffer, "123456789", 9), 0);
 
   EXPECT_THAT(nanoarrow::ViewArrayAsBytes<64>(&array),
-              ElementsAre("1234"_v, NA, NA, "56789"_v, ""_v));
+              ElementsAre("1234"_sv, NA, NA, "56789"_sv, ""_sv));
   ArrowArrayRelease(&array);
 }
 
@@ -915,7 +915,7 @@ TEST(ArrayTest, ArrayTestAppendToFixedSizeBinaryArray) {
   EXPECT_EQ(memcmp(data_buffer, expected_data, 25), 0);
 
   EXPECT_THAT(nanoarrow::ViewArrayAsFixedSizeBytes(&array, 5),
-              ElementsAre("12345"_v, NA, NA, "67890"_v, "\0\0\0\0\0"_v));
+              ElementsAre("12345"_sv, NA, NA, "67890"_sv, "\0\0\0\0\0"_sv));
   ArrowArrayRelease(&array);
   ArrowSchemaRelease(&schema);
 }
@@ -1264,9 +1264,8 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(array.children[0], 1)->capacity_bytes, 0);
 
-  struct ArrowStringView string_value = ArrowCharView("foobar");
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0]->children[0], 123), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[0]->children[1], string_value),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[0]->children[1], "foobar"_sv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishElement(array.children[0]), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishElement(&array), NANOARROW_OK);
@@ -2361,11 +2360,8 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 1), 1);
 
-  struct ArrowStringView item;
-  item = ArrowArrayViewGetStringUnsafe(array_view.dictionary, 0);
-  EXPECT_EQ(std::string(item.data, item.size_bytes), "abc");
-  item = ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1);
-  EXPECT_EQ(std::string(item.data, item.size_bytes), "def");
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 0), "abc"_sv);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1), "def"_sv);
 
   ArrowArrayRelease(&array);
 

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -257,8 +257,8 @@ TEST(ArrayTest, ArrayTestExplicitValidationLevel) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_asv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_NONE, &error),
             NANOARROW_OK);
 
@@ -313,8 +313,8 @@ TEST(ArrayTest, ArrayTestValidateMinimalBufferAccess) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_asv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_asv), NANOARROW_OK);
 
   // Temporarily make it so that referencing the offsets buffer will crash
   // but make sure it has the correct size_bytes and passes minimal validation
@@ -396,7 +396,7 @@ TEST(ArrayTest, ArrayTestAppendToNullArray) {
   buffer_view.data.data = nullptr;
   buffer_view.size_bytes = 0;
   EXPECT_EQ(ArrowArrayAppendBytes(&array, buffer_view), EINVAL);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ""_sv), EINVAL);
+  EXPECT_EQ(ArrowArrayAppendString(&array, ""_asv), EINVAL);
   ArrowArrayRelease(&array);
 }
 
@@ -524,9 +524,9 @@ TEST(ArrayTest, ArrayTestAppendToStringArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(&array, 1)->capacity_bytes, (5 + 1) * sizeof(int32_t));
 
-  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
@@ -560,7 +560,7 @@ TEST(ArrayTest, ArrayTestAppendEmptyToString) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ""_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, ""_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
   EXPECT_NE(array.buffers[2], nullptr);
   ArrowArrayRelease(&array);
@@ -860,9 +860,9 @@ TEST(ArrayTest, ArrayTestAppendToLargeStringArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(&array, 1)->capacity_bytes, (5 + 1) * sizeof(int64_t));
 
-  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
@@ -880,7 +880,7 @@ TEST(ArrayTest, ArrayTestAppendToLargeStringArray) {
   EXPECT_EQ(memcmp(data_buffer, "123456789", 9), 0);
 
   EXPECT_THAT(nanoarrow::ViewArrayAsBytes<64>(&array),
-              ElementsAre("1234"_sv, NA, NA, "56789"_sv, ""_sv));
+              ElementsAre("1234"_asv, NA, NA, "56789"_asv, ""_asv));
   ArrowArrayRelease(&array);
 }
 
@@ -916,7 +916,7 @@ TEST(ArrayTest, ArrayTestAppendToFixedSizeBinaryArray) {
   EXPECT_EQ(memcmp(data_buffer, expected_data, 25), 0);
 
   EXPECT_THAT(nanoarrow::ViewArrayAsFixedSizeBytes(&array, 5),
-              ElementsAre("12345"_sv, NA, NA, "67890"_sv, "\0\0\0\0\0"_sv));
+              ElementsAre("12345"_asv, NA, NA, "67890"_asv, "\0\0\0\0\0"_asv));
   ArrowArrayRelease(&array);
   ArrowSchemaRelease(&schema);
 }
@@ -1266,7 +1266,7 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   EXPECT_EQ(ArrowArrayBuffer(array.children[0], 1)->capacity_bytes, 0);
 
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0]->children[0], 123), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[0]->children[1], "foobar"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[0]->children[1], "foobar"_asv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishElement(array.children[0]), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishElement(&array), NANOARROW_OK);
@@ -1653,7 +1653,7 @@ TEST(ArrayTest, ArrayTestAppendToDenseUnionArray) {
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_asv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
@@ -1699,7 +1699,7 @@ TEST(ArrayTest, ArrayTestAppendToSparseUnionArray) {
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_asv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
@@ -2345,8 +2345,8 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "abc"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "def"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "abc"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "def"_asv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(&array, 0), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
@@ -2361,8 +2361,8 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 0), 0);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&array_view, 1), 1);
 
-  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 0), "abc"_sv);
-  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1), "def"_sv);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 0), "abc"_asv);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(array_view.dictionary, 1), "def"_asv);
 
   ArrowArrayRelease(&array);
 
@@ -2402,7 +2402,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
@@ -2510,7 +2510,7 @@ TEST(ArrayTest, ArrayViewTestDenseUnionGet) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
@@ -2556,7 +2556,7 @@ TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);

--- a/src/nanoarrow/array_test.cc
+++ b/src/nanoarrow/array_test.cc
@@ -256,8 +256,8 @@ TEST(ArrayTest, ArrayTestExplicitValidationLevel) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("1234")), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("5678")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuilding(&array, NANOARROW_VALIDATION_LEVEL_NONE, &error),
             NANOARROW_OK);
 
@@ -312,8 +312,8 @@ TEST(ArrayTest, ArrayTestValidateMinimalBufferAccess) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("1234")), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("5678")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "5678"_sv), NANOARROW_OK);
 
   // Temporarily make it so that referencing the offsets buffer will crash
   // but make sure it has the correct size_bytes and passes minimal validation
@@ -395,7 +395,7 @@ TEST(ArrayTest, ArrayTestAppendToNullArray) {
   buffer_view.data.data = nullptr;
   buffer_view.size_bytes = 0;
   EXPECT_EQ(ArrowArrayAppendBytes(&array, buffer_view), EINVAL);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("")), EINVAL);
+  EXPECT_EQ(ArrowArrayAppendString(&array, ""_sv), EINVAL);
   ArrowArrayRelease(&array);
 }
 
@@ -523,9 +523,9 @@ TEST(ArrayTest, ArrayTestAppendToStringArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(&array, 1)->capacity_bytes, (5 + 1) * sizeof(int32_t));
 
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("1234")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("56789")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
@@ -559,7 +559,7 @@ TEST(ArrayTest, ArrayTestAppendEmptyToString) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("")), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, ""_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
   EXPECT_NE(array.buffers[2], nullptr);
   ArrowArrayRelease(&array);
@@ -859,9 +859,9 @@ TEST(ArrayTest, ArrayTestAppendToLargeStringArray) {
   ASSERT_EQ(ArrowArrayReserve(&array, 5), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayBuffer(&array, 1)->capacity_bytes, (5 + 1) * sizeof(int64_t));
 
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("1234")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "1234"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayAppendString(&array, ArrowCharView("56789")), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendString(&array, "56789"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
@@ -1652,7 +1652,7 @@ TEST(ArrayTest, ArrayTestAppendToDenseUnionArray) {
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
@@ -1698,7 +1698,7 @@ TEST(ArrayTest, ArrayTestAppendToSparseUnionArray) {
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendNull(&array, 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
             NANOARROW_OK);
   EXPECT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayAppendEmpty(&array, 1), NANOARROW_OK);
@@ -2344,8 +2344,8 @@ TEST(ArrayTest, ArrayViewTestDictionary) {
   struct ArrowArray array;
   ASSERT_EQ(ArrowArrayInitFromSchema(&array, &schema, nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, ArrowCharView("abc")), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, ArrowCharView("def")), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "abc"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(array.dictionary, "def"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(&array, 0), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
@@ -2401,7 +2401,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
@@ -2509,7 +2509,7 @@ TEST(ArrayTest, ArrayViewTestDenseUnionGet) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
@@ -2555,7 +2555,7 @@ TEST(ArrayTest, ArrayViewTestSparseUnionGet) {
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(array.children[0], 123), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(array.children[1], ArrowCharView("one twenty four")),
+  ASSERT_EQ(ArrowArrayAppendString(array.children[1], "one twenty four"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -194,6 +194,8 @@ TEST(BufferTest, BufferTestError) {
 }
 
 TEST(BufferTest, BufferTestAppendHelpers) {
+  using namespace nanoarrow::literals;
+
   struct ArrowBuffer buffer;
   ArrowBufferInit(&buffer);
 

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -239,7 +239,7 @@ TEST(BufferTest, BufferTestAppendHelpers) {
   EXPECT_EQ(reinterpret_cast<float*>(buffer.data)[0], 123);
   ArrowBufferReset(&buffer);
 
-  EXPECT_EQ(ArrowBufferAppendStringView(&buffer, "a"_sv), NANOARROW_OK);
+  EXPECT_EQ(ArrowBufferAppendStringView(&buffer, "a"_asv), NANOARROW_OK);
   EXPECT_EQ(reinterpret_cast<char*>(buffer.data)[0], 'a');
   EXPECT_EQ(buffer.size_bytes, 1);
   ArrowBufferReset(&buffer);

--- a/src/nanoarrow/buffer_test.cc
+++ b/src/nanoarrow/buffer_test.cc
@@ -21,7 +21,7 @@
 
 #include <gtest/gtest.h>
 
-#include "nanoarrow/nanoarrow.h"
+#include "nanoarrow/nanoarrow.hpp"
 
 // This test allocator guarantees that allocator->reallocate will return
 // a new pointer so that we can test when reallocations happen whilst
@@ -237,7 +237,7 @@ TEST(BufferTest, BufferTestAppendHelpers) {
   EXPECT_EQ(reinterpret_cast<float*>(buffer.data)[0], 123);
   ArrowBufferReset(&buffer);
 
-  EXPECT_EQ(ArrowBufferAppendStringView(&buffer, ArrowCharView("a")), NANOARROW_OK);
+  EXPECT_EQ(ArrowBufferAppendStringView(&buffer, "a"_sv), NANOARROW_OK);
   EXPECT_EQ(reinterpret_cast<char*>(buffer.data)[0], 'a');
   EXPECT_EQ(buffer.size_bytes, 1);
   ArrowBufferReset(&buffer);

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -90,8 +90,8 @@ namespace literals {
 ///
 /// @{
 
-/// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView operator"" _sv(const char* data, std::size_t size_bytes) {
+/// \brief User literal operator allowing ArrowStringView construction like "str"_asv
+inline ArrowStringView operator"" _asv(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -906,7 +906,7 @@ inline bool operator==(ArrowStringView l, ArrowStringView r) {
 }
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView operator"" _v(const char* data, std::size_t size_bytes) {
+inline ArrowStringView operator"" _sv(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 /// @}

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -82,6 +82,23 @@ class Exception : public std::exception {
 
 /// @}
 
+namespace literals {
+
+/// \defgroup nanoarrow_hpp-string_view_helpers ArrowStringView helpers
+///
+/// Factories and equality comparison for ArrowStringView.
+///
+/// @{
+
+/// \brief User literal operator allowing ArrowStringView construction like "str"_sv
+inline ArrowStringView operator"" _sv(const char* data, std::size_t size_bytes) {
+  return {data, static_cast<int64_t>(size_bytes)};
+}
+
+// @}
+
+}  // namespace literals
+
 namespace internal {
 
 /// \defgroup nanoarrow_hpp-unique_base Base classes for Unique wrappers
@@ -893,22 +910,11 @@ class ViewArrayStream {
 
 }  // namespace nanoarrow
 
-/// \defgroup nanoarrow_hpp-string_view_helpers ArrowStringView helpers
-///
-/// Factories and equality comparison for ArrowStringView.
-///
-/// @{
-
 /// \brief Equality comparison operator between ArrowStringView
+/// \ingroup nanoarrow_hpp-string_view_helpers
 inline bool operator==(ArrowStringView l, ArrowStringView r) {
   if (l.size_bytes != r.size_bytes) return false;
   return memcmp(l.data, r.data, l.size_bytes) == 0;
 }
-
-/// \brief User literal operator allowing ArrowStringView construction like "str"_sv
-inline ArrowStringView operator"" _sv(const char* data, std::size_t size_bytes) {
-  return {data, static_cast<int64_t>(size_bytes)};
-}
-/// @}
 
 #endif

--- a/src/nanoarrow/nanoarrow_device_cuda_test.cc
+++ b/src/nanoarrow/nanoarrow_device_cuda_test.cc
@@ -197,6 +197,8 @@ std::tuple<ArrowDeviceType, enum ArrowType, bool> TestParams(ArrowDeviceType dev
 }
 
 TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowDevice* gpu = ArrowDeviceCuda(std::get<0>(GetParam()), 0);
   struct ArrowArray array;

--- a/src/nanoarrow/nanoarrow_device_cuda_test.cc
+++ b/src/nanoarrow/nanoarrow_device_cuda_test.cc
@@ -208,13 +208,13 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCudaArrayViewString) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, string_type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("abc")), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("defg")), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_asv), NANOARROW_OK);
   if (include_null) {
     ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
     expected_data_size = 7;
   } else {
-    ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("hjk")), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendString(&array, "hjk"_asv), NANOARROW_OK);
     expected_data_size = 10;
   }
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);

--- a/src/nanoarrow/nanoarrow_device_metal_test.cc
+++ b/src/nanoarrow/nanoarrow_device_metal_test.cc
@@ -231,8 +231,8 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, string_type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_asv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 

--- a/src/nanoarrow/nanoarrow_device_metal_test.cc
+++ b/src/nanoarrow/nanoarrow_device_metal_test.cc
@@ -222,6 +222,8 @@ class StringTypeParameterizedTestFixture
 };
 
 TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDevice* metal = ArrowDeviceMetalDefaultDevice();
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowArray array;

--- a/src/nanoarrow/nanoarrow_device_metal_test.cc
+++ b/src/nanoarrow/nanoarrow_device_metal_test.cc
@@ -231,8 +231,8 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceMetalArrayViewString) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, string_type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("abc")), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("defg")), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 

--- a/src/nanoarrow/nanoarrow_device_test.cc
+++ b/src/nanoarrow/nanoarrow_device_test.cc
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 
-#include "nanoarrow/nanoarrow_device.h"
+#include "nanoarrow/nanoarrow_device.hpp"
 
 TEST(NanoarrowDevice, CheckRuntime) {
   EXPECT_EQ(ArrowDeviceCheckRuntime(nullptr), NANOARROW_OK);
@@ -76,8 +76,8 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCpuArrayViewString) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, string_type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("abc")), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, ArrowCharView("defg")), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 

--- a/src/nanoarrow/nanoarrow_device_test.cc
+++ b/src/nanoarrow/nanoarrow_device_test.cc
@@ -68,6 +68,8 @@ class StringTypeParameterizedTestFixture
 };
 
 TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCpuArrayViewString) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDevice* cpu = ArrowDeviceCpu();
   struct ArrowArray array;
   struct ArrowDeviceArray device_array;

--- a/src/nanoarrow/nanoarrow_device_test.cc
+++ b/src/nanoarrow/nanoarrow_device_test.cc
@@ -78,8 +78,8 @@ TEST_P(StringTypeParameterizedTestFixture, ArrowDeviceCpuArrayViewString) {
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, string_type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "abc"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "defg"_asv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -306,7 +306,8 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsBytesTest) {
   array.buffers = buffers;
 
   int i = 0;
-  ArrowStringView expected[] = {"a"_sv, "b"_sv, "c"_sv, "d"_sv, "e"_sv, "f"_sv, "g"_sv};
+  ArrowStringView expected[] = {"a"_asv, "b"_asv, "c"_asv, "d"_asv,
+                                "e"_asv, "f"_asv, "g"_asv};
   for (auto slot : nanoarrow::ViewArrayAsBytes<32>(&array)) {
     if (i == 2 || i == 5) {
       EXPECT_EQ(slot, nanoarrow::NA);
@@ -339,7 +340,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsFixedSizeBytesTest) {
     if (i == 2 || i == 5) {
       EXPECT_EQ(slot, nanoarrow::NA);
     } else {
-      EXPECT_EQ(slot, i % 2 == 0 ? "foo"_sv : "bar"_sv);
+      EXPECT_EQ(slot, i % 2 == 0 ? "foo"_asv : "bar"_asv);
     }
     ++i;
   }

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -304,7 +304,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsBytesTest) {
   array.buffers = buffers;
 
   int i = 0;
-  ArrowStringView expected[] = {"a"_v, "b"_v, "c"_v, "d"_v, "e"_v, "f"_v, "g"_v};
+  ArrowStringView expected[] = {"a"_sv, "b"_sv, "c"_sv, "d"_sv, "e"_sv, "f"_sv, "g"_sv};
   for (auto slot : nanoarrow::ViewArrayAsBytes<32>(&array)) {
     if (i == 2 || i == 5) {
       EXPECT_EQ(slot, nanoarrow::NA);
@@ -335,7 +335,7 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsFixedSizeBytesTest) {
     if (i == 2 || i == 5) {
       EXPECT_EQ(slot, nanoarrow::NA);
     } else {
-      EXPECT_EQ(slot, i % 2 == 0 ? "foo"_v : "bar"_v);
+      EXPECT_EQ(slot, i % 2 == 0 ? "foo"_sv : "bar"_sv);
     }
     ++i;
   }

--- a/src/nanoarrow/nanoarrow_hpp_test.cc
+++ b/src/nanoarrow/nanoarrow_hpp_test.cc
@@ -288,6 +288,8 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsTest) {
 }
 
 TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsBytesTest) {
+  using namespace nanoarrow::literals;
+
   nanoarrow::UniqueBuffer is_valid, offsets, data;
   nanoarrow::BufferInitSequence(is_valid.get(), std::vector<uint8_t>{0xFF});
   ArrowBitClear(is_valid->data, 2);
@@ -316,6 +318,8 @@ TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsBytesTest) {
 }
 
 TEST(NanoarrowHppTest, NanoarrowHppViewArrayAsFixedSizeBytesTest) {
+  using namespace nanoarrow::literals;
+
   nanoarrow::UniqueBuffer is_valid, data;
   nanoarrow::BufferInitSequence(is_valid.get(), std::vector<uint8_t>{0xFF});
   ArrowBitClear(is_valid->data, 2);

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -210,8 +210,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
       },
       [](ArrowArray* array) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_asv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_asv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -237,7 +237,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
       [](ArrowArray* array) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "\u0001"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "\u0001"_asv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -252,8 +252,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnLargeString) {
       },
       [](ArrowArray* array) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_asv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_asv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -273,7 +273,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnBinary) {
         value_view.size_bytes = sizeof(value);
 
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_asv));
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendBytes(array, value_view));
         return NANOARROW_OK;
       },
@@ -451,9 +451,9 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
         nanoarrow::UniqueBuffer buffer;
         NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderInit(buffer.get(), nullptr));
         NANOARROW_RETURN_NOT_OK(
-            ArrowMetadataBuilderAppend(buffer.get(), "k1"_sv, "v1"_sv));
+            ArrowMetadataBuilderAppend(buffer.get(), "k1"_asv, "v1"_asv));
         NANOARROW_RETURN_NOT_OK(
-            ArrowMetadataBuilderAppend(buffer.get(), "k2"_sv, "v2"_sv));
+            ArrowMetadataBuilderAppend(buffer.get(), "k2"_asv, "v2"_asv));
 
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         NANOARROW_RETURN_NOT_OK(
@@ -724,8 +724,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestReadSchema) {
   ArrowStringView key;
   ArrowStringView value;
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata_reader, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(key, "k1"_sv);
-  ASSERT_EQ(value, "v1"_sv);
+  ASSERT_EQ(key, "k1"_asv);
+  ASSERT_EQ(value, "v1"_asv);
 
   // Check invalid JSON
   EXPECT_EQ(reader.ReadSchema(R"({)", schema.get()), EINVAL);
@@ -800,12 +800,12 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldMetadata) {
   ASSERT_EQ(metadata.remaining_keys, 2);
 
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(key, "k1"_sv);
-  ASSERT_EQ(value, "v1"_sv);
+  ASSERT_EQ(key, "k1"_asv);
+  ASSERT_EQ(value, "v1"_asv);
 
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(key, "k2"_sv);
-  ASSERT_EQ(value, "v2"_sv);
+  ASSERT_EQ(key, "k2"_asv);
+  ASSERT_EQ(value, "v2"_asv);
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldNested) {
@@ -1399,8 +1399,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchemaComparison) {
   // With different top-level metadata
   nanoarrow::UniqueBuffer buf;
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_asv, "value1"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1487,15 +1489,19 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of order
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_asv, "value1"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_asv, "value1"_asv),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(expected.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1549,8 +1555,9 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of item content
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "gazornenplat"_sv),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_asv, "gazornenplat"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
@@ -1583,8 +1590,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of item keys
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key3"_sv, "value1"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key3"_asv, "value1"_asv),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1616,8 +1625,9 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // Metadata that are not equal and contain duplicate keys
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2 again"_sv),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_asv, "value2 again"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
@@ -1753,7 +1763,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestArrayWithDictionaryComparison) {
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(expected.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(expected->children[0], 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(expected->children[0]->dictionary, "abc"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(expected->children[0]->dictionary, "abc"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(expected.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(expected.get(), nullptr), NANOARROW_OK);
@@ -1762,7 +1772,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestArrayWithDictionaryComparison) {
   ASSERT_EQ(ArrowArrayInitFromSchema(actual.get(), schema.get(), nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(actual.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(actual->children[0], 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(actual->children[0]->dictionary, "def"_sv),
+  ASSERT_EQ(ArrowArrayAppendString(actual->children[0]->dictionary, "def"_asv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(actual.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(actual.get(), nullptr), NANOARROW_OK);

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -723,8 +723,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestReadSchema) {
   ArrowStringView key;
   ArrowStringView value;
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata_reader, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(std::string(key.data, key.size_bytes), "k1");
-  ASSERT_EQ(std::string(value.data, value.size_bytes), "v1");
+  ASSERT_EQ(key, "k1"_sv);
+  ASSERT_EQ(value, "v1"_sv);
 
   // Check invalid JSON
   EXPECT_EQ(reader.ReadSchema(R"({)", schema.get()), EINVAL);
@@ -799,12 +799,12 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldMetadata) {
   ASSERT_EQ(metadata.remaining_keys, 2);
 
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(std::string(key.data, key.size_bytes), "k1");
-  ASSERT_EQ(std::string(value.data, value.size_bytes), "v1");
+  ASSERT_EQ(key, "k1"_sv);
+  ASSERT_EQ(value, "v1"_sv);
 
   ASSERT_EQ(ArrowMetadataReaderRead(&metadata, &key, &value), NANOARROW_OK);
-  ASSERT_EQ(std::string(key.data, key.size_bytes), "k2");
-  ASSERT_EQ(std::string(value.data, value.size_bytes), "v2");
+  ASSERT_EQ(key, "k2"_sv);
+  ASSERT_EQ(value, "v2"_sv);
 }
 
 TEST(NanoarrowTestingTest, NanoarrowTestingTestReadFieldNested) {

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -209,8 +209,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
       },
       [](ArrowArray* array) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("abc")));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("def")));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_sv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -236,7 +236,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnString) {
         return ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRING);
       },
       [](ArrowArray* array) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("\u0001")));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "\u0001"_sv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -251,8 +251,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnLargeString) {
       },
       [](ArrowArray* array) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("abc")));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("def")));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "def"_sv));
         return NANOARROW_OK;
       },
       &WriteColumnJSON,
@@ -272,7 +272,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestColumnBinary) {
         value_view.size_bytes = sizeof(value);
 
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendNull(array, 1));
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, ArrowCharView("abc")));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendString(array, "abc"_sv));
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendBytes(array, value_view));
         return NANOARROW_OK;
       },
@@ -449,10 +449,10 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestFieldMetadata) {
       [](ArrowSchema* schema) {
         nanoarrow::UniqueBuffer buffer;
         NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderInit(buffer.get(), nullptr));
-        NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderAppend(
-            buffer.get(), ArrowCharView("k1"), ArrowCharView("v1")));
-        NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderAppend(
-            buffer.get(), ArrowCharView("k2"), ArrowCharView("v2")));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowMetadataBuilderAppend(buffer.get(), "k1"_sv, "v1"_sv));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowMetadataBuilderAppend(buffer.get(), "k2"_sv, "v2"_sv));
 
         NANOARROW_RETURN_NOT_OK(ArrowSchemaInitFromType(schema, NANOARROW_TYPE_NA));
         NANOARROW_RETURN_NOT_OK(
@@ -1398,12 +1398,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestSchemaComparison) {
   // With different top-level metadata
   nanoarrow::UniqueBuffer buf;
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key1"),
-                                       ArrowCharView("value1")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1490,23 +1486,15 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of order
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key1"),
-                                       ArrowCharView("value1")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key1"),
-                                       ArrowCharView("value1")),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "value1"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(expected.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1560,11 +1548,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of item content
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key1"),
-                                       ArrowCharView("gazornenplat")),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key1"_sv, "gazornenplat"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
@@ -1597,12 +1582,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // With different top-level metadata that are not equivalent because of item keys
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key3"),
-                                       ArrowCharView("value1")),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key3"_sv, "value1"_sv), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
 
@@ -1634,11 +1615,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestMetadataComparison) {
   // Metadata that are not equal and contain duplicate keys
   buf.reset();
   ASSERT_EQ(ArrowMetadataBuilderInit(buf.get(), nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2")),
-            NANOARROW_OK);
-  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), ArrowCharView("key2"),
-                                       ArrowCharView("value2 again")),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderAppend(buf.get(), "key2"_sv, "value2 again"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetMetadata(actual.get(), reinterpret_cast<char*>(buf->data)),
             NANOARROW_OK);
@@ -1774,9 +1752,8 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestArrayWithDictionaryComparison) {
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(expected.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(expected->children[0], 0), NANOARROW_OK);
-  ASSERT_EQ(
-      ArrowArrayAppendString(expected->children[0]->dictionary, ArrowCharView("abc")),
-      NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(expected->children[0]->dictionary, "abc"_sv),
+            NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(expected.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(expected.get(), nullptr), NANOARROW_OK);
 
@@ -1784,7 +1761,7 @@ TEST(NanoarrowTestingTest, NanoarrowTestingTestArrayWithDictionaryComparison) {
   ASSERT_EQ(ArrowArrayInitFromSchema(actual.get(), schema.get(), nullptr), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(actual.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendInt(actual->children[0], 0), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(actual->children[0]->dictionary, ArrowCharView("def")),
+  ASSERT_EQ(ArrowArrayAppendString(actual->children[0]->dictionary, "def"_sv),
             NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishElement(actual.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(actual.get(), nullptr), NANOARROW_OK);

--- a/src/nanoarrow/nanoarrow_testing_test.cc
+++ b/src/nanoarrow/nanoarrow_testing_test.cc
@@ -25,6 +25,7 @@
 using nanoarrow::testing::TestingJSONComparison;
 using nanoarrow::testing::TestingJSONReader;
 using nanoarrow::testing::TestingJSONWriter;
+using namespace nanoarrow::literals;
 
 ArrowErrorCode WriteBatchJSON(std::ostream& out, TestingJSONWriter& writer,
                               const ArrowSchema* schema, ArrowArrayView* array_view) {

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -1495,6 +1495,8 @@ TEST(SchemaViewTest, SchemaViewInitDictionaryErrors) {
 }
 
 TEST(SchemaViewTest, SchemaViewInitExtension) {
+  using namespace nanoarrow::literals;
+
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
@@ -1506,7 +1508,7 @@ TEST(SchemaViewTest, SchemaViewInitExtension) {
   auto int_field = field("field_name", int32(), arrow_meta);
   ARROW_EXPECT_OK(ExportField(*int_field, &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
-  EXPECT_EQ(schema_view.extension_name.data, "arrow.test.ext_name"_sv);
+  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_sv);
   EXPECT_EQ(schema_view.extension_metadata, "test metadata"_sv);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "arrow.test.ext_name{int32}");
 
@@ -1514,6 +1516,8 @@ TEST(SchemaViewTest, SchemaViewInitExtension) {
 }
 
 TEST(SchemaViewTest, SchemaViewInitExtensionDictionary) {
+  using namespace nanoarrow::literals;
+
   struct ArrowSchema schema;
   struct ArrowSchemaView schema_view;
   struct ArrowError error;
@@ -1568,6 +1572,8 @@ TEST(SchemaViewTest, SchemaFormatInvalid) {
 }
 
 TEST(MetadataTest, Metadata) {
+  using namespace nanoarrow::literals;
+
   // Encoded metadata string for "key": "value"
   std::string simple_metadata = SimpleMetadata();
 
@@ -1590,6 +1596,8 @@ TEST(MetadataTest, Metadata) {
 }
 
 TEST(MetadataTest, MetadataBuild) {
+  using namespace nanoarrow::literals;
+
   // Encoded metadata string for "key": "value"
   std::string simple_metadata = SimpleMetadata();
 

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -1508,8 +1508,8 @@ TEST(SchemaViewTest, SchemaViewInitExtension) {
   auto int_field = field("field_name", int32(), arrow_meta);
   ARROW_EXPECT_OK(ExportField(*int_field, &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
-  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_sv);
-  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_sv);
+  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_asv);
+  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_asv);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "arrow.test.ext_name{int32}");
 
   ArrowSchemaRelease(&schema);
@@ -1531,8 +1531,8 @@ TEST(SchemaViewTest, SchemaViewInitExtensionDictionary) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_DICTIONARY);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
-  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_sv);
-  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_sv);
+  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_asv);
+  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_asv);
   EXPECT_EQ(ArrowSchemaToStdString(&schema),
             "arrow.test.ext_name{dictionary(int32)<string>}");
 
@@ -1581,18 +1581,18 @@ TEST(MetadataTest, Metadata) {
   EXPECT_EQ(ArrowMetadataSizeOf(simple_metadata.data()),
             static_cast<int64_t>(simple_metadata.size()));
 
-  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata.data(), "key"_sv), 1);
-  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata.data(), "not_a_key"_sv), 0);
+  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata.data(), "key"_asv), 1);
+  EXPECT_EQ(ArrowMetadataHasKey(simple_metadata.data(), "not_a_key"_asv), 0);
 
-  struct ArrowStringView value = "default_val"_sv;
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata.data(), "key"_sv, &value),
+  struct ArrowStringView value = "default_val"_asv;
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata.data(), "key"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "value"_sv);
+  EXPECT_EQ(value, "value"_asv);
 
-  value = "default_val"_sv;
-  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata.data(), "not_a_key"_sv, &value),
+  value = "default_val"_asv;
+  EXPECT_EQ(ArrowMetadataGetValue(simple_metadata.data(), "not_a_key"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "default_val"_sv);
+  EXPECT_EQ(value, "default_val"_asv);
 }
 
 TEST(MetadataTest, MetadataBuild) {
@@ -1617,49 +1617,49 @@ TEST(MetadataTest, MetadataBuild) {
   EXPECT_EQ(metadata_builder.data, nullptr);
 
   // Recreate simple_metadata
-  ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, "key"_sv, "value"_sv),
+  ASSERT_EQ(ArrowMetadataBuilderAppend(&metadata_builder, "key"_asv, "value"_asv),
             NANOARROW_OK);
   ASSERT_EQ(metadata_builder.size_bytes, simple_metadata.size());
   EXPECT_EQ(memcmp(metadata_builder.data, simple_metadata.data(), simple_metadata.size()),
             0);
 
   // Remove a key that doesn't exist
-  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key2"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key2"_asv), NANOARROW_OK);
   ASSERT_EQ(metadata_builder.size_bytes, simple_metadata.size());
   EXPECT_EQ(
       memcmp(metadata_builder.data, simple_metadata.data(), metadata_builder.size_bytes),
       0);
 
   // Add a new key
-  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2"_sv, "value2"_sv),
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key2"_asv, "value2"_asv),
             NANOARROW_OK);
   EXPECT_EQ(metadata_builder.size_bytes,
             simple_metadata.size() + sizeof(int32_t) + 4 + sizeof(int32_t) + 6);
 
   struct ArrowStringView value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "value2"_sv);
+  EXPECT_EQ(value, "value2"_asv);
 
   // Set an existing key
-  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key"_sv, "value3"_sv),
+  ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key"_asv, "value3"_asv),
             NANOARROW_OK);
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key"_sv, &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "value3"_sv);
+  EXPECT_EQ(value, "value3"_asv);
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "value2"_sv);
+  EXPECT_EQ(value, "value2"_asv);
 
   // Remove a key that does exist
-  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"_sv), NANOARROW_OK);
-  EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"_sv), false);
+  ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"_asv), NANOARROW_OK);
+  EXPECT_EQ(ArrowMetadataHasKey((const char*)metadata_builder.data, "key"_asv), false);
   value = ArrowCharView(nullptr);
-  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
+  ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_asv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(value, "value2"_sv);
+  EXPECT_EQ(value, "value2"_asv);
 
   ArrowBufferReset(&metadata_builder);
 }

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -22,7 +22,7 @@
 #include <arrow/testing/gtest_util.h>
 #include <arrow/util/key_value_metadata.h>
 
-#include "nanoarrow/nanoarrow.h"
+#include "nanoarrow/nanoarrow.hpp"
 
 using namespace arrow;
 
@@ -1589,13 +1589,13 @@ TEST(MetadataTest, Metadata) {
   struct ArrowStringView value = ArrowCharView("default_val");
   EXPECT_EQ(ArrowMetadataGetValue(simple_metadata.data(), ArrowCharView("key"), &value),
             NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "value");
+  EXPECT_EQ(value, "value"_sv);
 
   value = ArrowCharView("default_val");
   EXPECT_EQ(
       ArrowMetadataGetValue(simple_metadata.data(), ArrowCharView("not_a_key"), &value),
       NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "default_val");
+  EXPECT_EQ(value, "default_val"_sv);
 }
 
 TEST(MetadataTest, MetadataBuild) {

--- a/src/nanoarrow/schema_test.cc
+++ b/src/nanoarrow/schema_test.cc
@@ -1506,12 +1506,8 @@ TEST(SchemaViewTest, SchemaViewInitExtension) {
   auto int_field = field("field_name", int32(), arrow_meta);
   ARROW_EXPECT_OK(ExportField(*int_field, &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
-  EXPECT_EQ(
-      std::string(schema_view.extension_name.data, schema_view.extension_name.size_bytes),
-      "arrow.test.ext_name");
-  EXPECT_EQ(std::string(schema_view.extension_metadata.data,
-                        schema_view.extension_metadata.size_bytes),
-            "test metadata");
+  EXPECT_EQ(schema_view.extension_name.data, "arrow.test.ext_name"_sv);
+  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_sv);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "arrow.test.ext_name{int32}");
 
   ArrowSchemaRelease(&schema);
@@ -1531,12 +1527,8 @@ TEST(SchemaViewTest, SchemaViewInitExtensionDictionary) {
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_DICTIONARY);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_INT32);
-  EXPECT_EQ(
-      std::string(schema_view.extension_name.data, schema_view.extension_name.size_bytes),
-      "arrow.test.ext_name");
-  EXPECT_EQ(std::string(schema_view.extension_metadata.data,
-                        schema_view.extension_metadata.size_bytes),
-            "test metadata");
+  EXPECT_EQ(schema_view.extension_name, "arrow.test.ext_name"_sv);
+  EXPECT_EQ(schema_view.extension_metadata, "test metadata"_sv);
   EXPECT_EQ(ArrowSchemaToStdString(&schema),
             "arrow.test.ext_name{dictionary(int32)<string>}");
 
@@ -1639,7 +1631,7 @@ TEST(MetadataTest, MetadataBuild) {
   struct ArrowStringView value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "value2");
+  EXPECT_EQ(value, "value2"_sv);
 
   // Set an existing key
   ASSERT_EQ(ArrowMetadataBuilderSet(&metadata_builder, "key"_sv, "value3"_sv),
@@ -1647,11 +1639,11 @@ TEST(MetadataTest, MetadataBuild) {
   value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key"_sv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "value3");
+  EXPECT_EQ(value, "value3"_sv);
   value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "value2");
+  EXPECT_EQ(value, "value2"_sv);
 
   // Remove a key that does exist
   ASSERT_EQ(ArrowMetadataBuilderRemove(&metadata_builder, "key"_sv), NANOARROW_OK);
@@ -1659,7 +1651,7 @@ TEST(MetadataTest, MetadataBuild) {
   value = ArrowCharView(nullptr);
   ASSERT_EQ(ArrowMetadataGetValue((const char*)metadata_builder.data, "key2"_sv, &value),
             NANOARROW_OK);
-  EXPECT_EQ(std::string(value.data, value.size_bytes), "value2");
+  EXPECT_EQ(value, "value2"_sv);
 
   ArrowBufferReset(&metadata_builder);
 }

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -286,6 +286,8 @@ TEST(DecimalTest, Decimal128Test) {
 }
 
 TEST(DecimalTest, DecimalNegateTest) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDecimal decimal;
   struct ArrowBuffer buffer;
   ArrowBufferInit(&buffer);
@@ -341,6 +343,8 @@ TEST(DecimalTest, DecimalNegateTest) {
 }
 
 TEST(DecimalTest, Decimal256Test) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDecimal decimal;
   ArrowDecimalInit(&decimal, 256, 10, 3);
 
@@ -378,6 +382,8 @@ TEST(DecimalTest, Decimal256Test) {
 }
 
 TEST(DecimalTest, DecimalStringTestBasic) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDecimal decimal;
   ArrowDecimalInit(&decimal, 128, 39, 0);
 
@@ -455,6 +461,8 @@ TEST(DecimalTest, DecimalStringTestBasic) {
 }
 
 TEST(DecimalTest, DecimalStringTestInvalid) {
+  using namespace nanoarrow::literals;
+
   struct ArrowDecimal decimal;
   ArrowDecimalInit(&decimal, 128, 39, 0);
   EXPECT_EQ(ArrowDecimalSetDigits(&decimal, "this is not an integer"_sv), EINVAL);

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -315,7 +315,7 @@ TEST(DecimalTest, DecimalNegateTest) {
 
     // Check with a large value that fits in the 128 bit size
     ASSERT_EQ(
-        ArrowDecimalSetDigits(&decimal, "123456789012345678901234567890123456789"_sv),
+        ArrowDecimalSetDigits(&decimal, "123456789012345678901234567890123456789"_asv),
         NANOARROW_OK);
     ArrowDecimalNegate(&decimal);
 
@@ -391,7 +391,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
   ArrowBufferInit(&buffer);
 
   // Only spans one 32-bit word
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "123456"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "123456"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), 123456);
 
   // Check roundtrip to string
@@ -401,7 +401,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "123456");
 
   // Negative value
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "-123456"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "-123456"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), -123456);
 
   // Check roundtrip to string
@@ -411,7 +411,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "-123456");
 
   // Spans >1 32-bit word
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "1234567899"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "1234567899"_asv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), 1234567899L);
 
   // Check roundtrip to string
@@ -421,7 +421,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "1234567899");
 
   // Check maximum value of a 64-bit integer
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "18446744073709551615"_sv), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "18446744073709551615"_asv), NANOARROW_OK);
   EXPECT_EQ(decimal.words[decimal.low_word_index], std::numeric_limits<uint64_t>::max());
   EXPECT_EQ(decimal.words[decimal.high_word_index], 0);
 
@@ -432,8 +432,9 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "18446744073709551615");
 
   // Check with the maximum value of a signed 128-bit integer
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "170141183460469231731687303715884105727"_sv),
-            NANOARROW_OK);
+  ASSERT_EQ(
+      ArrowDecimalSetDigits(&decimal, "170141183460469231731687303715884105727"_asv),
+      NANOARROW_OK);
   EXPECT_EQ(decimal.words[decimal.low_word_index], std::numeric_limits<uint64_t>::max());
   EXPECT_EQ(decimal.words[decimal.high_word_index], std::numeric_limits<int64_t>::max());
 
@@ -465,7 +466,7 @@ TEST(DecimalTest, DecimalStringTestInvalid) {
 
   struct ArrowDecimal decimal;
   ArrowDecimalInit(&decimal, 128, 39, 0);
-  EXPECT_EQ(ArrowDecimalSetDigits(&decimal, "this is not an integer"_sv), EINVAL);
+  EXPECT_EQ(ArrowDecimalSetDigits(&decimal, "this is not an integer"_asv), EINVAL);
 }
 
 TEST(DecimalTest, DecimalRoundtripPowerOfTenTest) {

--- a/src/nanoarrow/utils_test.cc
+++ b/src/nanoarrow/utils_test.cc
@@ -312,9 +312,9 @@ TEST(DecimalTest, DecimalNegateTest) {
               std::numeric_limits<uint64_t>::max());
 
     // Check with a large value that fits in the 128 bit size
-    ASSERT_EQ(ArrowDecimalSetDigits(
-                  &decimal, ArrowCharView("123456789012345678901234567890123456789")),
-              NANOARROW_OK);
+    ASSERT_EQ(
+        ArrowDecimalSetDigits(&decimal, "123456789012345678901234567890123456789"_sv),
+        NANOARROW_OK);
     ArrowDecimalNegate(&decimal);
 
     buffer.size_bytes = 0;
@@ -385,7 +385,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
   ArrowBufferInit(&buffer);
 
   // Only spans one 32-bit word
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, ArrowCharView("123456")), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "123456"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), 123456);
 
   // Check roundtrip to string
@@ -395,7 +395,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "123456");
 
   // Negative value
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, ArrowCharView("-123456")), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "-123456"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), -123456);
 
   // Check roundtrip to string
@@ -405,7 +405,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "-123456");
 
   // Spans >1 32-bit word
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, ArrowCharView("1234567899")), NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "1234567899"_sv), NANOARROW_OK);
   EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), 1234567899L);
 
   // Check roundtrip to string
@@ -415,8 +415,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "1234567899");
 
   // Check maximum value of a 64-bit integer
-  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, ArrowCharView("18446744073709551615")),
-            NANOARROW_OK);
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "18446744073709551615"_sv), NANOARROW_OK);
   EXPECT_EQ(decimal.words[decimal.low_word_index], std::numeric_limits<uint64_t>::max());
   EXPECT_EQ(decimal.words[decimal.high_word_index], 0);
 
@@ -427,8 +426,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
             "18446744073709551615");
 
   // Check with the maximum value of a signed 128-bit integer
-  ASSERT_EQ(ArrowDecimalSetDigits(
-                &decimal, ArrowCharView("170141183460469231731687303715884105727")),
+  ASSERT_EQ(ArrowDecimalSetDigits(&decimal, "170141183460469231731687303715884105727"_sv),
             NANOARROW_OK);
   EXPECT_EQ(decimal.words[decimal.low_word_index], std::numeric_limits<uint64_t>::max());
   EXPECT_EQ(decimal.words[decimal.high_word_index], std::numeric_limits<int64_t>::max());
@@ -459,8 +457,7 @@ TEST(DecimalTest, DecimalStringTestBasic) {
 TEST(DecimalTest, DecimalStringTestInvalid) {
   struct ArrowDecimal decimal;
   ArrowDecimalInit(&decimal, 128, 39, 0);
-  EXPECT_EQ(ArrowDecimalSetDigits(&decimal, ArrowCharView("this is not an integer")),
-            EINVAL);
+  EXPECT_EQ(ArrowDecimalSetDigits(&decimal, "this is not an integer"_sv), EINVAL);
 }
 
 TEST(DecimalTest, DecimalRoundtripPowerOfTenTest) {


### PR DESCRIPTION
In https://github.com/apache/arrow-nanoarrow/pull/404, the `_v` literal was added, making it much more compact to define an `ArrowStringView` and compare its equality to something else.

This PR refactors tests that used `EXPECT/ASSERT_EQ()` to be more compact, and replaces `ArrowCharView()` with the string literal.

From reading https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv and https://json.nlohmann.me/api/macros/json_use_global_udls/#notes it seems like constraining the user-defined literal to a namespace is the "modern" way to do this...I am not sure that `"_sv"` is the best choice (maybe too close to `"sv"`?), but it did seem more descriptive than `"_v` for those reading the tests without knowing that these literals are defined.