### PR TITLE
chore(ci): Run clang-tidy and ensure nanoarrow passes checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+# Disable valist, it's buggy: https://github.com/llvm/llvm-project/issues/40656
+Checks: '-clang-analyzer-valist.Uninitialized'
+FormatStyle: google
+UseColor: true

--- a/src/nanoarrow/array.c
+++ b/src/nanoarrow/array.c
@@ -764,8 +764,7 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
   // is always data dependent for all current Arrow types.
   for (int i = 0; i < 2; i++) {
     int64_t element_size_bytes = array_view->layout.element_size_bits[i] / 8;
-    // Initialize with a value that will cause an error if accidentally used uninitialized
-    int64_t min_buffer_size_bytes = array_view->buffer_views[i].size_bytes + 1;
+    int64_t min_buffer_size_bytes;
 
     switch (array_view->layout.buffer_type[i]) {
       case NANOARROW_BUFFER_TYPE_VALIDITY:

--- a/src/nanoarrow/schema.c
+++ b/src/nanoarrow/schema.c
@@ -1322,7 +1322,7 @@ static inline void ArrowToStringLogChars(char** out, int64_t n_chars_last,
   // In the unlikely snprintf() returning a negative value (encoding error),
   // ensure the result won't cause an out-of-bounds access.
   if (n_chars_last < 0) {
-    n_chars = 0;
+    n_chars_last = 0;
   }
 
   *n_chars += n_chars_last;


### PR DESCRIPTION
Closes #537.