### PR TITLE
chore: Remove valgrind suppression for R bindings after updated jsonlite release

### DIFF
--- a/valgrind.supp
+++ b/valgrind.supp
@@ -57,12 +57,3 @@
    fun:malloc
    fun:_PyObject_GC_NewVar
 }
-
-# Can be removed when https://github.com/jeroen/jsonlite/pull/442 is released
-{
-   <jsonlite>:Leak in base64_encode
-   Memcheck:Leak
-   ...
-   fun:base64_encode
-   fun:R_base64_encode
-}


### PR DESCRIPTION
This suppression was annotated "Can be removed when https://github.com/jeroen/jsonlite/pull/442 is released". This PR can serve as a placeholder for that until it is released