### PR TITLE
refactor: Consolidate per-target actions in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,31 +356,13 @@ foreach(target
             DESTINATION lib
             EXPORT nanoarrow-exports)
 
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-      if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(${target}
-                               PRIVATE -Wall
-                                       -Werror
-                                       -Wextra
-                                       -Wpedantic
-                                       -Wno-type-limits
-                                       -Wmaybe-uninitialized
-                                       -Wunused-result
-                                       -Wconversion
-                                       -Wno-sign-conversion)
-      elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
-                                                          "Clang")
-        target_compile_options(${target}
-                               PRIVATE -Wall
-                                       -Werror
-                                       -Wextra
-                                       -Wpedantic
-                                       -Wdocumentation
-                                       -Wconversion
-                                       -Wno-sign-conversion)
-      endif()
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Wall -Werror -Wextra -Wpedantic -Wno-type-limits -Wmaybe-uninitialized -Wunused-result -Wconversion -Wno-sign-conversion>)
+    elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
+                                                        "Clang")
+      target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Wall -Werror -Wextra -Wpedantic -Wdocumentation -Wconversion -Wno-sign-conversion>)
     endif()
-  endif()
+    endif()
 endforeach()
 
 if(NANOARROW_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ set(NANOARROW_VERSION_MAJOR "${nanoarrow_VERSION_MAJOR}")
 set(NANOARROW_VERSION_MINOR "${nanoarrow_VERSION_MINOR}")
 set(NANOARROW_VERSION_PATCH "${nanoarrow_VERSION_PATCH}")
 
+# General options
+option(NANOARROW_NAMESPACE "A prefix for exported symbols" OFF)
+
 # Feature options
 option(NANOARROW_IPC "Build IPC extension" OFF)
 option(NANOARROW_FLATCC_ROOT_DIR "Root directory for flatcc include and lib directories"
@@ -41,6 +44,8 @@ option(NANOARROW_FLATCC_LIB_DIR "Library directory that contains libflatccrt.a" 
 
 option(NANOARROW_DEVICE "Build device extension" OFF)
 option(NANOARROW_TESTING "Build testng extension" OFF)
+option(NANOARROW_DEVICE_WITH_METAL "Build Apple metal libraries" OFF)
+option(NANOARROW_DEVICE_WITH_CUDA "Build CUDA libraries" OFF)
 
 # Development options
 option(NANOARROW_BUILD_APPS "Build utility applications" OFF)
@@ -50,20 +55,9 @@ option(NANOARROW_BUILD_INTEGRATION_TESTS
        "Build cross-implementation Arrow integration tests" OFF)
 option(NANOARROW_BUNDLE "Create bundled nanoarrow.h and nanoarrow.c" OFF)
 option(NANOARROW_BUNDLE_AS_CPP "Bundle nanoarrow source file as nanoarrow.cc" OFF)
-option(NANOARROW_NAMESPACE "A prefix for exported symbols" OFF)
+option(NANOARROW_CODE_COVERAGE "Enable coverage reporting" OFF)
 option(NANOARROW_ARROW_STATIC
        "Use a statically-linked Arrow C++ build when linking tests" OFF)
-
-option(NANOARROW_DEVICE_WITH_METAL "Build Apple metal libraries" OFF)
-option(NANOARROW_DEVICE_WITH_CUDA "Build CUDA libraries" OFF)
-
-if(NANOARROW_IPC)
-  add_library(ipc_coverage_config INTERFACE)
-endif()
-
-if(NANOARROW_DEVICE)
-  add_library(device_coverage_config INTERFACE)
-endif()
 
 if(NANOARROW_NAMESPACE)
   set(NANOARROW_NAMESPACE_DEFINE "#define NANOARROW_NAMESPACE ${NANOARROW_NAMESPACE}")
@@ -71,7 +65,15 @@ else()
   set(NANOARROW_NAMESPACE_DEFINE "// #define NANOARROW_NAMESPACE YourNamespaceHere")
 endif()
 
-option(NANOARROW_CODE_COVERAGE "Enable coverage reporting" OFF)
+add_library(nanoarrow_coverage_config INTERFACE)
+install(TARGETS nanoarrow_coverage_config
+            DESTINATION lib
+            EXPORT nanoarrow-exports)
+
+if(NANOARROW_CODE_COVERAGE)
+  target_compile_options(nanoarrow_coverage_config INTERFACE -O0 -g --coverage)
+  target_link_options(nanoarrow_coverage_config INTERFACE --coverage)
+endif()
 
 # Avoids a warning about timestamps on downloaded files (prefer new policy
 # if available))
@@ -211,7 +213,7 @@ if(NANOARROW_IPC)
   endif()
 
   add_library(nanoarrow_ipc ${NANOARROW_IPC_BUILD_SOURCES})
-  target_link_libraries(nanoarrow_ipc PRIVATE flatccrt)
+  target_link_libraries(nanoarrow_ipc PRIVATE flatccrt nanoarrow_coverage_config)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
@@ -292,7 +294,7 @@ if(NANOARROW_DEVICE)
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
   target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
-                                                 ${NANOARROW_DEVICE_LIBS_METAL})
+                                                 ${NANOARROW_DEVICE_LIBS_METAL} nanoarrow_coverage_config)
 
   install(TARGETS nanoarrow_device DESTINATION lib)
   install(FILES src/nanoarrow/nanoarrow_device.h DESTINATION include/nanoarrow)
@@ -320,7 +322,7 @@ if(NANOARROW_TESTING
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
-  target_link_libraries(nanoarrow_testing PRIVATE nlohmann_json::nlohmann_json)
+  target_link_libraries(nanoarrow_testing PRIVATE nlohmann_json::nlohmann_json nanoarrow)
   target_link_libraries(nanoarrow_testing PUBLIC nanoarrow)
   set_target_properties(nanoarrow_testing PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -336,7 +338,7 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
-  target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow nanoarrow_testing)
+  target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow_testing)
 endif()
 
 # Common configuration for all targets
@@ -420,38 +422,32 @@ if(NANOARROW_BUILD_TESTS)
   add_executable(c_data_integration_test
                  src/nanoarrow/integration/c_data_integration_test.cc)
 
-  if(NANOARROW_CODE_COVERAGE)
-    target_compile_options(nanoarrow PUBLIC -O0 -g --coverage)
-    target_link_options(nanoarrow PUBLIC --coverage)
-  endif()
-
   target_link_libraries(utils_test
-                        nanoarrow
                         nanoarrow_testing
                         gtest_main
                         gmock_main
                         ${NANOARROW_ARROW_TARGET}
-                        nlohmann_json::nlohmann_json)
-  target_link_libraries(buffer_test nanoarrow gtest_main)
+                        nanoarrow_coverage_config)
+  target_link_libraries(buffer_test nanoarrow gtest_main nanoarrow_coverage_config)
   target_link_libraries(array_test
                         nanoarrow
                         gtest_main
                         gmock_main
-                        ${NANOARROW_ARROW_TARGET})
-  target_link_libraries(schema_test nanoarrow gtest_main ${NANOARROW_ARROW_TARGET})
-  target_link_libraries(array_stream_test nanoarrow gtest_main gmock_main)
+                        ${NANOARROW_ARROW_TARGET}
+                        nanoarrow_coverage_config)
+  target_link_libraries(schema_test nanoarrow gtest_main ${NANOARROW_ARROW_TARGET} nanoarrow_coverage_config)
+  target_link_libraries(array_stream_test nanoarrow gtest_main gmock_main nanoarrow_coverage_config)
   target_link_libraries(nanoarrow_hpp_test
                         nanoarrow
                         gtest_main
                         gmock_main
-                        nlohmann_json::nlohmann_json)
+                        nanoarrow_coverage_config)
   target_link_libraries(nanoarrow_testing_test
-                        nanoarrow
                         nanoarrow_testing
                         gtest_main
-                        nlohmann_json::nlohmann_json)
+                        nanoarrow_coverage_config)
   target_link_libraries(c_data_integration_test nanoarrow nanoarrow_c_data_integration
-                        gtest_main)
+                        gtest_main nanoarrow_coverage_config)
 
   include(GoogleTest)
   # Some users have reported a timeout with the default value of 5
@@ -481,12 +477,6 @@ if(NANOARROW_BUILD_TESTS)
     enable_testing()
     include(GoogleTest)
 
-    if(NANOARROW_CODE_COVERAGE)
-      target_compile_options(ipc_coverage_config INTERFACE -O0 -g --coverage)
-      target_link_options(ipc_coverage_config INTERFACE --coverage)
-      target_link_libraries(nanoarrow_ipc PRIVATE ipc_coverage_config)
-    endif()
-
     foreach(name
             decoder
             encoder
@@ -501,7 +491,7 @@ if(NANOARROW_BUILD_TESTS)
                             nanoarrow
                             ${NANOARROW_ARROW_TARGET}
                             gtest_main
-                            ipc_coverage_config)
+                            nanoarrow_coverage_config)
 
       if(NOT (name MATCHES "_hpp_"))
         target_link_libraries(nanoarrow_ipc_${name}_test flatccrt)
@@ -510,7 +500,7 @@ if(NANOARROW_BUILD_TESTS)
       gtest_discover_tests(nanoarrow_ipc_${name}_test)
     endforeach()
 
-    target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB)
+    target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB nanoarrow_coverage_config)
   endif()
 
   if(NANOARROW_DEVICE)
@@ -518,22 +508,16 @@ if(NANOARROW_BUILD_TESTS)
     add_executable(nanoarrow_device_test src/nanoarrow/device/device_test.cc)
     add_executable(nanoarrow_device_hpp_test src/nanoarrow/device/device_hpp_test.cc)
 
-    if(NANOARROW_DEVICE_CODE_COVERAGE)
-      target_compile_options(device_coverage_config INTERFACE -O0 -g --coverage)
-      target_link_options(device_coverage_config INTERFACE --coverage)
-      target_link_libraries(nanoarrow_device PRIVATE device_coverage_config)
-    endif()
-
     target_link_libraries(nanoarrow_device_test
                           nanoarrow_device
                           nanoarrow
                           gtest_main
-                          device_coverage_config)
+                          nanoarrow_coverage_config)
     target_link_libraries(nanoarrow_device_hpp_test
                           nanoarrow_device
                           nanoarrow
                           gtest_main
-                          device_coverage_config)
+                          nanoarrow_coverage_config)
 
     include(GoogleTest)
     gtest_discover_tests(nanoarrow_device_test)
@@ -545,7 +529,7 @@ if(NANOARROW_BUILD_TESTS)
                             nanoarrow_device
                             nanoarrow
                             gtest_main
-                            device_coverage_config)
+                            nanoarrow_coverage_config)
       gtest_discover_tests(nanoarrow_device_metal_test)
     endif()
 
@@ -555,7 +539,7 @@ if(NANOARROW_BUILD_TESTS)
                             nanoarrow_device
                             nanoarrow
                             gtest_main
-                            device_coverage_config)
+                            nanoarrow_coverage_config)
       gtest_discover_tests(nanoarrow_device_cuda_test)
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,41 +145,17 @@ target_include_directories(nanoarrow
                            PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                   $<INSTALL_INTERFACE:include>)
-target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
-
-# Ensure targets/headers can be installed
-install(TARGETS nanoarrow
-        DESTINATION lib
-        EXPORT nanoarrow-exports)
-
 install(FILES ${NANOARROW_INSTALL_HEADERS} DESTINATION include/nanoarrow)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(nanoarrow
-                           PRIVATE -Wall
-                                   -Werror
-                                   -Wextra
-                                   -Wpedantic
-                                   -Wno-type-limits
-                                   -Wmaybe-uninitialized
-                                   -Wunused-result
-                                   -Wconversion
-                                   -Wno-sign-conversion)
-  elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
-                                                      "Clang")
-    target_compile_options(nanoarrow
-                           PRIVATE -Wall
-                                   -Werror
-                                   -Wextra
-                                   -Wpedantic
-                                   -Wdocumentation
-                                   -Wconversion
-                                   -Wno-sign-conversion)
-  endif()
-endif()
-
 if(NANOARROW_IPC)
+  # flatcc requires C11 for alignas() and static_assert() in flatcc_generated.h
+  # It may be possible to use C99 mode to build the runtime and/or generated header
+  # should this cause problems for users.
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+  endif()
+
   # Add the flatcc (runtime) dependency
   set(FLATCC_RTONLY
       ON
@@ -206,6 +182,7 @@ if(NANOARROW_IPC)
     target_include_directories(flatccrt
                                PUBLIC $<BUILD_INTERFACE:${NANOARROW_FLATCC_INCLUDE_DIR}>
                                       $<INSTALL_INTERFACE:include>)
+    install(TARGETS flatccrt DESTINATION lib EXPORT nanoarrow-exports)
 
   elseif(NOT NANOARROW_FLATCC_ROOT_DIR)
     add_library(flatccrt STATIC IMPORTED)
@@ -236,7 +213,7 @@ if(NANOARROW_IPC)
   target_include_directories(nanoarrow_ipc
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
-                                    $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}
+                                    $<BUILD_INTERFACE:${NANOARROW_IPC_FLATCC_INCLUDE_DIR}>
                                     $<INSTALL_INTERFACE:include>)
 
   install(TARGETS nanoarrow_ipc DESTINATION lib)
@@ -324,6 +301,7 @@ if(NANOARROW_TESTING
   endif()
 
   add_subdirectory("thirdparty/nlohmann_json")
+  install(TARGETS nlohmann_json DESTINATION lib EXPORT nanoarrow-exports)
 
   add_library(nanoarrow_testing src/nanoarrow/testing/testing.cc)
   target_include_directories(nanoarrow_testing
@@ -348,6 +326,42 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
                                     $<INSTALL_INTERFACE:include>)
   target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow nanoarrow_testing)
 endif()
+
+target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
+
+# Common configuration for all targets
+foreach(target nanoarrow nanoarrow_ipc nanoarrow_device nanoarrow_testing nanoarrow_c_data_integration)
+  if(TARGET ${target})
+    install(TARGETS ${target}
+            DESTINATION lib
+            EXPORT nanoarrow-exports)
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+      if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        target_compile_options(${target}
+                              PRIVATE -Wall
+                                      -Werror
+                                      -Wextra
+                                      -Wpedantic
+                                      -Wno-type-limits
+                                      -Wmaybe-uninitialized
+                                      -Wunused-result
+                                      -Wconversion
+                                      -Wno-sign-conversion)
+      elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
+                                                          "Clang")
+        target_compile_options(${target}
+                              PRIVATE -Wall
+                                      -Werror
+                                      -Wextra
+                                      -Wpedantic
+                                      -Wdocumentation
+                                      -Wconversion
+                                      -Wno-sign-conversion)
+      endif()
+    endif()
+  endif()
+endforeach()
 
 if(NANOARROW_BUILD_TESTS)
   set(MEMORYCHECK_COMMAND_OPTIONS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,8 @@ if(NANOARROW_DEVICE)
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
   target_link_libraries(nanoarrow_device
-                        PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
-                                ${NANOARROW_DEVICE_LIBS_METAL} nanoarrow_coverage_config)
+                        PUBLIC ${NANOARROW_DEVICE_LIBS_CUDA}
+                               ${NANOARROW_DEVICE_LIBS_METAL} nanoarrow_coverage_config)
 
   install(TARGETS nanoarrow_device DESTINATION lib)
   install(FILES src/nanoarrow/nanoarrow_device.h DESTINATION include/nanoarrow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,9 @@ if(NANOARROW_IPC)
     target_include_directories(flatccrt
                                PUBLIC $<BUILD_INTERFACE:${NANOARROW_FLATCC_INCLUDE_DIR}>
                                       $<INSTALL_INTERFACE:include>)
-    install(TARGETS flatccrt DESTINATION lib EXPORT nanoarrow-exports)
+    install(TARGETS flatccrt
+            DESTINATION lib
+            EXPORT nanoarrow-exports)
 
   elseif(NOT NANOARROW_FLATCC_ROOT_DIR)
     add_library(flatccrt STATIC IMPORTED)
@@ -251,9 +253,14 @@ if(NANOARROW_DEVICE)
 
     set(NANOARROW_DEVICE_INCLUDE_METAL "${CMAKE_BINARY_DIR}/metal-cpp")
     add_library(nanoarrow_metal_impl src/nanoarrow/device/metal_impl.cc)
-    target_link_libraries(nanoarrow_metal_impl PRIVATE ${METAL_LIBRARY} ${FOUNDATION_LIBRARY} ${QUARTZ_CORE_LIBRARY})
-    target_include_directories(nanoarrow_metal_impl PRIVATE ${NANOARROW_DEVICE_INCLUDE_METAL})
-    install(TARGETS nanoarrow_metal_impl DESTINATION lib EXPORT nanoarrow-exports)
+    target_link_libraries(nanoarrow_metal_impl
+                          PRIVATE ${METAL_LIBRARY} ${FOUNDATION_LIBRARY}
+                                  ${QUARTZ_CORE_LIBRARY})
+    target_include_directories(nanoarrow_metal_impl
+                               PRIVATE ${NANOARROW_DEVICE_INCLUDE_METAL})
+    install(TARGETS nanoarrow_metal_impl
+            DESTINATION lib
+            EXPORT nanoarrow-exports)
 
     set(NANOARROW_DEVICE_SOURCES_METAL src/nanoarrow/device/metal.cc)
     set(NANOARROW_DEVICE_DEFS_METAL "NANOARROW_DEVICE_WITH_METAL")
@@ -284,7 +291,8 @@ if(NANOARROW_DEVICE)
 
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
-  target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA} ${NANOARROW_DEVICE_LIBS_METAL})
+  target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
+                                                 ${NANOARROW_DEVICE_LIBS_METAL})
   target_compile_definitions(nanoarrow_device PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
   install(TARGETS nanoarrow_device DESTINATION lib)
@@ -304,7 +312,9 @@ if(NANOARROW_TESTING
   endif()
 
   add_subdirectory("thirdparty/nlohmann_json")
-  install(TARGETS nlohmann_json DESTINATION lib EXPORT nanoarrow-exports)
+  install(TARGETS nlohmann_json
+          DESTINATION lib
+          EXPORT nanoarrow-exports)
 
   add_library(nanoarrow_testing src/nanoarrow/testing/testing.cc)
   target_include_directories(nanoarrow_testing
@@ -333,7 +343,12 @@ endif()
 target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
 # Common configuration for all targets
-foreach(target nanoarrow nanoarrow_ipc nanoarrow_device nanoarrow_testing nanoarrow_c_data_integration)
+foreach(target
+        nanoarrow
+        nanoarrow_ipc
+        nanoarrow_device
+        nanoarrow_testing
+        nanoarrow_c_data_integration)
   if(TARGET ${target})
     install(TARGETS ${target}
             DESTINATION lib
@@ -342,25 +357,25 @@ foreach(target nanoarrow nanoarrow_ipc nanoarrow_device nanoarrow_testing nanoar
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
       if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
         target_compile_options(${target}
-                              PRIVATE -Wall
-                                      -Werror
-                                      -Wextra
-                                      -Wpedantic
-                                      -Wno-type-limits
-                                      -Wmaybe-uninitialized
-                                      -Wunused-result
-                                      -Wconversion
-                                      -Wno-sign-conversion)
+                               PRIVATE -Wall
+                                       -Werror
+                                       -Wextra
+                                       -Wpedantic
+                                       -Wno-type-limits
+                                       -Wmaybe-uninitialized
+                                       -Wunused-result
+                                       -Wconversion
+                                       -Wno-sign-conversion)
       elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
                                                           "Clang")
         target_compile_options(${target}
-                              PRIVATE -Wall
-                                      -Werror
-                                      -Wextra
-                                      -Wpedantic
-                                      -Wdocumentation
-                                      -Wconversion
-                                      -Wno-sign-conversion)
+                               PRIVATE -Wall
+                                       -Werror
+                                       -Wextra
+                                       -Wpedantic
+                                       -Wdocumentation
+                                       -Wconversion
+                                       -Wno-sign-conversion)
       endif()
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,11 +249,15 @@ if(NANOARROW_DEVICE)
     find_library(QUARTZ_CORE_LIBRARY QuartzCore REQUIRED)
     message(STATUS "CoreFoundation framework found at '${QUARTZ_CORE_LIBRARY}'")
 
+    set(NANOARROW_DEVICE_INCLUDE_METAL "${CMAKE_BINARY_DIR}/metal-cpp")
+    add_library(nanoarrow_metal_impl src/nanoarrow/device/metal_impl.cc)
+    target_link_libraries(nanoarrow_metal_impl PRIVATE ${METAL_LIBRARY} ${FOUNDATION_LIBRARY} ${QUARTZ_CORE_LIBRARY})
+    target_include_directories(nanoarrow_metal_impl PRIVATE ${NANOARROW_DEVICE_INCLUDE_METAL})
+    install(TARGETS nanoarrow_metal_impl DESTINATION lib EXPORT nanoarrow-exports)
+
     set(NANOARROW_DEVICE_SOURCES_METAL src/nanoarrow/device/metal.cc)
-    set(NANOARROW_DEVICE_INCLUDE_METAL ${CMAKE_BINARY_DIR}/metal-cpp)
-    set(NANOARROW_DEVICE_LIBS_METAL ${METAL_LIBRARY} ${FOUNDATION_LIBRARY}
-                                    ${QUARTZ_CORE_LIBRARY})
     set(NANOARROW_DEVICE_DEFS_METAL "NANOARROW_DEVICE_WITH_METAL")
+    set(NANOARROW_DEVICE_LIBS_METAL nanoarrow_metal_impl)
   endif()
 
   if(NANOARROW_DEVICE_WITH_CUDA)
@@ -280,8 +284,7 @@ if(NANOARROW_DEVICE)
 
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
-  target_link_libraries(nanoarrow_device PUBLIC ${NANOARROW_DEVICE_LIBS_METAL}
-                                                ${NANOARROW_DEVICE_LIBS_CUDA})
+  target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA} ${NANOARROW_DEVICE_LIBS_METAL})
   target_compile_definitions(nanoarrow_device PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
   install(TARGETS nanoarrow_device DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,12 +357,28 @@ foreach(target
             EXPORT nanoarrow-exports)
 
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-      target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Wall -Werror -Wextra -Wpedantic -Wno-type-limits -Wmaybe-uninitialized -Wunused-result -Wconversion -Wno-sign-conversion>)
+      target_compile_options(${target}
+                             PRIVATE $<$<CONFIG:Debug>:-Wall
+                                     -Werror
+                                     -Wextra
+                                     -Wpedantic
+                                     -Wno-type-limits
+                                     -Wmaybe-uninitialized
+                                     -Wunused-result
+                                     -Wconversion
+                                     -Wno-sign-conversion>)
     elseif(CMAKE_C_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_C_COMPILER_ID STREQUAL
                                                         "Clang")
-      target_compile_options(${target} PRIVATE $<$<CONFIG:Debug>:-Wall -Werror -Wextra -Wpedantic -Wdocumentation -Wconversion -Wno-sign-conversion>)
+      target_compile_options(${target}
+                             PRIVATE $<$<CONFIG:Debug>:-Wall
+                                     -Werror
+                                     -Wextra
+                                     -Wpedantic
+                                     -Wdocumentation
+                                     -Wconversion
+                                     -Wno-sign-conversion>)
     endif()
-    endif()
+  endif()
 endforeach()
 
 if(NANOARROW_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,8 @@ endif()
 
 add_library(nanoarrow_coverage_config INTERFACE)
 install(TARGETS nanoarrow_coverage_config
-            DESTINATION lib
-            EXPORT nanoarrow-exports)
+        DESTINATION lib
+        EXPORT nanoarrow-exports)
 
 if(NANOARROW_CODE_COVERAGE)
   target_compile_options(nanoarrow_coverage_config INTERFACE -O0 -g --coverage)
@@ -293,8 +293,9 @@ if(NANOARROW_DEVICE)
 
   target_compile_definitions(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_DEFS_METAL}
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
-  target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
-                                                 ${NANOARROW_DEVICE_LIBS_METAL} nanoarrow_coverage_config)
+  target_link_libraries(nanoarrow_device
+                        PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
+                                ${NANOARROW_DEVICE_LIBS_METAL} nanoarrow_coverage_config)
 
   install(TARGETS nanoarrow_device DESTINATION lib)
   install(FILES src/nanoarrow/nanoarrow_device.h DESTINATION include/nanoarrow)
@@ -435,19 +436,28 @@ if(NANOARROW_BUILD_TESTS)
                         gmock_main
                         ${NANOARROW_ARROW_TARGET}
                         nanoarrow_coverage_config)
-  target_link_libraries(schema_test nanoarrow gtest_main ${NANOARROW_ARROW_TARGET} nanoarrow_coverage_config)
-  target_link_libraries(array_stream_test nanoarrow gtest_main gmock_main nanoarrow_coverage_config)
+  target_link_libraries(schema_test
+                        nanoarrow
+                        gtest_main
+                        ${NANOARROW_ARROW_TARGET}
+                        nanoarrow_coverage_config)
+  target_link_libraries(array_stream_test
+                        nanoarrow
+                        gtest_main
+                        gmock_main
+                        nanoarrow_coverage_config)
   target_link_libraries(nanoarrow_hpp_test
                         nanoarrow
                         gtest_main
                         gmock_main
                         nanoarrow_coverage_config)
-  target_link_libraries(nanoarrow_testing_test
-                        nanoarrow_testing
+  target_link_libraries(nanoarrow_testing_test nanoarrow_testing gtest_main
+                        nanoarrow_coverage_config)
+  target_link_libraries(c_data_integration_test
+                        nanoarrow
+                        nanoarrow_c_data_integration
                         gtest_main
                         nanoarrow_coverage_config)
-  target_link_libraries(c_data_integration_test nanoarrow nanoarrow_c_data_integration
-                        gtest_main nanoarrow_coverage_config)
 
   include(GoogleTest)
   # Some users have reported a timeout with the default value of 5
@@ -500,7 +510,8 @@ if(NANOARROW_BUILD_TESTS)
       gtest_discover_tests(nanoarrow_ipc_${name}_test)
     endforeach()
 
-    target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB nanoarrow_coverage_config)
+    target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB
+                          nanoarrow_coverage_config)
   endif()
 
   if(NANOARROW_DEVICE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,6 @@ if(NANOARROW_DEVICE)
                                                       ${NANOARROW_DEVICE_DEFS_CUDA})
   target_link_libraries(nanoarrow_device PRIVATE ${NANOARROW_DEVICE_LIBS_CUDA}
                                                  ${NANOARROW_DEVICE_LIBS_METAL})
-  target_compile_definitions(nanoarrow_device PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 
   install(TARGETS nanoarrow_device DESTINATION lib)
   install(FILES src/nanoarrow/nanoarrow_device.h DESTINATION include/nanoarrow)
@@ -340,8 +339,6 @@ if(NANOARROW_BUILD_TESTS OR NANOARROW_BUILD_INTEGRATION_TESTS)
   target_link_libraries(nanoarrow_c_data_integration PRIVATE nanoarrow nanoarrow_testing)
 endif()
 
-target_compile_definitions(nanoarrow PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
-
 # Common configuration for all targets
 foreach(target
         nanoarrow
@@ -350,6 +347,8 @@ foreach(target
         nanoarrow_testing
         nanoarrow_c_data_integration)
   if(TARGET ${target})
+    target_compile_definitions(${target} PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
+
     install(TARGETS ${target}
             DESTINATION lib
             EXPORT nanoarrow-exports)

--- a/src/nanoarrow/device/cuda.c
+++ b/src/nanoarrow/device/cuda.c
@@ -518,7 +518,8 @@ static ArrowErrorCode ArrowDeviceCudaInitDevice(struct ArrowDevice* device,
   }
 
   CUdevice cu_device;
-  NANOARROW_CUDA_RETURN_NOT_OK(cuDeviceGet(&cu_device, device_id), "cuDeviceGet", error);
+  NANOARROW_CUDA_RETURN_NOT_OK(cuDeviceGet(&cu_device, (int)device_id), "cuDeviceGet",
+                               error);
 
   CUcontext cu_context;
   NANOARROW_CUDA_RETURN_NOT_OK(cuDevicePrimaryCtxRetain(&cu_context, cu_device),

--- a/src/nanoarrow/device/cuda.c
+++ b/src/nanoarrow/device/cuda.c
@@ -85,6 +85,9 @@ struct ArrowDeviceCudaAllocatorPrivate {
 
 static void ArrowDeviceCudaDeallocator(struct ArrowBufferAllocator* allocator,
                                        uint8_t* ptr, int64_t old_size) {
+  NANOARROW_UNUSED(ptr);
+  NANOARROW_UNUSED(old_size);
+
   struct ArrowDeviceCudaAllocatorPrivate* allocator_private =
       (struct ArrowDeviceCudaAllocatorPrivate*)allocator->private_data;
 

--- a/src/nanoarrow/device/metal.cc
+++ b/src/nanoarrow/device/metal.cc
@@ -20,8 +20,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#define NS_PRIVATE_IMPLEMENTATION
-#define MTL_PRIVATE_IMPLEMENTATION
 #include <Metal/Metal.hpp>
 
 #include "nanoarrow/nanoarrow_device.hpp"

--- a/src/nanoarrow/device/metal.cc
+++ b/src/nanoarrow/device/metal.cc
@@ -20,8 +20,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <Metal/Metal.hpp>
-
+#include "nanoarrow/device/metal_impl.h"
 #include "nanoarrow/nanoarrow_device.hpp"
 
 // If non-null, caller must ->release() the return value. This doesn't

--- a/src/nanoarrow/device/metal.cc
+++ b/src/nanoarrow/device/metal.cc
@@ -62,6 +62,8 @@ static MTL::Buffer* ArrowDeviceMetalWrapBufferNonOwning(MTL::Device* mtl_device,
 static uint8_t* ArrowDeviceMetalAllocatorReallocate(
     struct ArrowBufferAllocator* allocator, uint8_t* ptr, int64_t old_size,
     int64_t new_size) {
+  NANOARROW_UNUSED(allocator);
+
   // Cache the page size from the system call
   static int pagesize = 0;
   if (pagesize == 0) {
@@ -103,6 +105,8 @@ static uint8_t* ArrowDeviceMetalAllocatorReallocate(
 
 static void ArrowDeviceMetalAllocatorFree(struct ArrowBufferAllocator* allocator,
                                           uint8_t* ptr, int64_t old_size) {
+  NANOARROW_UNUSED(allocator);
+  NANOARROW_UNUSED(old_size);
   free(ptr);
 }
 
@@ -188,6 +192,10 @@ static ArrowErrorCode ArrowDeviceMetalBufferInitAsync(struct ArrowDevice* device
                                                       struct ArrowDevice* device_dst,
                                                       struct ArrowBuffer* dst,
                                                       void* stream) {
+  if (stream != nullptr) {
+    return ENOTSUP;
+  }
+
   if (device_src->device_type == ARROW_DEVICE_CPU &&
       device_dst->device_type == ARROW_DEVICE_METAL) {
     struct ArrowBuffer tmp;
@@ -255,6 +263,10 @@ static ArrowErrorCode ArrowDeviceMetalBufferCopyAsync(struct ArrowDevice* device
                                                       struct ArrowDevice* device_dst,
                                                       struct ArrowBufferView dst,
                                                       void* stream) {
+  if (stream != nullptr) {
+    return ENOTSUP;
+  }
+
   // This is all just memcpy since it's all living in the same address space
   if (device_src->device_type == ARROW_DEVICE_CPU &&
       device_dst->device_type == ARROW_DEVICE_METAL) {
@@ -299,6 +311,8 @@ static int ArrowDeviceMetalCopyRequiredCpuToMetal(MTL::Device* mtl_device,
 static ArrowErrorCode ArrowDeviceMetalSynchronize(struct ArrowDevice* device,
                                                   void* sync_event, void* stream,
                                                   struct ArrowError* error) {
+  NANOARROW_UNUSED(device);
+  NANOARROW_UNUSED(error);
   // TODO: sync events for Metal are harder than for CUDA
   // https://developer.apple.com/documentation/metal/resource_synchronization/synchronizing_events_between_a_gpu_and_the_cpu?language=objc
   // It would be much easier if sync_event were a command buffer

--- a/src/nanoarrow/device/metal_impl.cc
+++ b/src/nanoarrow/device/metal_impl.cc
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#define NS_PRIVATE_IMPLEMENTATION
+#define MTL_PRIVATE_IMPLEMENTATION
+#include <Metal/Metal.hpp>

--- a/src/nanoarrow/device/metal_impl.h
+++ b/src/nanoarrow/device/metal_impl.h
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#define NS_PRIVATE_IMPLEMENTATION
-#define MTL_PRIVATE_IMPLEMENTATION
-#include "metal_impl.h"
+// We have no control over the Metal headers
+#pragma GCC diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma GCC diagnostic ignored "-Wnested-anon-types"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic push
+#include <Metal/Metal.hpp>
+#pragma GCC diagnostic pop

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -98,6 +98,9 @@ struct ArrowIpcDecoderPrivate {
 };
 
 ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error) {
+  // Avoids an unused warning when bundling the header into nanoarrow_ipc.c
+  NANOARROW_UNUSED(flatbuffers_end);
+
   const char* nanoarrow_runtime_version = ArrowNanoarrowVersion();
   const char* nanoarrow_ipc_build_time_version = NANOARROW_VERSION;
 

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -226,18 +226,18 @@ static ArrowErrorCode ArrowIpcEncodeFieldType(flatcc_builder_t* builder,
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME32:
-      FLATCC_RETURN_UNLESS_0(
-          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 32));
+      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(
+          builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 32));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME64:
-      FLATCC_RETURN_UNLESS_0(
-          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 64));
+      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(
+          builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 64));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_DURATION:
-      FLATCC_RETURN_UNLESS_0(
-          Field_type_Duration_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit));
+      FLATCC_RETURN_UNLESS_0(Field_type_Duration_create(
+          builder, (ns(TimeUnit_enum_t))schema_view->time_unit));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_FIXED_SIZE_BINARY:

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -218,22 +218,26 @@ static ArrowErrorCode ArrowIpcEncodeFieldType(flatcc_builder_t* builder,
 
     case NANOARROW_TYPE_TIMESTAMP:
       FLATCC_RETURN_UNLESS_0(Field_type_Timestamp_start(builder));
-      FLATCC_RETURN_UNLESS_0(Timestamp_unit_add(builder, schema_view->time_unit));
+      FLATCC_RETURN_UNLESS_0(
+          Timestamp_unit_add(builder, (ns(TimeUnit_enum_t))schema_view->time_unit));
       FLATCC_RETURN_UNLESS_0(
           Timestamp_timezone_create_str(builder, schema_view->timezone));
       FLATCC_RETURN_UNLESS_0(Field_type_Timestamp_end(builder));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME32:
-      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(builder, schema_view->time_unit, 32));
+      FLATCC_RETURN_UNLESS_0(
+          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 32));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_TIME64:
-      FLATCC_RETURN_UNLESS_0(Field_type_Time_create(builder, schema_view->time_unit, 64));
+      FLATCC_RETURN_UNLESS_0(
+          Field_type_Time_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit, 64));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_DURATION:
-      FLATCC_RETURN_UNLESS_0(Field_type_Duration_create(builder, schema_view->time_unit));
+      FLATCC_RETURN_UNLESS_0(
+          Field_type_Duration_create(builder, (ns(TimeUnit_enum_t))schema_view->time_unit));
       return NANOARROW_OK;
 
     case NANOARROW_TYPE_FIXED_SIZE_BINARY:
@@ -316,10 +320,12 @@ static ArrowErrorCode ArrowIpcEncodeMetadata(flatcc_builder_t* builder,
                                                  (*push_end)(flatcc_builder_t*),
                                              struct ArrowError* error) {
   struct ArrowMetadataReader metadata;
-  NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderInit(&metadata, schema->metadata));
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowMetadataReaderInit(&metadata, schema->metadata),
+                                     error);
   while (metadata.remaining_keys > 0) {
     struct ArrowStringView key, value;
-    NANOARROW_RETURN_NOT_OK(ArrowMetadataReaderRead(&metadata, &key, &value));
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowMetadataReaderRead(&metadata, &key, &value),
+                                       error);
     if (push_start(builder) != 0) {
       return ENOMEM;
     }
@@ -395,7 +401,8 @@ ArrowErrorCode ArrowIpcEncoderEncodeSchema(struct ArrowIpcEncoder* encoder,
 
   FLATCC_RETURN_UNLESS_0(Message_header_Schema_start(builder));
 
-  FLATCC_RETURN_UNLESS_0(Schema_endianness_add(builder, ArrowIpcSystemEndianness()));
+  FLATCC_RETURN_UNLESS_0(
+      Schema_endianness_add(builder, (ns(Endianness_enum_t))ArrowIpcSystemEndianness()));
 
   FLATCC_RETURN_UNLESS_0(Schema_fields_start(builder));
   NANOARROW_RETURN_NOT_OK(ArrowIpcEncodeFields(builder, schema,

--- a/src/nanoarrow/testing/testing.cc
+++ b/src/nanoarrow/testing/testing.cc
@@ -1564,7 +1564,7 @@ ArrowErrorCode SetBufferBitmap(const json& value, ArrowBitmap* bitmap,
     // says [1, 0, 1]. Accept both for simplicity.
     NANOARROW_RETURN_NOT_OK(Check(item.is_boolean() || item.is_number_integer(), error,
                                   "bitmap item must be bool or integer"));
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapAppend(bitmap, item.get<int>(), 1),
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapAppend(bitmap, item.get<uint8_t>(), 1),
                                        error);
   }
 


### PR DESCRIPTION
In previous PRs we consolidated the extensions into the main CMakeLists.txt; however, there were some things happening for certain targets (like installing them or setting NANOARROW_DEBUG) but not others.

Noticed in https://github.com/apache/arrow-nanoarrow/pull/555#discussion_r1702103767 where there was a DCHECK referencing a variable that didn't exist that made it through CI 😬 