### PR TITLE
Fix: CMake deprecation warnings from subprojects

### DIFF
--- a/thirdparty/googletest/CMakeLists.txt
+++ b/thirdparty/googletest/CMakeLists.txt
@@ -21,8 +21,8 @@ include(FetchContent)
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION
                                                VERSION_GREATER_EQUAL "5.0.0")
   fetchcontent_declare(googletest
-                       URL https://github.com/google/googletest/archive/release-1.11.0.zip
-                       URL_HASH SHA256=353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
+                       URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+                       URL_HASH SHA256=8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
   )
 else()
   fetchcontent_declare(googletest

--- a/thirdparty/nlohmann_json/CMakeLists.txt
+++ b/thirdparty/nlohmann_json/CMakeLists.txt
@@ -18,7 +18,7 @@
 include(FetchContent)
 
 fetchcontent_declare(nlohmann_json
-                     URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip
-                     URL_HASH SHA256=95651d7d1fcf2e5c3163c3d37df6d6b3e9e5027299e6bd050d157322ceda9ac9
+                     URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
+                     URL_HASH SHA256=04022b05d806eb5ff73023c280b68697d12b93e1b7267a0b22a1a39ec7578069
 )
 fetchcontent_makeavailable(nlohmann_json)


### PR DESCRIPTION
closes https://github.com/apache/arrow-nanoarrow/issues/309
