### PR TITLE
fix(ci): Fix verification workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -134,8 +134,9 @@ jobs:
               platform: "centos7",
               arch: "amd64",
               # Currently the Python on the centos7 image is 3.6, which does not support
-              # new enough setuptools to build the Python package.
-              compose_args: "-e NANOARROW_ACCEPT_IMPORT_GPG_KEYS_ERROR=1 -e TEST_PYTHON=0"
+              # new enough setuptools to build the Python package. Our test dependencies
+              # no longer support centos7 for R, either.
+              compose_args: "-e NANOARROW_ACCEPT_IMPORT_GPG_KEYS_ERROR=1 -e TEST_PYTHON=0 -e TEST_R=0"
             }
           - {
               platform: "ubuntu",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,7 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
   set_target_properties(nanoarrow PROPERTIES POSITION_INDEPENDENT_CODE ON)
   add_library(nanoarrow_c_data_integration SHARED
               src/nanoarrow/integration/c_data_integration.cc)
+  target_compile_definitions(nanoarrow_c_data_integration PRIVATE NANOARROW_BUILD_DLL)
   target_include_directories(nanoarrow_c_data_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,8 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
   set_target_properties(nanoarrow PROPERTIES POSITION_INDEPENDENT_CODE ON)
   add_library(nanoarrow_c_data_integration SHARED
               src/nanoarrow/integration/c_data_integration.cc)
-  target_compile_definitions(nanoarrow_c_data_integration PRIVATE NANOARROW_BUILD_DLL)
+  target_compile_definitions(nanoarrow_c_data_integration PRIVATE NANOARROW_BUILD_DLL
+                                                                  NANOARROW_EXPORT_DLL)
   target_include_directories(nanoarrow_c_data_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -57,3 +57,10 @@
    fun:malloc
    fun:_PyObject_GC_NewVar
 }
+
+{
+   <jsonlite>:Leak in base64_encode
+   Memcheck:Leak
+   fun:base64_encode
+   fun:R_base64_encode
+}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -58,9 +58,11 @@
    fun:_PyObject_GC_NewVar
 }
 
+# Can be removed when https://github.com/jeroen/jsonlite/pull/442 is released
 {
    <jsonlite>:Leak in base64_encode
    Memcheck:Leak
+   ...
    fun:base64_encode
    fun:R_base64_encode
 }


### PR DESCRIPTION
There are a few problems in the verification workflow:

- On Windows, we weren't exporting any symbols in the C data integration test (when building with CMake)
- The R package testthat doesn't seem to support centos7, which we would need to test the R package there
- The R package jsonlite seems to leak memory. One fix is https://github.com/jeroen/jsonlite/pull/442 , but in the meantime we can ignore the leak since it doesn't come from us.