### PR TITLE
feat: Add `ArrowArrayViewCompare()` to check for array equality

### DIFF
--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1336,14 +1336,8 @@ ArrowErrorCode ArrowArrayViewValidate(struct ArrowArrayView* array_view,
   return EINVAL;
 }
 
-enum ArrowComparisonLevel {
-  NANOARROW_COMPARE_SAME,
-  NANOARROW_COMPARE_IDENTICAL,
-  NANOARROW_COMPARE_STRUCTURE,
-};
-
 struct ArrowComparisonInternalState {
-  enum ArrowComparisonLevel level;
+  enum ArrowCompareLevel level;
   int is_equal;
   struct ArrowBuffer path;
   struct ArrowError reason;
@@ -1409,19 +1403,14 @@ static ArrowErrorCode ArrowArrayViewCompareImpl(
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(
       ArrowArrayViewCompareStructure(actual, expected, state), error);
 
-  if (state->level == NANOARROW_COMPARE_STRUCTURE) {
-    return NANOARROW_OK;
-  }
-
-  ArrowErrorSet(error, "Comparison level not supported");
-  return ENOTSUP;
+  return NANOARROW_OK;
 }
 
 // Top-level entry point to take care of creating, cleaning up, and
 // propagating the ArrowComparisonInternalState to the caller
 ArrowErrorCode ArrowArrayViewCompare(const struct ArrowArrayView* actual,
                                      const struct ArrowArrayView* expected,
-                                     enum ArrowComparisonLevel level, int* out,
+                                     enum ArrowCompareLevel level, int* out,
                                      struct ArrowError* error) {
   struct ArrowComparisonInternalState state;
   state.level = level;

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1356,7 +1356,7 @@ struct ArrowComparisonInternalState {
 #define RETURN_NOT_EQUAL(state_, path_size_, condition_) \
   RETURN_NOT_EQUAL_IMPL(state_, path_size_, condition_, #condition_)
 
-ArrowErrorCode ArrowArrayViewCompareStructure(
+static ArrowErrorCode ArrowArrayViewCompareStructure(
     const struct ArrowArrayView* actual, const struct ArrowArrayView* expected,
     struct ArrowComparisonInternalState* state) {
   int64_t path_size = state->path.size_bytes;

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1489,7 +1489,7 @@ ArrowErrorCode ArrowArrayViewCompare(const struct ArrowArrayView* actual,
   state.level = level;
   state.is_equal = 1;
   ArrowBufferInit(&state.path);
-  ArrowErrorSet(&state.reason, "");
+  ArrowErrorInit(&state.reason);
 
   int result = ArrowArrayViewCompareImpl(actual, expected, &state, error);
   if (result != NANOARROW_OK) {

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1371,7 +1371,7 @@ ArrowErrorCode ArrowArrayViewCompareStructure(
   char child_id[128];
   child_id[0] = '\0';
   for (int64_t i = 0; i < actual->n_children; i++) {
-    snprintf(child_id, sizeof(child_id), ".%" PRId64, i);
+    snprintf(child_id, sizeof(child_id), ".children[%" PRId64 "]", i);
     state->path.size_bytes = path_size;
     NANOARROW_RETURN_NOT_OK(
         ArrowBufferAppendStringView(&state->path, ArrowCharView(child_id)));
@@ -1385,7 +1385,9 @@ ArrowErrorCode ArrowArrayViewCompareStructure(
   if (actual->dictionary != NULL) {
     state->path.size_bytes = path_size;
     NANOARROW_RETURN_NOT_OK(
-        ArrowBufferAppendStringView(&state->path, ArrowCharView("dictionary")));
+        ArrowBufferAppendStringView(&state->path, ArrowCharView(".dictionary")));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayViewCompareStructure(actual->dictionary, expected->dictionary, state));
     if (!state->is_equal) {
       return NANOARROW_OK;
     }
@@ -1399,7 +1401,7 @@ static ArrowErrorCode ArrowArrayViewCompareImpl(
     const struct ArrowArrayView* actual, const struct ArrowArrayView* expected,
     struct ArrowComparisonInternalState* state, struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-      ArrowBufferAppend(&state->path, "root", strlen("root")), error);
+      ArrowBufferAppendStringView(&state->path, ArrowCharView("root")), error);
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(
       ArrowArrayViewCompareStructure(actual, expected, state), error);
 

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -1900,6 +1900,105 @@ TEST(ArrayTest, ArrayViewCompareTestStructure) {
   ArrowArrayViewReset(&expected);
 }
 
+TEST(ArrayTest, ArrayViewCompareTestIdentical) {
+  struct ArrowError error;
+  struct ArrowArrayView actual;
+  struct ArrowArrayView expected;
+  int is_equal = -1;
+
+  // Check non-equal length/offset/null count
+  ArrowArrayViewInitFromType(&actual, NANOARROW_TYPE_INT32);
+  ArrowArrayViewInitFromType(&expected, NANOARROW_TYPE_INT32);
+  expected.length = 1;
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message, "root: actual->length != expected->length");
+
+  is_equal = -1;
+  expected.length = actual.length;
+  expected.offset = 1;
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message, "root: actual->offset != expected->offset");
+
+  is_equal = -1;
+  expected.offset = actual.offset;
+  expected.null_count = 1;
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message, "root: actual->null_count != expected->null_count");
+
+  // Check non-equal buffer size
+  is_equal = -1;
+  expected.null_count = actual.null_count;
+  expected.buffer_views[1].size_bytes = 5;
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message,
+               "root.buffers[1]: actual->buffer_views[i].size_bytes != "
+               "expected->buffer_views[i].size_bytes");
+
+  is_equal = -1;
+  const char* actual_content = "abcde";
+  const char* expected_content = "bcdef";
+  actual.buffer_views[1].size_bytes = 5;
+  actual.buffer_views[1].data.as_char = actual_content;
+  expected.buffer_views[1].data.as_char = expected_content;
+
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message,
+               "root.buffers[1]: memcmp(actual->buffer_views[i].data.data, "
+               "expected->buffer_views[i].data.data, buffer_size) != 0");
+
+  // Check difference in a child
+  is_equal = -1;
+  ArrowArrayViewReset(&actual);
+  ArrowArrayViewReset(&expected);
+  ArrowArrayViewInitFromType(&actual, NANOARROW_TYPE_STRUCT);
+  ArrowArrayViewInitFromType(&expected, NANOARROW_TYPE_STRUCT);
+  ASSERT_EQ(ArrowArrayViewAllocateChildren(&actual, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewAllocateChildren(&expected, 1), NANOARROW_OK);
+  ArrowArrayViewInitFromType(actual.children[0], NANOARROW_TYPE_INT32);
+  ArrowArrayViewInitFromType(expected.children[0], NANOARROW_TYPE_INT32);
+  actual.children[0]->length = 1;
+
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message, "root.children[0]: actual->length != expected->length");
+
+  // Check difference in a dictionary
+  is_equal = -1;
+  ArrowArrayViewReset(&actual);
+  ArrowArrayViewReset(&expected);
+  ArrowArrayViewInitFromType(&actual, NANOARROW_TYPE_INT32);
+  ArrowArrayViewInitFromType(&expected, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewAllocateDictionary(&actual), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewAllocateDictionary(&expected), NANOARROW_OK);
+  actual.dictionary->length = 1;
+
+  ASSERT_EQ(ArrowArrayViewCompare(&expected, &actual, NANOARROW_COMPARE_IDENTICAL,
+                                  &is_equal, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(is_equal, 0);
+  EXPECT_STREQ(error.message, "root.dictionary: actual->length != expected->length");
+
+  ArrowArrayViewReset(&actual);
+  ArrowArrayViewReset(&expected);
+}
+
 TEST(ArrayTest, ArrayViewTestComputeNullCount) {
   struct ArrowError error;
 

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -579,9 +579,6 @@ enum ArrowValidationLevel {
 /// \brief Comparison level enumerator
 /// \ingroup nanoarrow-utils
 enum ArrowCompareLevel {
-  /// \brief Consider arrays equal if buffers point to the same memory
-  /// location and have identical offset, null count, and length.
-  NANOARROW_COMPARE_SAME,
   /// \brief Consider arrays equal if buffers contain identical content
   /// and have identical offset, null count, and length.
   NANOARROW_COMPARE_IDENTICAL,

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -576,6 +576,17 @@ enum ArrowValidationLevel {
   NANOARROW_VALIDATION_LEVEL_FULL = 3
 };
 
+/// \brief Comparison level enumerator
+/// \ingroup nanoarrow-utils
+enum ArrowCompareLevel {
+  /// \brief Consider arrays equal if buffers point to the same memory
+  /// location and have identical offset, null count, and length.
+  NANOARROW_COMPARE_SAME,
+  /// \brief Consider arrays equal if buffers contain identical content
+  /// and have identical offset, null count, and length.
+  NANOARROW_COMPARE_IDENTICAL,
+};
+
 /// \brief Get a string value of an enum ArrowTimeUnit value
 /// \ingroup nanoarrow-utils
 ///

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -580,7 +580,10 @@ enum ArrowValidationLevel {
 /// \ingroup nanoarrow-utils
 enum ArrowCompareLevel {
   /// \brief Consider arrays equal if buffers contain identical content
-  /// and have identical offset, null count, and length.
+  /// and have identical offset, null count, and length. Note that this is
+  /// a much stricter check than logical equality, which would take into
+  /// account potentially different content of null slots, arrays with a
+  /// non-zero offset, and other considerations.
   NANOARROW_COMPARE_IDENTICAL,
 };
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -128,6 +128,7 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewSetArrayMinimal)
 #define ArrowArrayViewValidate \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewValidate)
+#define ArrowArrayViewCompare NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewCompare)
 #define ArrowArrayViewReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayViewReset)
 #define ArrowBasicArrayStreamInit \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowBasicArrayStreamInit)
@@ -1063,6 +1064,19 @@ ArrowErrorCode ArrowArrayViewSetArrayMinimal(struct ArrowArrayView* array_view,
 ArrowErrorCode ArrowArrayViewValidate(struct ArrowArrayView* array_view,
                                       enum ArrowValidationLevel validation_level,
                                       struct ArrowError* error);
+
+/// \brief Compare two ArrowArrayView objects for equality
+///
+/// Given two ArrowArrayView instances, place either 0 (not equal) and
+/// 1 (equal) at the address pointed to by out. If the comparison determines
+/// that actual and expected are not equal, a reason will be communicated via
+/// error if error is non-NULL.
+///
+/// Returns NANOARROW_OK if the comparison completed successfully.
+ArrowErrorCode ArrowArrayViewCompare(const struct ArrowArrayView* actual,
+                                     const struct ArrowArrayView* expected,
+                                     enum ArrowCompareLevel level, int* out,
+                                     struct ArrowError* error);
 
 /// \brief Reset the contents of an ArrowArrayView and frees resources
 void ArrowArrayViewReset(struct ArrowArrayView* array_view);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1076,7 +1076,7 @@ ArrowErrorCode ArrowArrayViewValidate(struct ArrowArrayView* array_view,
 ArrowErrorCode ArrowArrayViewCompare(const struct ArrowArrayView* actual,
                                      const struct ArrowArrayView* expected,
                                      enum ArrowCompareLevel level, int* out,
-                                     struct ArrowError* error);
+                                     struct ArrowError* reason);
 
 /// \brief Reset the contents of an ArrowArrayView and frees resources
 void ArrowArrayViewReset(struct ArrowArrayView* array_view);


### PR DESCRIPTION
This PR is one possible component to address #577. While in some cases we want a more relaxed comparison that allows (for example) arrays with the same content to be considered equal even if they have different content in null slots, in some cases we really do want an exact match. This PR adds `ArrowArrayViewCompare()` in such a way that the same signature could be used to apply the equality check at a more relaxed validation level when this is implemented in a future PR, but only implements the "identical" level since this is the easiest/most pressing (applies to IPC validation).

The messages given by the implementation give the location of the difference but not what the difference actually was. Knowing where the error was is usually sufficient for a higher level runtime (e.g., R, Python, C++) to give a fancier message if they want or need to.