### PR TITLE
fix(ci): Fix build and test of nanoarrow on centos7 and s390x

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -71,7 +71,7 @@ jobs:
           use-public-rspm: true
           windows-path-include-rtools: false
           windows-path-include-mingw: false
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           needs: check
           working-directory: src/r

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if(NANOARROW_BUNDLE)
   execute_process(COMMAND ${Python3_EXECUTABLE}
                           "${CMAKE_CURRENT_SOURCE_DIR}/ci/scripts/bundle.py"
                           "--output-dir" "${CMAKE_BINARY_DIR}/bundled"
-                          ${NANOARROW_BUNDLE_ARGS} COMMAND_ECHO STDERR)
+                          ${NANOARROW_BUNDLE_ARGS})
 
   set(NANOARROW_BUILD_INCLUDE_DIR "${CMAKE_BINARY_DIR}/bundled/include")
   set(NANOARROW_IPC_BUILD_SOURCES "${CMAKE_BINARY_DIR}/bundled/src/nanoarrow_ipc.c")

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -493,12 +493,10 @@ std::string ArrowSchemaMetadataToString(const char* metadata) {
 }
 
 std::string ArrowSchemaToString(const struct ArrowSchema* schema) {
-  std::string out;
-  size_t n = 1024;
-  while (out.size() < n) {
-    out.resize(n);
-    n = ArrowSchemaToString(schema, out.data(), out.size(), /*recursive=*/false);
-  }
+  int64_t n = ArrowSchemaToString(schema, nullptr, 0, /*recursive=*/false);
+  std::vector<char> out_vec(n, '\0');
+  ArrowSchemaToString(schema, out_vec.data(), n, /*recursive=*/false);
+  std::string out(out_vec.data(), out_vec.size());
 
   std::string metadata = ArrowSchemaMetadataToString(schema->metadata);
   if (!metadata.empty()) {

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -395,7 +395,11 @@ ArrowErrorCode ArrowIpcEncoderEncodeSchema(struct ArrowIpcEncoder* encoder,
 
   FLATCC_RETURN_UNLESS_0(Message_header_Schema_start(builder));
 
-  FLATCC_RETURN_UNLESS_0(Schema_endianness_add(builder, ArrowIpcSystemEndianness()));
+  if (ArrowIpcSystemEndianness() == NANOARROW_IPC_ENDIANNESS_LITTLE) {
+    FLATCC_RETURN_UNLESS_0(Schema_endianness_add(builder, ns(Endianness_Little)));
+  } else {
+    FLATCC_RETURN_UNLESS_0(Schema_endianness_add(builder, ns(Endianness_Big)));
+  }
 
   FLATCC_RETURN_UNLESS_0(Schema_fields_start(builder));
   NANOARROW_RETURN_NOT_OK(ArrowIpcEncodeFields(builder, schema,

--- a/src/nanoarrow/ipc/writer_test.cc
+++ b/src/nanoarrow/ipc/writer_test.cc
@@ -21,8 +21,6 @@
 
 #include "nanoarrow/nanoarrow_ipc.hpp"
 
-using nanoarrow::literals::operator""_asv;
-
 TEST(NanoarrowIpcWriter, OutputStreamBuffer) {
   struct ArrowError error;
 
@@ -47,9 +45,10 @@ TEST(NanoarrowIpcWriter, OutputStreamBuffer) {
 
   EXPECT_EQ(output->size_bytes, header.size() + 4 * message.size());
 
-  std::string output_str(output->size_bytes, '\0');
+  std::vector<char> output_str(output->size_bytes, '\0');
   memcpy(output_str.data(), output->data, output->size_bytes);
-  EXPECT_EQ(output_str, header + message + message + message + message);
+  EXPECT_EQ(std::string(output_str.data(), output_str.size()),
+            header + message + message + message + message);
 }
 
 TEST(NanoarrowIpcWriter, OutputStreamFile) {
@@ -81,10 +80,11 @@ TEST(NanoarrowIpcWriter, OutputStreamFile) {
 
   // Read back the whole file
   fseek(file_ptr, 0, SEEK_END);
-  std::string buffer(static_cast<size_t>(ftell(file_ptr)), '\0');
+  std::vector<char> buffer(static_cast<size_t>(ftell(file_ptr)), '\0');
   rewind(file_ptr);
   ASSERT_EQ(fread(buffer.data(), 1, buffer.size(), file_ptr), buffer.size());
 
   EXPECT_EQ(buffer.size(), 6 + 4 * message.size());
-  EXPECT_EQ(buffer, "HELLO " + message + message + message + message);
+  EXPECT_EQ(std::string(buffer.data(), buffer.size()),
+            "HELLO " + message + message + message + message);
 }


### PR DESCRIPTION
Noted in the weekly verification run: https://github.com/apache/arrow-nanoarrow/actions/runs/10232042714/job/28308701770

I think there were a three issues:

- The bundling setup used a feature of the command execution not available in stock `cmake3` on centos7
- Some C++17 (or unsupported gcc4.8 C++11) in some of the newer IPC additions
- IPC tests were failing on big endian ( https://github.com/apache/arrow-nanoarrow/actions/runs/10232042714/job/28308702337#step:4:2640 )

Reproducible via:

```shell
export NANOARROW_PLATFORM=centos7
docker compose run -e TEST_PYTHON=0 -e TEST_R=0 --rm verify
```

```shell
export NANOARROW_PLATFORM=alpine
export NANOARROW_ARCH=s390x
docker compose run -e TEST_DEFAULT=0 -e TEST_C=1 --rm verify
```