### PR TITLE
fix(ci): Fix verify, meson-build, and docker-build weekly runs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -90,7 +90,7 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker-compose build verify
+          docker compose build verify
 
       - name: Push
         if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/arrow-nanoarrow'}}
@@ -99,7 +99,7 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker-compose push ${{ matrix.config.service }}
+          docker compose push ${{ matrix.config.service }}
 
   # Build some arch-agnostic images for non-verify docker bits
   build-docker-manifest:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -90,7 +90,7 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker compose build verify
+          docker compose build verify || docker-compose build verify
 
       - name: Push
         if: ${{ github.event_name != 'pull_request' && github.repository == 'apache/arrow-nanoarrow'}}
@@ -99,7 +99,8 @@ jobs:
           NANOARROW_PLATFORM: ${{ matrix.config.platform }}
           DOCKER_DEFAULT_PLATFORM: "linux/${{ matrix.config.arch }}"
         run: |
-          docker compose push ${{ matrix.config.service }}
+          docker compose push ${{ matrix.config.service }} || \
+            docker-compose push ${{ matrix.config.service }}
 
   # Build some arch-agnostic images for non-verify docker bits
   build-docker-manifest:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(NANOARROW_IPC)
   # flatcc requires C11 for alignas() and static_assert() in flatcc_generated.h
   # It may be possible to use C99 mode to build the runtime and/or generated header
   # should this cause problems for users.
-  if(NOT DEFINED CMAKE_CXX_STANDARD)
+  if(NOT DEFINED CMAKE_C_STANDARD)
     set(CMAKE_C_STANDARD 11)
     set(CMAKE_C_STANDARD_REQUIRED ON)
   endif()
@@ -226,6 +226,10 @@ if(NANOARROW_IPC)
 endif()
 
 if(NANOARROW_IPC AND (NANOARROW_BUILD_INTEGRATION_TESTS OR NANOARROW_BUILD_TESTS))
+  if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  endif()
   add_executable(nanoarrow_ipc_integration src/nanoarrow/integration/ipc_integration.cc)
   target_include_directories(nanoarrow_ipc_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>

--- a/src/nanoarrow/ipc/encoder_test.cc
+++ b/src/nanoarrow/ipc/encoder_test.cc
@@ -31,7 +31,7 @@ struct ArrowIpcEncoderPrivate {
 }
 
 #define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
-static_assert(sizeof(NANOARROW_IPC_FILE_PADDED_MAGIC) == 8);
+static_assert(sizeof(NANOARROW_IPC_FILE_PADDED_MAGIC) == 8, "");
 
 TEST(NanoarrowIpcTest, NanoarrowIpcEncoderConstruction) {
   nanoarrow::ipc::UniqueEncoder encoder;


### PR DESCRIPTION
We have several errors in the weekly jobs:

- Some runners no longer have `docker-compose`, so we need to switch to `docker compose`.
- There was a missing `#include <stdio.h>` in `array.c`