### PR TITLE
feat: Add IPC stream writing

### DIFF
--- a/src/nanoarrow/common/inline_buffer.h
+++ b/src/nanoarrow/common/inline_buffer.h
@@ -451,8 +451,8 @@ static inline void ArrowBitClear(uint8_t* bits, int64_t i) {
 }
 
 static inline void ArrowBitSetTo(uint8_t* bits, int64_t i, uint8_t bit_is_set) {
-  bits[i / 8] ^=
-      ((uint8_t)(-((uint8_t)(bit_is_set != 0)) ^ bits[i / 8])) & _ArrowkBitmask[i % 8];
+  bits[i / 8] ^= (uint8_t)(((uint8_t)(-((uint8_t)(bit_is_set != 0)) ^ bits[i / 8])) &
+                           _ArrowkBitmask[i % 8]);
 }
 
 static inline void ArrowBitsSetTo(uint8_t* bits, int64_t start_offset, int64_t length,

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -314,7 +314,7 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)
 #else
 #define NANOARROW_ASSERT_OK(EXPR) (void)(EXPR)
-#define NANOARROW_DCHECK(EXPR)
+#define NANOARROW_DCHECK(EXPR) (void)(EXPR)
 #endif
 
 static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dst) {

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -314,7 +314,7 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 #define NANOARROW_DCHECK(EXPR) _NANOARROW_DCHECK_IMPL(EXPR, #EXPR)
 #else
 #define NANOARROW_ASSERT_OK(EXPR) (void)(EXPR)
-#define NANOARROW_DCHECK(EXPR) (void)(EXPR)
+#define NANOARROW_DCHECK(EXPR)
 #endif
 
 static inline void ArrowSchemaMove(struct ArrowSchema* src, struct ArrowSchema* dst) {

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -230,24 +230,31 @@ static ArrowErrorCode ArrowIpcEncodeFieldType(flatcc_builder_t* builder,
 
     case NANOARROW_TYPE_TIMESTAMP:
       FLATCC_RETURN_UNLESS_0(Field_type_Timestamp_start(builder), error);
-      FLATCC_RETURN_UNLESS_0(Timestamp_unit_add(builder, schema_view->time_unit), error);
+      FLATCC_RETURN_UNLESS_0(
+          Timestamp_unit_add(builder, (ns(TimeUnit_enum_t))schema_view->time_unit),
+          error);
       FLATCC_RETURN_UNLESS_0(
           Timestamp_timezone_create_str(builder, schema_view->timezone), error);
       FLATCC_RETURN_UNLESS_0(Field_type_Timestamp_end(builder), error);
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME32:
-      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(builder, schema_view->time_unit, 32),
-                             error);
+      FLATCC_RETURN_UNLESS_0(
+          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit,
+                                 32),
+          error);
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME64:
-      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(builder, schema_view->time_unit, 64),
-                             error);
+      FLATCC_RETURN_UNLESS_0(
+          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit,
+                                 64),
+          error);
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_DURATION:
-      FLATCC_RETURN_UNLESS_0(Field_type_Duration_create(builder, schema_view->time_unit),
+      FLATCC_RETURN_UNLESS_0(Field_type_Duration_create(
+                                 builder, (ns(TimeUnit_enum_t))schema_view->time_unit),
                              error);
       return NANOARROW_OK;
 

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -531,7 +531,6 @@ static ArrowErrorCode ArrowIpcEncoderEncodeRecordBatch(
     const struct ArrowArrayView* array_view, struct ArrowError* error) {
   NANOARROW_DCHECK(encoder != NULL && encoder->private_data != NULL &&
                    buffer_encoder != NULL && buffer_encoder->encode_buffer != NULL);
-
   if (array_view->null_count != 0 && ArrowArrayViewComputeNullCount(array_view) != 0) {
     ArrowErrorSet(error,
                   "RecordBatches cannot be constructed from arrays with top level nulls");

--- a/src/nanoarrow/ipc/files_test.cc
+++ b/src/nanoarrow/ipc/files_test.cc
@@ -201,12 +201,8 @@ class TestFile {
     nanoarrow::ipc::UniqueOutputStream output_stream;
     NANOARROW_RETURN_NOT_OK(ArrowIpcOutputStreamInitBuffer(output_stream.get(), buffer));
 
-    nanoarrow::ipc::UniqueEncoder encoder;
-    NANOARROW_RETURN_NOT_OK(ArrowIpcEncoderInit(encoder.get()));
-
     nanoarrow::ipc::UniqueWriter writer;
-    NANOARROW_RETURN_NOT_OK(
-        ArrowIpcWriterInit(writer.get(), encoder.get(), output_stream.get()));
+    NANOARROW_RETURN_NOT_OK(ArrowIpcWriterInit(writer.get(), output_stream.get()));
 
     nanoarrow::UniqueArrayView array_view;
     NANOARROW_RETURN_NOT_OK(
@@ -216,6 +212,7 @@ class TestFile {
     for (const auto& array : arrays) {
       NANOARROW_RETURN_NOT_OK(
           ArrowArrayViewSetArray(array_view.get(), array.get(), error));
+
       NANOARROW_RETURN_NOT_OK(
           ArrowIpcWriterWriteArrayView(writer.get(), array_view.get(), error));
     }

--- a/src/nanoarrow/ipc/files_test.cc
+++ b/src/nanoarrow/ipc/files_test.cc
@@ -29,7 +29,7 @@
 #include <gtest/gtest.h>
 
 #include "nanoarrow/nanoarrow.hpp"
-#include "nanoarrow/nanoarrow_ipc.h"
+#include "nanoarrow/nanoarrow_ipc.hpp"
 #include "nanoarrow/nanoarrow_testing.hpp"
 
 #include "flatcc/portable/pendian_detect.h"
@@ -105,6 +105,29 @@ class TestFile {
     return NANOARROW_OK;
   }
 
+  ArrowErrorCode ReadArrowArrayStreamIPC(const std::string& dir_prefix,
+                                         struct ArrowSchema* schema,
+                                         std::vector<nanoarrow::UniqueArray>* arrays,
+                                         ArrowError* error) {
+    nanoarrow::UniqueArrayStream stream;
+    NANOARROW_RETURN_NOT_OK(GetArrowArrayStreamIPC(dir_prefix, stream.get(), error));
+
+    NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetSchema(stream.get(), schema, error));
+
+    while (true) {
+      nanoarrow::UniqueArray array;
+
+      NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetNext(stream.get(), array.get(), error));
+
+      if (array->release == nullptr) {
+        break;
+      }
+
+      arrays->push_back(std::move(array));
+    }
+    return NANOARROW_OK;
+  }
+
   ArrowErrorCode GetArrowArrayStreamCheckJSON(const std::string& dir_prefix,
                                               ArrowArrayStream* out, ArrowError* error) {
     std::stringstream path_builder;
@@ -171,6 +194,60 @@ class TestFile {
     return std::make_shared<io::BufferReader>(content_copy_wrapped);
   }
 
+  // Set a trivial release callback which won't free() anything
+  template <typename T>
+  static void SetTrivialRelease(void (**release)(T*)) {
+    *release = [](T* ptr) { ptr->release = nullptr; };
+  }
+
+  ArrowErrorCode WriteNanoarrowStream(const nanoarrow::UniqueSchema& schema,
+                                      const std::vector<nanoarrow::UniqueArray>& arrays,
+                                      struct ArrowBuffer* buffer,
+                                      struct ArrowError* error) {
+    struct {
+      const nanoarrow::UniqueSchema& schema;
+      const std::vector<nanoarrow::UniqueArray>& arrays;
+      size_t i = 0;
+    } stream_private{schema, arrays};
+
+    static auto get_private = [](struct ArrowArrayStream* stream) {
+      return static_cast<decltype(&stream_private)>(stream->private_data);
+    };
+
+    struct ArrowArrayStream in;
+    in.get_schema = [](struct ArrowArrayStream* stream, struct ArrowSchema* out) {
+      memcpy(out, get_private(stream)->schema.get(), sizeof(struct ArrowSchema));
+      SetTrivialRelease(&out->release);
+      return 0;
+    };
+    in.get_next = [](struct ArrowArrayStream* stream, struct ArrowArray* out) {
+      size_t i = get_private(stream)->i++;
+      out->release = nullptr;
+      if (i < get_private(stream)->arrays.size()) {
+        memcpy(out, get_private(stream)->arrays[i].get(), sizeof(struct ArrowArray));
+        SetTrivialRelease(&out->release);
+      }
+      return 0;
+    };
+    in.get_last_error = [](struct ArrowArrayStream*) { return "temp stream error"; };
+    in.private_data = &stream_private;
+    SetTrivialRelease(&in.release);
+
+    nanoarrow::ipc::UniqueOutputStream output_stream;
+    NANOARROW_RETURN_NOT_OK(ArrowIpcOutputStreamInitBuffer(output_stream.get(), buffer));
+
+    nanoarrow::ipc::UniqueArrayStreamWriter writer;
+    NANOARROW_RETURN_NOT_OK(
+        ArrowIpcArrayStreamWriterInit(writer.get(), &in, output_stream.get()));
+
+    while (!writer->finished) {
+      NANOARROW_RETURN_NOT_OK(ArrowIpcArrayStreamWriterWriteSome(writer.get(), error));
+    }
+    writer.reset();
+
+    return NANOARROW_OK;
+  }
+
   void TestEqualsArrowCpp(const std::string& dir_prefix) {
     std::stringstream path_builder;
     path_builder << dir_prefix << "/" << path_;
@@ -179,38 +256,14 @@ class TestFile {
     ArrowErrorInit(&error);
 
     // Read using nanoarrow_ipc
-    nanoarrow::UniqueArrayStream stream;
-    ASSERT_EQ(GetArrowArrayStreamIPC(dir_prefix, stream.get(), &error), NANOARROW_OK)
-        << error.message;
-
     nanoarrow::UniqueSchema schema;
-    int result = ArrowArrayStreamGetSchema(stream.get(), schema.get(), &error);
+    std::vector<nanoarrow::UniqueArray> arrays;
+    int result = ReadArrowArrayStreamIPC(dir_prefix, schema.get(), &arrays, &error);
     if (result != NANOARROW_OK) {
       if (Check(result, error.message)) {
         return;
       }
-
       GTEST_FAIL() << MakeError(result, error.message);
-    }
-
-    std::vector<nanoarrow::UniqueArray> arrays;
-    while (true) {
-      nanoarrow::UniqueArray array;
-
-      result = ArrowArrayStreamGetNext(stream.get(), array.get(), &error);
-      if (result != NANOARROW_OK) {
-        if (Check(result, error.message)) {
-          return;
-        }
-
-        GTEST_FAIL() << MakeError(result, error.message);
-      }
-
-      if (array->release == nullptr) {
-        break;
-      }
-
-      arrays.push_back(std::move(array));
     }
 
     // If the file was supposed to fail the read but did not, fail here
@@ -218,37 +271,57 @@ class TestFile {
       GTEST_FAIL() << MakeError(NANOARROW_OK, "");
     }
 
-    // Read the same file with Arrow C++
-    nanoarrow::UniqueBuffer content_copy;
-    ASSERT_EQ(ReadFileBuffer(path_builder.str(), content_copy.get(), &error),
+    // Write back to a buffer using nanoarrow
+    nanoarrow::UniqueBuffer roundtripped;
+    ASSERT_EQ(WriteNanoarrowStream(schema, arrays, roundtripped.get(), &error),
               NANOARROW_OK)
         << error.message;
-    std::shared_ptr<io::InputStream> input_stream = BufferInputStream(content_copy.get());
 
-    auto maybe_reader = ipc::RecordBatchStreamReader::Open(input_stream);
-    FAIL_RESULT_NOT_OK(maybe_reader);
-
-    auto maybe_table_arrow = maybe_reader.ValueUnsafe()->ToTable();
+    // Read the same file with Arrow C++
+    auto maybe_table_arrow = ReadTable(io::ReadableFile::Open(path_builder.str()));
     FAIL_RESULT_NOT_OK(maybe_table_arrow);
 
-    // Make a Table from the our vector of arrays
-    auto maybe_schema = ImportSchema(schema.get());
-    FAIL_RESULT_NOT_OK(maybe_schema);
+    AssertEqualsTable(std::move(schema), std::move(arrays),
+                      maybe_table_arrow.ValueUnsafe());
 
-    ASSERT_TRUE(maybe_table_arrow.ValueUnsafe()->schema()->Equals(**maybe_schema, true));
+    // Read the roundtripped buffer using nanoarrow
+    nanoarrow::UniqueSchema roundtripped_schema;
+    std::vector<nanoarrow::UniqueArray> roundtripped_arrays;
+    ASSERT_EQ(ReadArrowArrayStreamIPC(dir_prefix, roundtripped_schema.get(),
+                                      &roundtripped_arrays, &error),
+              NANOARROW_OK);
 
-    std::vector<std::shared_ptr<RecordBatch>> batches;
+    AssertEqualsTable(std::move(roundtripped_schema), std::move(roundtripped_arrays),
+                      maybe_table_arrow.ValueUnsafe());
+  }
+
+  Result<std::shared_ptr<Table>> ReadTable(
+      Result<std::shared_ptr<io::InputStream>> maybe_input_stream) {
+    ARROW_ASSIGN_OR_RAISE(auto input_stream, maybe_input_stream);
+    ARROW_ASSIGN_OR_RAISE(auto reader, ipc::RecordBatchStreamReader::Open(input_stream));
+    return reader->ToTable();
+  }
+
+  Result<std::shared_ptr<Table>> ToTable(nanoarrow::UniqueSchema schema,
+                                         std::vector<nanoarrow::UniqueArray> arrays) {
+    ARROW_ASSIGN_OR_RAISE(auto arrow_schema, ImportSchema(schema.get()));
+
+    std::vector<std::shared_ptr<RecordBatch>> batches(arrays.size());
+    size_t i = 0;
     for (auto& array : arrays) {
-      auto maybe_batch = ImportRecordBatch(array.get(), *maybe_schema);
-      FAIL_RESULT_NOT_OK(maybe_batch);
-
-      batches.push_back(std::move(*maybe_batch));
+      ARROW_ASSIGN_OR_RAISE(auto batch, ImportRecordBatch(array.get(), arrow_schema));
+      batches[i++] = std::move(batch);
     }
+    return Table::FromRecordBatches(std::move(arrow_schema), std::move(batches));
+  }
 
-    auto maybe_table = Table::FromRecordBatches(*maybe_schema, batches);
+  void AssertEqualsTable(nanoarrow::UniqueSchema schema,
+                         std::vector<nanoarrow::UniqueArray> arrays,
+                         const std::shared_ptr<Table>& expected) {
+    auto maybe_table = ToTable(std::move(schema), std::move(arrays));
     FAIL_RESULT_NOT_OK(maybe_table);
-
-    EXPECT_TRUE(maybe_table.ValueUnsafe()->Equals(**maybe_table_arrow, true));
+    ASSERT_TRUE(expected->schema()->Equals(maybe_table.ValueUnsafe()->schema(), true));
+    EXPECT_TRUE(maybe_table.ValueUnsafe()->Equals(*expected, true));
   }
 
   void TestIPCCheckJSON(const std::string& dir_prefix) {
@@ -382,7 +455,8 @@ INSTANTIATE_TEST_SUITE_P(
     NanoarrowIpcTest, TestFileFixture,
     ::testing::Values(
         // Files in data/arrow-ipc-stream/integration/1.0.0-(little|big)endian/
-        // should read without error and the data should match Arrow C++'s read
+        // should read without error and the data should match Arrow C++'s read.
+        // Also write the stream to a buffer and check Arrow C++'s read of that.
         TestFile::OK("generated_custom_metadata.stream"),
         TestFile::OK("generated_datetime.stream"),
         TestFile::OK("generated_decimal.stream"),

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -69,14 +69,18 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcOutputStreamInitBuffer)
 #define ArrowIpcOutputStreamInitFile \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcOutputStreamInitFile)
+#define ArrowIpcOutputStreamWrite \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcOutputStreamWrite)
 #define ArrowIpcOutputStreamMove \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcOutputStreamMove)
-#define ArrowIpcArrayStreamWriterInit \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcArrayStreamWriterInit)
-#define ArrowIpcArrayStreamWriterReset \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcArrayStreamWriterReset)
-#define ArrowIpcArrayStreamWriterWriteSome \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcArrayStreamWriterWriteSome)
+#define ArrowIpcWriterInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterInit)
+#define ArrowIpcWriterReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterReset)
+#define ArrowIpcWriterWriteSchema \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterWriteSchema)
+#define ArrowIpcWriterWriteArrayView \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterWriteArrayView)
+#define ArrowIpcWriterWriteArrayStream \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterWriteArrayStream)
 
 #endif
 
@@ -498,48 +502,58 @@ ArrowErrorCode ArrowIpcOutputStreamInitBuffer(struct ArrowIpcOutputStream* strea
 ArrowErrorCode ArrowIpcOutputStreamInitFile(struct ArrowIpcOutputStream* stream,
                                             void* file_ptr, int close_on_release);
 
-/// \brief A stream writer which encodes ArrowArrays into an IPC byte stream
+/// \brief Write to a stream, trying again until all are written or the stream errors.
+ArrowErrorCode ArrowIpcOutputStreamWrite(struct ArrowIpcOutputStream* stream,
+                                         struct ArrowBufferView data,
+                                         struct ArrowError* error);
+
+/// \brief A stream writer which encodes Schemas and ArrowArrays into an IPC byte stream
 ///
 /// This structure is intended to be allocated by the caller,
-/// initialized using ArrowIpcArrayStreamWriterInit(), and released with
-/// ArrowIpcArrayStreamWriterReset().
-///
-/// Note: although ArrowArrayStream is a sufficient interface to wrap a stream reader,
-/// a stream writer cannot be wrapped as an ArrowArrayStream.
-struct ArrowIpcArrayStreamWriter {
-  /// \brief Set to non-zero after the writer is finished.
-  int finished;
-
+/// initialized using ArrowIpcWriterInit(), and released with
+/// ArrowIpcWriterReset().
+struct ArrowIpcWriter {
   /// \brief Private resources managed by this library
   void* private_data;
 };
 
 /// \brief Initialize an output stream of bytes from an ArrowArrayStream
 ///
-/// The writer will not pull from the input array stream or push to the
-/// output stream until ArrowIpcArrayStreamWriterContinue().
-///
 /// Returns NANOARROW_OK on success. If NANOARROW_OK is returned the writer
-/// takes ownership of both the input array stream and the output byte stream
-/// and the caller is responsible for releasing the writer by calling
-/// ArrowIpcArrayStreamWriterReset().
-ArrowErrorCode ArrowIpcArrayStreamWriterInit(struct ArrowIpcArrayStreamWriter* writer,
-                                             struct ArrowArrayStream* in,
-                                             struct ArrowIpcOutputStream* output_stream);
+/// takes ownership of the output byte stream and the encoder, and the caller is
+/// responsible for releasing the writer by calling ArrowIpcWriterReset().
+ArrowErrorCode ArrowIpcWriterInit(struct ArrowIpcWriter* writer,
+                                  struct ArrowIpcEncoder* encoder,
+                                  struct ArrowIpcOutputStream* output_stream);
 
 /// \brief Release all resources attached to a writer
-void ArrowIpcArrayStreamWriterReset(struct ArrowIpcArrayStreamWriter* writer);
+void ArrowIpcWriterReset(struct ArrowIpcWriter* writer);
 
-/// \brief Write some bytes into the output byte stream
+/// \brief Write a schema to the output byte stream
 ///
-/// The stream will first be queried for its Schema, then for all the RecordBatches in the
-/// stream, each of which will be encoded and pushed into the output byte stream.
+/// Errors are propagated from the underlying encoder and output byte stream.
+ArrowErrorCode ArrowIpcWriterWriteSchema(struct ArrowIpcWriter* writer,
+                                         const struct ArrowSchema* in,
+                                         struct ArrowError* error);
+
+/// \brief Write an array view to the output byte stream
 ///
-/// Errors are propagated from the underlying streams.
-ArrowErrorCode ArrowIpcArrayStreamWriterWriteSome(
-    struct ArrowIpcArrayStreamWriter* writer, struct ArrowError* error);
+/// The array view may be NULL, in which case an EOS will be written.
+/// The writer does not check that a schema was already written.
+///
+/// Errors are propagated from the underlying encoder and output byte stream,
+ArrowErrorCode ArrowIpcWriterWriteArrayView(struct ArrowIpcWriter* writer,
+                                            const struct ArrowArrayView* in,
+                                            struct ArrowError* error);
+
+/// \brief Write an entire stream (including EOS) to the output byte stream
+///
+/// Errors are propagated from the underlying encoder, array stream, and output byte
+/// stream.
+ArrowErrorCode ArrowIpcWriterWriteArrayStream(struct ArrowIpcWriter* writer,
+                                              struct ArrowArrayStream* in,
+                                              struct ArrowError* error);
 /// @}
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -520,10 +520,9 @@ struct ArrowIpcWriter {
 /// \brief Initialize an output stream of bytes from an ArrowArrayStream
 ///
 /// Returns NANOARROW_OK on success. If NANOARROW_OK is returned the writer
-/// takes ownership of the output byte stream and the encoder, and the caller is
+/// takes ownership of the output byte stream, and the caller is
 /// responsible for releasing the writer by calling ArrowIpcWriterReset().
 ArrowErrorCode ArrowIpcWriterInit(struct ArrowIpcWriter* writer,
-                                  struct ArrowIpcEncoder* encoder,
                                   struct ArrowIpcOutputStream* output_stream);
 
 /// \brief Release all resources attached to a writer

--- a/src/nanoarrow/nanoarrow_ipc.hpp
+++ b/src/nanoarrow/nanoarrow_ipc.hpp
@@ -95,6 +95,23 @@ inline void release_pointer(struct ArrowIpcOutputStream* data) {
   }
 }
 
+template <>
+inline void init_pointer(struct ArrowIpcArrayStreamWriter* data) {
+  data->private_data = nullptr;
+}
+
+template <>
+inline void move_pointer(struct ArrowIpcArrayStreamWriter* src,
+                         struct ArrowIpcArrayStreamWriter* dst) {
+  memcpy(dst, src, sizeof(struct ArrowIpcArrayStreamWriter));
+  src->private_data = nullptr;
+}
+
+template <>
+inline void release_pointer(struct ArrowIpcArrayStreamWriter* data) {
+  ArrowIpcArrayStreamWriterReset(data);
+}
+
 }  // namespace internal
 }  // namespace nanoarrow
 
@@ -120,6 +137,9 @@ using UniqueInputStream = internal::Unique<struct ArrowIpcInputStream>;
 
 /// \brief Class wrapping a unique struct ArrowIpcOutputStream
 using UniqueOutputStream = internal::Unique<struct ArrowIpcOutputStream>;
+
+/// \brief Class wrapping a unique struct ArrowIpcArrayStreamWriter
+using UniqueArrayStreamWriter = internal::Unique<struct ArrowIpcArrayStreamWriter>;
 
 /// @}
 

--- a/src/nanoarrow/nanoarrow_ipc.hpp
+++ b/src/nanoarrow/nanoarrow_ipc.hpp
@@ -101,8 +101,7 @@ inline void init_pointer(struct ArrowIpcWriter* data) {
 }
 
 template <>
-inline void move_pointer(struct ArrowIpcWriter* src,
-                         struct ArrowIpcWriter* dst) {
+inline void move_pointer(struct ArrowIpcWriter* src, struct ArrowIpcWriter* dst) {
   memcpy(dst, src, sizeof(struct ArrowIpcWriter));
   src->private_data = nullptr;
 }

--- a/src/nanoarrow/nanoarrow_ipc.hpp
+++ b/src/nanoarrow/nanoarrow_ipc.hpp
@@ -96,20 +96,20 @@ inline void release_pointer(struct ArrowIpcOutputStream* data) {
 }
 
 template <>
-inline void init_pointer(struct ArrowIpcArrayStreamWriter* data) {
+inline void init_pointer(struct ArrowIpcWriter* data) {
   data->private_data = nullptr;
 }
 
 template <>
-inline void move_pointer(struct ArrowIpcArrayStreamWriter* src,
-                         struct ArrowIpcArrayStreamWriter* dst) {
-  memcpy(dst, src, sizeof(struct ArrowIpcArrayStreamWriter));
+inline void move_pointer(struct ArrowIpcWriter* src,
+                         struct ArrowIpcWriter* dst) {
+  memcpy(dst, src, sizeof(struct ArrowIpcWriter));
   src->private_data = nullptr;
 }
 
 template <>
-inline void release_pointer(struct ArrowIpcArrayStreamWriter* data) {
-  ArrowIpcArrayStreamWriterReset(data);
+inline void release_pointer(struct ArrowIpcWriter* data) {
+  ArrowIpcWriterReset(data);
 }
 
 }  // namespace internal
@@ -138,8 +138,8 @@ using UniqueInputStream = internal::Unique<struct ArrowIpcInputStream>;
 /// \brief Class wrapping a unique struct ArrowIpcOutputStream
 using UniqueOutputStream = internal::Unique<struct ArrowIpcOutputStream>;
 
-/// \brief Class wrapping a unique struct ArrowIpcArrayStreamWriter
-using UniqueArrayStreamWriter = internal::Unique<struct ArrowIpcArrayStreamWriter>;
+/// \brief Class wrapping a unique struct ArrowIpcWriter
+using UniqueWriter = internal::Unique<struct ArrowIpcWriter>;
 
 /// @}
 

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -66,3 +66,10 @@
    fun:base64_encode
    fun:R_base64_encode
 }
+
+# TODO https://github.com/apache/arrow-nanoarrow/issues/579 remove this
+{
+   <flatcc>:flatcc uses realloc() and valgrind thinks something was free'd
+   Memcheck:Addr4
+   fun:flatcc_builder_create_cached_vtable
+}


### PR DESCRIPTION
- adds ArrowIpcArrayStreamWriter along with Init() and Reset() methods
  - embeds an Encoder and an OutputStream
- adds WriteSchema() and WriteArrayView() methods which encode then write a schema or array
- adds WriteArrayStream() method which serializes an entire ArrowArrayStream, finishing with an explicit EOS
  - non-blocking IO is not currently supported