### PR TITLE
fix(ci): Pin r-lib actions as a workaround for latest action updates

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -52,11 +52,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      # r-lib/actions pinned because the latest action on the v2 branch requires
-      # quarto-dev actions which have not yet beeen whitelisted by Apache Infra
-      - uses: r-lib/actions/setup-pandoc@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
-      - uses: r-lib/actions/setup-r@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -73,13 +70,15 @@ jobs:
           R CMD INSTALL r --preclean
         shell: bash
 
+      # r-lib/actions/setup-r-dependencies pinned because the latest action on the
+      # v2 branch requires quarto-dev actions which have not yet been whitelisted by Apache Infra
       - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           extra-packages: any::rcmdcheck, arrow=?ignore-before-r=4.0.0
           needs: check
           working-directory: r
 
-      - uses: r-lib/actions/check-r-package@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
+      - uses: r-lib/actions/check-r-package@v2
         env:
           ARROW_R_VERBOSE_TEST: "true"
           _R_CHECK_FORCE_SUGGESTS_: false

--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -53,8 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      # r-lib/actions pinned because the latest action on the v2 branch requires
+      # quarto-dev actions which have not yet beeen whitelisted by Apache Infra
+      - uses: r-lib/actions/setup-pandoc@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
+      - uses: r-lib/actions/setup-r@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -71,13 +73,13 @@ jobs:
           R CMD INSTALL r --preclean
         shell: bash
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           extra-packages: any::rcmdcheck, arrow=?ignore-before-r=4.0.0
           needs: check
           working-directory: r
 
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         env:
           ARROW_R_VERBOSE_TEST: "true"
           _R_CHECK_FORCE_SUGGESTS_: false


### PR DESCRIPTION
First noticed at https://github.com/apache/arrow-nanoarrow/pull/555#discussion_r1702201173 , the R check action is failing because an update to r-lib actions resulted in some quarto actions being invoked, and these have not yet been whitelisted for use in Apache repositories. It also may be that we don't need the quarto actions (we probably don't) but some brief experimentation to attempt circumventing the use of the quarto action did not result in a successful workflow. Hence, a pin to unblock PR checks until either the v2 branch is updated or it is clear how to avoid the failure.