### PR TITLE
fix: IPC streams did not include RecordBatch headers

### DIFF
--- a/src/nanoarrow/ipc/writer.c
+++ b/src/nanoarrow/ipc/writer.c
@@ -270,6 +270,10 @@ ArrowErrorCode ArrowIpcWriterWriteArrayView(struct ArrowIpcWriter* writer,
 
   NANOARROW_RETURN_NOT_OK(ArrowIpcEncoderEncodeSimpleRecordBatch(
       &private->encoder, in, &private->body_buffer, error));
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcEncoderFinalizeBuffer(&private->encoder, /*encapsulate=*/1,
+                                    &private->buffer),
+      error);
 
   NANOARROW_RETURN_NOT_OK(ArrowIpcOutputStreamWrite(
       &private->output_stream, ArrowBufferToBufferView(&private->buffer), error));


### PR DESCRIPTION
- As noted https://github.com/apache/arrow-nanoarrow/pull/571#discussion_r1712730976 RecordBatch Messages were not being written during IPC streaming. This has been corrected
- Testing uses one more round trip case where we have arrow C++ read from a stream written by nanoarrow.
- During testing it also became apparent that encapsulated messages were not always stored with the correct size; metadata_size should include padding (but not the continuation or size itself) https://arrow.apache.org/docs/format/Columnar.html#encapsulated-message-format