### PR TITLE
feat: add ipc RecordBatch encoding

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -58,6 +58,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+          install-quarto: false
 
       # Check package install with extra warning flags except on Windows,
       # where the R headers cause some problems

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -58,7 +58,6 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          install-quarto: 'false'
 
       # Check package install with extra warning flags except on Windows,
       # where the R headers cause some problems

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -58,7 +58,7 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          install-quarto: false
+          install-quarto: 'false'
 
       # Check package install with extra warning flags except on Windows,
       # where the R headers cause some problems

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,7 @@ if(NANOARROW_BUILD_TESTS)
 
     target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB
                           nanoarrow_coverage_config)
+    target_link_libraries(nanoarrow_ipc_decoder_test gmock_main)
   endif()
 
   if(NANOARROW_DEVICE)

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1657,9 +1657,16 @@ static ArrowErrorCode ArrowIpcDecoderDecodeArrayViewInternal(
     return EINVAL;
   }
 
+  // RecordBatch messages don't count the root node but decoder->fields does
+  // (decoder->fields[0] is the root field)
+  if (field_i + 1 >= private_data->n_fields) {
+    ArrowErrorSet(error, "cannot decode column %" PRId64 "; there are only %" PRId64,
+                  field_i, private_data->n_fields - 1);
+    return EINVAL;
+  }
+
   ns(RecordBatch_table_t) batch = (ns(RecordBatch_table_t))private_data->last_message;
 
-  // RecordBatch messages don't count the root node but decoder->fields does
   struct ArrowIpcField* root = private_data->fields + field_i + 1;
 
   struct ArrowIpcArraySetter setter;

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -96,7 +96,6 @@ ArrowErrorCode ArrowIpcEncoderFinalizeBuffer(struct ArrowIpcEncoder* encoder,
     return encapsulate ? ArrowBufferAppend(out, &header, sizeof(header)) : NANOARROW_OK;
   }
 
-  int64_t i = out->size_bytes;
   if (encapsulate) {
     int64_t encapsulated_size =
         _ArrowRoundUpToMultipleOf8(sizeof(int32_t) + sizeof(int32_t) + size);
@@ -284,7 +283,7 @@ static ArrowErrorCode ArrowIpcEncodeFieldType(flatcc_builder_t* builder,
           int32_t* type_ids_32 = (int32_t*)ns(Union_typeIds_extend(builder, n));
           FLATCC_RETURN_IF_NULL(type_ids_32);
 
-          for (int i = 0; i < n; ++i) {
+          for (int i = 0; i < n; i++) {
             type_ids_32[i] = type_ids[i];
           }
           FLATCC_RETURN_UNLESS_0(Union_typeIds_end(builder));
@@ -343,7 +342,7 @@ static ArrowErrorCode ArrowIpcEncodeFields(flatcc_builder_t* builder,
                                            ns(Field_ref_t) *
                                                (*push_end)(flatcc_builder_t*),
                                            struct ArrowError* error) {
-  for (int i = 0; i < schema->n_children; ++i) {
+  for (int i = 0; i < schema->n_children; i++) {
     FLATCC_RETURN_UNLESS_0_NO_NS(push_start(builder));
     NANOARROW_RETURN_NOT_OK(ArrowIpcEncodeField(builder, schema->children[i], error));
     FLATCC_RETURN_IF_NULL(push_end(builder));

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -85,7 +85,7 @@ ArrowErrorCode ArrowIpcEncoderFinalizeBuffer(struct ArrowIpcEncoder* encoder,
       (struct ArrowIpcEncoderPrivate*)encoder->private_data;
 
   size_t size = flatcc_builder_get_buffer_size(&private->builder);
-  _NANOARROW_CHECK_RANGE(size, 0, INT32_MAX);
+  _NANOARROW_CHECK_UPPER_LIMIT(size, INT32_MAX);
 
   int32_t header[] = {-1, (int32_t)size};
   if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_BIG) {
@@ -109,6 +109,7 @@ ArrowErrorCode ArrowIpcEncoderFinalizeBuffer(struct ArrowIpcEncoder* encoder,
   void* data =
       flatcc_builder_copy_buffer(&private->builder, out->data + out->size_bytes, size);
   NANOARROW_DCHECK(data != NULL);
+  NANOARROW_UNUSED(data);
   out->size_bytes += size;
 
   if (encapsulate) {

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -76,10 +76,11 @@ ArrowErrorCode ArrowIpcEncoderFinalizeBuffer(struct ArrowIpcEncoder* encoder,
   struct ArrowIpcEncoderPrivate* private =
       (struct ArrowIpcEncoderPrivate*)encoder->private_data;
 
-  int64_t size = (int64_t)flatcc_builder_get_buffer_size(&private->builder);
-  int32_t header[] = {-1, ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_BIG
-                              ? bswap32((int32_t)size)
-                              : (int32_t)size};
+  int32_t size = (int32_t)flatcc_builder_get_buffer_size(&private->builder);
+  int32_t header[] = {-1, size};
+  if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_BIG) {
+    header[1] = (int32_t)bswap32((uint32_t)size);
+  }
 
   if (size == 0) {
     // Finalizing an empty flatcc_builder_t triggers an assertion

--- a/src/nanoarrow/ipc/encoder_test.cc
+++ b/src/nanoarrow/ipc/encoder_test.cc
@@ -36,9 +36,6 @@ TEST(NanoarrowIpcTest, NanoarrowIpcEncoderConstruction) {
   EXPECT_EQ(ArrowIpcEncoderInit(encoder.get()), NANOARROW_OK);
 
   EXPECT_EQ(encoder->codec, NANOARROW_IPC_COMPRESSION_TYPE_NONE);
-  EXPECT_EQ(encoder->body_length, 0);
-  EXPECT_EQ(encoder->encode_buffer, nullptr);
-  EXPECT_EQ(encoder->encode_buffer_state, nullptr);
 
   auto* p = static_cast<struct ArrowIpcEncoderPrivate*>(encoder->private_data);
   ASSERT_NE(p, nullptr);

--- a/src/nanoarrow/ipc/encoder_test.cc
+++ b/src/nanoarrow/ipc/encoder_test.cc
@@ -35,8 +35,6 @@ TEST(NanoarrowIpcTest, NanoarrowIpcEncoderConstruction) {
 
   EXPECT_EQ(ArrowIpcEncoderInit(encoder.get()), NANOARROW_OK);
 
-  EXPECT_EQ(encoder->codec, NANOARROW_IPC_COMPRESSION_TYPE_NONE);
-
   auto* p = static_cast<struct ArrowIpcEncoderPrivate*>(encoder->private_data);
   ASSERT_NE(p, nullptr);
   for (auto* b : {&p->buffers, &p->nodes}) {

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -413,9 +413,6 @@ ArrowErrorCode ArrowIpcArrayStreamReaderInit(
 /// initialized using ArrowIpcEncoderInit(), and released with
 /// ArrowIpcEncoderReset().
 struct ArrowIpcEncoder {
-  /// \brief Compression to encode in the next RecordBatch message.
-  enum ArrowIpcCompressionType codec;
-
   /// \brief Private resources managed by this library
   void* private_data;
 };

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -63,6 +63,10 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcEncoderFinalizeBuffer)
 #define ArrowIpcEncoderEncodeSchema \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcEncoderEncodeSchema)
+#define ArrowIpcEncoderBuildContiguousBodyBuffer \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcEncoderBuildContiguousBodyBuffer)
+#define ArrowIpcEncoderEncodeRecordBatch \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcEncoderEncodeRecordBatch)
 #define ArrowIpcOutputStreamInitBuffer \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcOutputStreamInitBuffer)
 #define ArrowIpcOutputStreamInitFile \
@@ -214,7 +218,7 @@ void ArrowIpcDecoderReset(struct ArrowIpcDecoder* decoder);
 
 /// \brief Peek at a message header
 ///
-/// The first 8 bytes of an Arrow IPC message are 0xFFFFFF followed by the size
+/// The first 8 bytes of an Arrow IPC message are 0xFFFFFFFF followed by the size
 /// of the header as a little-endian 32-bit integer. ArrowIpcDecoderPeekHeader() reads
 /// these bytes and returns ESPIPE if there are not enough remaining bytes in data to read
 /// the entire header message, EINVAL if the first 8 bytes are not valid, ENODATA if the
@@ -461,6 +465,21 @@ ArrowErrorCode ArrowIpcEncoderFinalizeBuffer(struct ArrowIpcEncoder* encoder,
 ArrowErrorCode ArrowIpcEncoderEncodeSchema(struct ArrowIpcEncoder* encoder,
                                            const struct ArrowSchema* schema,
                                            struct ArrowError* error);
+/// \brief Set the encoder to concatenate encoded buffers into body_buffer
+///
+/// encoder->encode_buffer_state will point to the provided ArrowBuffer.
+/// The contiguous body buffer will be appended to this during
+/// ArrowIpcEncoderEncodeRecordBatch.
+void ArrowIpcEncoderBuildContiguousBodyBuffer(struct ArrowIpcEncoder* encoder,
+                                              struct ArrowBuffer* body_buffer);
+
+/// \brief Encode a struct typed ArrayView to a flatbuffer RecordBatch, embedded in a
+/// Message.
+///
+/// Returns ENOMEM if allocation fails, NANOARROW_OK otherwise.
+ArrowErrorCode ArrowIpcEncoderEncodeRecordBatch(struct ArrowIpcEncoder* encoder,
+                                                const struct ArrowArrayView* array_view,
+                                                struct ArrowError* error);
 
 /// \brief An user-extensible output data sink
 struct ArrowIpcOutputStream {


### PR DESCRIPTION
- added `ArrowIpcEncoderEncodeRecordBatch()`
- added `ArrowIpcEncoderBuildContiguousBodyBuffer()` to provide a default buffer encoder implementation which simply concatenates a batch's buffers into one contiguous (properly aligned and padded) body buffer
- testing uses the decoder tests, replacing arrow C++'s encoder with the new nanoarrow encoder
