### PR TITLE
fix: Fix Meson include directories

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Meson example
         run: |
-          python3 -m pip install meson ninja-build
+          python3 -m pip install meson ninja
           cd examples/meson-minimal
           meson setup builddir
           meson compile -C builddir

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Meson example
         run: |
+          python3 -m pip install meson
           cd examples/meson-minimal
           meson setup builddir
           meson compile -C builddir

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Meson example
         run: |
-          python3 -m pip install meson
+          python3 -m pip install meson ninja-build
           cd examples/meson-minimal
           meson setup builddir
           meson compile -C builddir

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -111,3 +111,11 @@ jobs:
             ./${dir}/minimal_cpp_app;
             echo ;
           done
+
+      - name: Meson example
+        run: |
+          cd examples/meson-minimal
+          meson setup builddir
+          meson compile -C builddir
+
+          ./builddir/example_meson_minimal_app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,8 +222,8 @@ if(NANOARROW_IPC)
   target_link_libraries(nanoarrow_ipc PRIVATE flatccrt)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
                                     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+                                    $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
                                     $<INSTALL_INTERFACE:include>)
 
   install(TARGETS nanoarrow_ipc DESTINATION lib)
@@ -285,8 +285,8 @@ if(NANOARROW_DEVICE)
 
   target_include_directories(nanoarrow_device
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${NANOARROW_DEVICE_INCLUDE_METAL}>
                                     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+                                    $<BUILD_INTERFACE:${NANOARROW_DEVICE_INCLUDE_METAL}>
                                     $<INSTALL_INTERFACE:include>)
 
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
               src/nanoarrow/integration/c_data_integration.cc)
   target_include_directories(nanoarrow_c_data_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
   target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow nlohmann_json)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ if(NANOARROW_IPC)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
+                                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
 
   install(TARGETS nanoarrow_ipc DESTINATION lib)
@@ -285,6 +286,7 @@ if(NANOARROW_DEVICE)
   target_include_directories(nanoarrow_device
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${NANOARROW_DEVICE_INCLUDE_METAL}>
+                                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
 
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if(NANOARROW_BUNDLE)
   set(NANOARROW_FLATCC_BUILD_SOURCES "${CMAKE_BINARY_DIR}/bundled/src/flatcc.c")
 else()
   # Generate the version information
-  configure_file(src/nanoarrow/nanoarrow_config.h.in generated/nanoarrow_config.h)
+  configure_file(src/nanoarrow/nanoarrow_config.h.in src/nanoarrow/nanoarrow_config.h)
   set(NANOARROW_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 endif()
 
@@ -129,7 +129,7 @@ if(NOT NANOARROW_BUNDLE)
        src/nanoarrow/array_inline.h
        src/nanoarrow/buffer_inline.h
        src/nanoarrow/nanoarrow_types.h
-       "${CMAKE_CURRENT_BINARY_DIR}/generated/nanoarrow_config.h")
+       "${CMAKE_CURRENT_BINARY_DIR}/src/nanoarrow/nanoarrow_config.h")
 endif()
 
 # Add the nanoarrow library target
@@ -138,7 +138,7 @@ add_library(nanoarrow::nanoarrow ALIAS nanoarrow)
 
 target_include_directories(nanoarrow
                            PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
+                                  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                   $<INSTALL_INTERFACE:include>)
 target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
@@ -222,7 +222,6 @@ if(NANOARROW_IPC)
   target_link_libraries(nanoarrow_ipc PRIVATE flatccrt)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
                                     $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
                                     $<INSTALL_INTERFACE:include>)
 
@@ -285,7 +284,6 @@ if(NANOARROW_DEVICE)
 
   target_include_directories(nanoarrow_device
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
                                     $<BUILD_INTERFACE:${NANOARROW_DEVICE_INCLUDE_METAL}>
                                     $<INSTALL_INTERFACE:include>)
 
@@ -308,7 +306,6 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
               src/nanoarrow/integration/c_data_integration.cc)
   target_include_directories(nanoarrow_c_data_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
                                     $<INSTALL_INTERFACE:include>)
   target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow nlohmann_json)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ add_library(nanoarrow::nanoarrow ALIAS nanoarrow)
 
 target_include_directories(nanoarrow
                            PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+                                  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                   $<INSTALL_INTERFACE:include>)
 target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
@@ -222,7 +222,7 @@ if(NANOARROW_IPC)
   target_link_libraries(nanoarrow_ipc PRIVATE flatccrt)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
                                     $<INSTALL_INTERFACE:include>)
 
@@ -285,7 +285,7 @@ if(NANOARROW_DEVICE)
 
   target_include_directories(nanoarrow_device
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
-                                    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<BUILD_INTERFACE:${NANOARROW_DEVICE_INCLUDE_METAL}>
                                     $<INSTALL_INTERFACE:include>)
 

--- a/ci/scripts/bundle.py
+++ b/ci/scripts/bundle.py
@@ -122,7 +122,7 @@ def bundle_nanoarrow(
         ]
     )
 
-    nanoarrow_h = re.sub(r'#include "[a-z_.]+"', "", nanoarrow_h)
+    nanoarrow_h = re.sub(r'#include "(nanoarrow/)?[a-z_.]+"', "", nanoarrow_h)
     yield f"{output_include_dir}/nanoarrow.h", nanoarrow_h
 
     # Generate files that don't need special handling

--- a/meson.build
+++ b/meson.build
@@ -62,17 +62,18 @@ else
     libtype = 'library'
 endif
 
+incdir = include_directories('src/')
+
 nanoarrow_lib = build_target(
     'nanoarrow',
     'src/nanoarrow/array.c',
     'src/nanoarrow/schema.c',
     'src/nanoarrow/array_stream.c',
     'src/nanoarrow/utils.c',
+    include_directories: [incdir],
     install: true,
     target_type: libtype,
 )
-
-incdir = include_directories('src/')
 
 nanoarrow_dep = declare_dependency(include_directories: [incdir],
                                    link_with: nanoarrow_lib)

--- a/meson.build
+++ b/meson.build
@@ -29,30 +29,6 @@ project(
     ]
 )
 
-conf_data = configuration_data()
-
-ns = get_option('namespace')
-conf_data.set('NANOARROW_NAMESPACE_DEFINE', '#define NANOARROW_NAMESPACE ' + ns)
-
-version = meson.project_version()
-# Remove any pre-release / build identifiers
-version_no_pre_release = version.split('-')[0]
-version_no_build = version_no_pre_release.split('+')[0]
-components = version_no_build.split('.')
-assert(components.length() >= 3,
-       'The version does not contain major, minor and patch')
-ver_major = components[0]
-ver_minor = components[1]
-ver_patch = components[2]
-conf_data.set('NANOARROW_VERSION', version)
-conf_data.set('NANOARROW_VERSION_MAJOR', ver_major)
-conf_data.set('NANOARROW_VERSION_MINOR', ver_minor)
-conf_data.set('NANOARROW_VERSION_PATCH', ver_patch)
-
-configure_file(input: 'src/nanoarrow/nanoarrow_config.h.in',
-               output: 'nanoarrow_config.h',
-               configuration: conf_data)
-
 # Windows shared libraries are not exporting the right symbols
 # See https://github.com/mesonbuild/wrapdb/pull/1536#issuecomment-2136011408
 # and https://github.com/apache/arrow-nanoarrow/issues/495
@@ -62,6 +38,7 @@ else
     libtype = 'library'
 endif
 
+subdir('src')
 incdir = include_directories('src/')
 
 nanoarrow_lib = build_target(

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ else
     libtype = 'library'
 endif
 
-subdir('src')
+subdir('src/nanoarrow')
 incdir = include_directories('src/')
 
 nanoarrow_lib = build_target(

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+conf_data = configuration_data()
+
+ns = get_option('namespace')
+conf_data.set('NANOARROW_NAMESPACE_DEFINE', '#define NANOARROW_NAMESPACE ' + ns)
+
+version = meson.project_version()
+# Remove any pre-release / build identifiers
+version_no_pre_release = version.split('-')[0]
+version_no_build = version_no_pre_release.split('+')[0]
+components = version_no_build.split('.')
+assert(components.length() >= 3,
+       'The version does not contain major, minor and patch')
+ver_major = components[0]
+ver_minor = components[1]
+ver_patch = components[2]
+conf_data.set('NANOARROW_VERSION', version)
+conf_data.set('NANOARROW_VERSION_MAJOR', ver_major)
+conf_data.set('NANOARROW_VERSION_MINOR', ver_minor)
+conf_data.set('NANOARROW_VERSION_PATCH', ver_patch)
+
+configure_file(input: 'nanoarrow/nanoarrow_config.h.in',
+               output: 'nanoarrow_config.h',
+               configuration: conf_data)

--- a/src/nanoarrow/meson.build
+++ b/src/nanoarrow/meson.build
@@ -35,6 +35,6 @@ conf_data.set('NANOARROW_VERSION_MAJOR', ver_major)
 conf_data.set('NANOARROW_VERSION_MINOR', ver_minor)
 conf_data.set('NANOARROW_VERSION_PATCH', ver_patch)
 
-configure_file(input: 'nanoarrow/nanoarrow_config.h.in',
+configure_file(input: 'nanoarrow_config.h.in',
                output: 'nanoarrow_config.h',
                configuration: conf_data)

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "nanoarrow_config.h"
+#include <nanoarrow/nanoarrow_config.h>
 
 #if defined(NANOARROW_DEBUG) && !defined(NANOARROW_PRINT_AND_DIE)
 #include <stdio.h>

--- a/src/nanoarrow/nanoarrow_types.h
+++ b/src/nanoarrow/nanoarrow_types.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <nanoarrow/nanoarrow_config.h>
+#include "nanoarrow/nanoarrow_config.h"
 
 #if defined(NANOARROW_DEBUG) && !defined(NANOARROW_PRINT_AND_DIE)
 #include <stdio.h>


### PR DESCRIPTION
Quick follow up to https://github.com/apache/arrow-nanoarrow/pull/508 - the array.c includes stopped working without this

```
FAILED: libnanoarrow.so.p/src_nanoarrow_array.c.o 
ccache cc -Ilibnanoarrow.so.p -I. -I.. -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -O0 -g -fPIC -MD -MQ libnanoarrow.so.p/src_nanoarrow_array.c.o -MF libnanoarrow.so.p/src_nanoarrow_array.c.o.d -o libnanoarrow.so.p/src_nanoarrow_array.c.o -c ../src/nanoarrow/array.c
../src/nanoarrow/array.c:23:10: fatal error: nanoarrow/nanoarrow.h: No such file or directory
   23 | #include "nanoarrow/nanoarrow.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
```