### PR TITLE
add ArrowArrayViewComputeNullCount

### DIFF
--- a/python/src/nanoarrow/_lib.pyx
+++ b/python/src/nanoarrow/_lib.pyx
@@ -365,10 +365,7 @@ cdef class CArrayView:
         elif validity_bits == NULL:
             self._ptr.null_count = 0
         elif self._device is DEVICE_CPU:
-            self._ptr.null_count = (
-                self._ptr.length -
-                ArrowBitCountSet(validity_bits, self.offset, self.length)
-            )
+            self._ptr.null_count = ArrowArrayViewComputeNullCount(self._ptr)
 
         return self._ptr.null_count
 

--- a/r/src/materialize_unspecified.h
+++ b/r/src/materialize_unspecified.h
@@ -35,19 +35,18 @@ static inline int nanoarrow_materialize_unspecified(struct ArrayViewSlice* src,
 
   if (ArrowArrayViewComputeNullCount(src->array_view) == 0) {
     // We can blindly set all the values to NA_LOGICAL without checking
-    for (int64_t i = 0; i < length; i++) {
+    for (int64_t i = 0; i < src->length; i++) {
       result[dst->offset + i] = NA_LOGICAL;
     }
     return NANOARROW_OK;
   }
 
   int64_t total_offset = src->array_view->array->offset + src->offset;
-  int64_t length = src->length;
   const uint8_t* bits = src->array_view->buffer_views[0].data.as_uint8;
 
   // Count non-null values and warn
   int64_t n_bad_values = 0;
-  for (int64_t i = 0; i < length; i++) {
+  for (int64_t i = 0; i < src->length; i++) {
     n_bad_values += ArrowBitGet(bits, total_offset + i);
     result[dst->offset + i] = NA_LOGICAL;
   }

--- a/r/src/materialize_unspecified.h
+++ b/r/src/materialize_unspecified.h
@@ -33,7 +33,7 @@ static inline int nanoarrow_materialize_unspecified(struct ArrayViewSlice* src,
 
   int* result = LOGICAL(dst->vec_sexp);
 
-  if (ArrowArrayViewComputeNullCount(src->array_view) == 0) {
+  if (ArrowArrayViewComputeNullCount(src->array_view) == src->length) {
     // We can blindly set all the values to NA_LOGICAL without checking
     for (int64_t i = 0; i < src->length; i++) {
       result[dst->offset + i] = NA_LOGICAL;

--- a/r/src/materialize_unspecified.h
+++ b/r/src/materialize_unspecified.h
@@ -33,26 +33,27 @@ static inline int nanoarrow_materialize_unspecified(struct ArrayViewSlice* src,
 
   int* result = LOGICAL(dst->vec_sexp);
 
-  if (ArrowArrayViewComputeNullCount(src->array_view) == src->length) {
-    // We can blindly set all the values to NA_LOGICAL without checking
-    for (int64_t i = 0; i < src->length; i++) {
-      result[dst->offset + i] = NA_LOGICAL;
-    }
-    return NANOARROW_OK;
-  }
-
   int64_t total_offset = src->array_view->array->offset + src->offset;
+  int64_t length = src->length;
   const uint8_t* bits = src->array_view->buffer_views[0].data.as_uint8;
 
-  // Count non-null values and warn
-  int64_t n_bad_values = 0;
-  for (int64_t i = 0; i < src->length; i++) {
-    n_bad_values += ArrowBitGet(bits, total_offset + i);
-    result[dst->offset + i] = NA_LOGICAL;
-  }
+  if (length == 0 || src->array_view->storage_type == NANOARROW_TYPE_NA ||
+      ArrowBitCountSet(bits, total_offset, length) == 0) {
+    // We can blindly set all the values to NA_LOGICAL without checking
+    for (int64_t i = 0; i < length; i++) {
+      result[dst->offset + i] = NA_LOGICAL;
+    }
+  } else {
+    // Count non-null values and warn
+    int64_t n_bad_values = 0;
+    for (int64_t i = 0; i < length; i++) {
+      n_bad_values += ArrowBitGet(bits, total_offset + i);
+      result[dst->offset + i] = NA_LOGICAL;
+    }
 
-  if (n_bad_values > 0) {
-    warn_lossy_conversion(n_bad_values, "that were non-null set to NA");
+    if (n_bad_values > 0) {
+      warn_lossy_conversion(n_bad_values, "that were non-null set to NA");
+    }
   }
 
   return NANOARROW_OK;

--- a/r/src/materialize_unspecified.h
+++ b/r/src/materialize_unspecified.h
@@ -33,27 +33,27 @@ static inline int nanoarrow_materialize_unspecified(struct ArrayViewSlice* src,
 
   int* result = LOGICAL(dst->vec_sexp);
 
-  int64_t total_offset = src->array_view->array->offset + src->offset;
-  int64_t length = src->length;
-  const uint8_t* bits = src->array_view->buffer_views[0].data.as_uint8;
-
-  if (length == 0 || src->array_view->storage_type == NANOARROW_TYPE_NA ||
-      ArrowBitCountSet(bits, total_offset, length) == 0) {
+  if (ArrowArrayViewComputeNullCount(src->array_view) == 0) {
     // We can blindly set all the values to NA_LOGICAL without checking
     for (int64_t i = 0; i < length; i++) {
       result[dst->offset + i] = NA_LOGICAL;
     }
-  } else {
-    // Count non-null values and warn
-    int64_t n_bad_values = 0;
-    for (int64_t i = 0; i < length; i++) {
-      n_bad_values += ArrowBitGet(bits, total_offset + i);
-      result[dst->offset + i] = NA_LOGICAL;
-    }
+    return NANOARROW_OK;
+  }
 
-    if (n_bad_values > 0) {
-      warn_lossy_conversion(n_bad_values, "that were non-null set to NA");
-    }
+  int64_t total_offset = src->array_view->array->offset + src->offset;
+  int64_t length = src->length;
+  const uint8_t* bits = src->array_view->buffer_views[0].data.as_uint8;
+
+  // Count non-null values and warn
+  int64_t n_bad_values = 0;
+  for (int64_t i = 0; i < length; i++) {
+    n_bad_values += ArrowBitGet(bits, total_offset + i);
+    result[dst->offset + i] = NA_LOGICAL;
+  }
+
+  if (n_bad_values > 0) {
+    warn_lossy_conversion(n_bad_values, "that were non-null set to NA");
   }
 
   return NANOARROW_OK;

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -1816,6 +1816,88 @@ TEST(ArrayTest, ArrayViewTestBasic) {
   ArrowArrayViewReset(&array_view);
 }
 
+TEST(ArrayTest, ArrayViewTestComputeNullCount) {
+  struct ArrowError error;
+
+  int32_t values[] = {17, 87, 23, 53};
+  uint8_t all_valid = 0b1111'1111;
+  uint8_t all_null = 0b0000'0000;
+  uint8_t half_valid = 0b1010'1010;
+  uint8_t* all_valid_because_missing = nullptr;
+
+  const void* buffers[2];
+  buffers[1] = values;
+
+  nanoarrow::UniqueArray array;
+  array->length = 4;
+  array->offset = 0;
+  array->n_buffers = 2;
+  array->n_children = 0;
+  array->buffers = buffers;
+  array->children = nullptr;
+  array->dictionary = nullptr;
+  array->release = [](struct ArrowArray*) {};
+
+  for (auto [buffer, null_count] : {
+           std::pair{&all_valid, int64_t(0)},
+           std::pair{&all_null, array->length},
+           std::pair{&half_valid, array->length / 2},
+           std::pair{all_valid_because_missing, int64_t(0)},
+       }) {
+    array->null_count = null_count;
+    buffers[0] = buffer;
+    nanoarrow::UniqueArrayView array_view;
+    ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_INT32);
+    EXPECT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), &error), NANOARROW_OK)
+        << error.message;
+    EXPECT_EQ(ArrowArrayViewComputeNullCount(array_view.get()), null_count);
+  }
+}
+
+TEST(ArrayTest, ArrayViewTestComputeNullCountUnion) {
+  struct ArrowError error;
+
+  // Build a simple union with one int and one string
+  nanoarrow::UniqueSchema schema;
+  ArrowSchemaInit(schema.get());
+  ASSERT_EQ(ArrowSchemaSetTypeUnion(schema.get(), NANOARROW_TYPE_DENSE_UNION, 2),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema->children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(ArrowArrayInitFromSchema(array.get(), schema.get(), &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(array.get()), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(array->children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishUnionElement(array.get(), 0), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(array->children[1], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishUnionElement(array.get(), 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(array.get(), &error), NANOARROW_OK);
+
+  nanoarrow::UniqueArrayView array_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), &error),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewComputeNullCount(array_view.get()), 0);
+}
+
+TEST(ArrayTest, ArrayViewTestComputeNullCountNull) {
+  struct ArrowError error;
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(ArrowArrayInitFromType(array.get(), NANOARROW_TYPE_NA), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayStartAppending(array.get()), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendNull(array.get(), 11), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendNull(array.get(), 42), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayFinishBuildingDefault(array.get(), &error), NANOARROW_OK)
+      << error.message;
+
+  nanoarrow::UniqueArrayView array_view;
+  ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_NA);
+  ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewComputeNullCount(array_view.get()), 53);
+}
+
 TEST(ArrayTest, ArrayViewTestMove) {
   struct ArrowArrayView array_view;
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_STRING);
@@ -2407,7 +2489,7 @@ TEST(ArrayTest, ArrayViewTestUnionChildIndices) {
   ASSERT_EQ(ArrowArrayFinishUnionElement(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
 
-  // The ArrayView for a union could in theroy be created without a schema.
+  // The ArrayView for a union could in theory be created without a schema.
   // Currently FULL validation will fail here since we can't guarantee that
   // these are valid.
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_DENSE_UNION);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -1852,6 +1852,15 @@ TEST(ArrayTest, ArrayViewTestComputeNullCount) {
         << error.message;
     EXPECT_EQ(ArrowArrayViewComputeNullCount(array_view.get()), null_count);
   }
+
+  array->length = 0;
+  array->null_count = 0;
+  buffers[0] = &all_null;
+  nanoarrow::UniqueArrayView array_view;
+  ArrowArrayViewInitFromType(array_view.get(), NANOARROW_TYPE_INT32);
+  EXPECT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), &error), NANOARROW_OK)
+      << error.message;
+  EXPECT_EQ(ArrowArrayViewComputeNullCount(array_view.get()), 0);
 }
 
 TEST(ArrayTest, ArrayViewTestComputeNullCountUnion) {

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1071,6 +1071,10 @@ void ArrowArrayViewReset(struct ArrowArrayView* array_view);
 static inline int8_t ArrowArrayViewIsNull(const struct ArrowArrayView* array_view,
                                           int64_t i);
 
+/// \brief Compute null count for an ArrowArrayView
+static inline int64_t ArrowArrayViewComputeNullCount(
+    const struct ArrowArrayView* array_view);
+
 /// \brief Get the type id of a union array element
 static inline int8_t ArrowArrayViewUnionTypeId(const struct ArrowArrayView* array_view,
                                                int64_t i);

--- a/src/nanoarrow/nanoarrow_testing.hpp
+++ b/src/nanoarrow/nanoarrow_testing.hpp
@@ -2013,20 +2013,8 @@ class TestingJSONReader {
       ArrowBufferView* buffer_view = array_view->buffer_views + i;
       buffer_view->data.as_uint8 = buffer->data;
       buffer_view->size_bytes = buffer->size_bytes;
-
-      // If this is a validity buffer, set the null_count
-      if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_VALIDITY &&
-          _ArrowBytesForBits(array_view->length) <= buffer_view->size_bytes) {
-        array_view->null_count =
-            array_view->length -
-            ArrowBitCountSet(buffer_view->data.as_uint8, 0, array_view->length);
-      }
     }
-
-    // The null type doesn't have any buffers but we can set the null_count
-    if (array_view->storage_type == NANOARROW_TYPE_NA) {
-      array_view->null_count = array_view->length;
-    }
+    array_view->null_count = ArrowArrayViewComputeNullCount(array_view);
 
     // If there is a dictionary associated with schema, parse its value into dictionary
     if (schema->dictionary != nullptr) {

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -23,3 +23,4 @@ fetchcontent_makeavailable(nanoarrow_zlib)
 
 add_library(ZLIB::ZLIB ALIAS zlibstatic)
 target_include_directories(zlibstatic INTERFACE ${zlib_BINARY_DIR} ${zlib_SOURCE_DIR})
+target_include_directories(zlib INTERFACE ${zlib_BINARY_DIR} ${zlib_SOURCE_DIR})


### PR DESCRIPTION
Adds `ArrowArrayViewComputeNullCount()` and tests. Extracted from https://github.com/apache/arrow-nanoarrow/pull/555