### PR TITLE
chore(ci): Fix wheel building workflow and add pyodide wheels

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - {os: "ubuntu-20.04", label: "pyiodide", platform: "pyiodide"}
+          - {os: "ubuntu-20.04", label: "pyodide", platform: "pyodide"}
           - {os: "ubuntu-20.04", label: "linux", platform: "auto"}
           - {os: "windows-2019", label: "windows", platform: "auto"}
           - {os: "macOS-13", label: "macOS", platform: "auto"}

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -33,6 +33,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_sdist:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -85,9 +85,11 @@ jobs:
     strategy:
       matrix:
         config:
+          - {os: "ubuntu-20.04", label: "linux", platform: "pyiodide"}
           - {os: "ubuntu-20.04", label: "linux"}
           - {os: "windows-2019", label: "windows"}
-          - {os: "macOS-11", label: "macOS"}
+          - {os: "macOS-13", label: "macOS"}
+          - {os: "macOS-14", label: "macOS-arm64"}
           - {os: ["self-hosted", "arm"], label: "linux-arm64"}
 
     steps:
@@ -102,7 +104,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
+        run: python -m pip install cibuildwheel==2.19.1
 
       - name: Set nanoarrow Python dev version
         if: github.ref == 'refs/heads/main'
@@ -116,6 +118,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
+          CIBW_PLATFORM: ${{ matrox.config.platform }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -121,7 +121,7 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
-          CIBW_PLATFORM: ${{ matrox.config.platform }}
+          CIBW_PLATFORM: ${{ matrix.config.platform }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -118,7 +118,6 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse python
         env:
-          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           CIBW_PLATFORM: ${{ matrix.config.platform }}

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Build Python Wheels
+name: python-wheels
 
 # Build wheels on commit to main, or when requested
 on:
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 jobs:
-  build_sdist:
+  sdist:
     runs-on: "ubuntu-20.04"
     steps:
     - uses: actions/checkout@v4
@@ -81,9 +81,9 @@ jobs:
         name: release-sdist
         path: ./python/dist/nanoarrow-*.tar.gz
 
-  build_wheels:
-    needs: ["build_sdist"]
-    name: Build wheels on ${{ matrix.config.label }}
+  wheels:
+    needs: ["sdist"]
+    name: ${{ matrix.config.label }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -36,6 +36,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   sdist:
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: matrix.config.label != 'linux-arm64'
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.19.1

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -88,12 +88,12 @@ jobs:
     strategy:
       matrix:
         config:
-          - {os: "ubuntu-20.04", label: "linux", platform: "pyiodide"}
-          - {os: "ubuntu-20.04", label: "linux"}
-          - {os: "windows-2019", label: "windows"}
-          - {os: "macOS-13", label: "macOS"}
-          - {os: "macOS-14", label: "macOS-arm64"}
-          - {os: ["self-hosted", "arm"], label: "linux-arm64"}
+          - {os: "ubuntu-20.04", label: "pyiodide", platform: "pyiodide"}
+          - {os: "ubuntu-20.04", label: "linux", platform: "auto"}
+          - {os: "windows-2019", label: "windows", platform: "auto"}
+          - {os: "macOS-13", label: "macOS", platform: "auto"}
+          - {os: "macOS-14", label: "macOS-arm64", platform: "auto"}
+          - {os: ["self-hosted", "arm"], label: "linux-arm64", platform: "auto"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -130,7 +130,7 @@ jobs:
 
 
   upload_nightly:
-    needs: ["build_sdist", "build_wheels"]
+    needs: ["sdist", "wheels"]
     name: Upload nightly packages
     runs-on: "ubuntu-20.04"
     if: github.repository == 'apache/arrow-nanoarrow' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
We had been building wheels on macOS-11, but that runner will be disabled at the end of the week. The updated documentation for cibuildwheel suggests using macOS-13 and macOS-14 (for x86 and arm, respectively), and the updated cibuildwheel version supports building for pyodide!