### PR TITLE
feat: Add IPC integration test executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,19 @@ if(NANOARROW_IPC)
           DESTINATION include/nanoarrow)
 endif()
 
+if(NANOARROW_IPC AND NANOARROW_BUILD_INTEGRATION_TESTS)
+  add_executable(nanoarrow_ipc_json_integration
+                 src/nanoarrow/ipc/json_integration.cc)
+  target_include_directories(nanoarrow_ipc_json_integration
+                             PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
+                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
+                                    $<INSTALL_INTERFACE:include>)
+  target_link_libraries(nanoarrow_ipc_json_integration
+                        PRIVATE nanoarrow_testing
+                                nanoarrow_ipc
+                                flatccrt)
+endif()
+
 if(NANOARROW_DEVICE)
   if(NANOARROW_DEVICE_WITH_METAL)
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/metal-cpp")
@@ -348,7 +361,8 @@ foreach(target
         nanoarrow_ipc
         nanoarrow_device
         nanoarrow_testing
-        nanoarrow_c_data_integration)
+        nanoarrow_c_data_integration
+        nanoarrow_ipc_json_integration)
   if(TARGET ${target})
     target_compile_definitions(${target} PUBLIC "$<$<CONFIG:Debug>:NANOARROW_DEBUG>")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,14 +225,14 @@ if(NANOARROW_IPC)
           DESTINATION include/nanoarrow)
 endif()
 
-if(NANOARROW_IPC AND NANOARROW_BUILD_INTEGRATION_TESTS)
-  add_executable(nanoarrow_ipc_json_integration src/nanoarrow/ipc/json_integration.cc)
-  target_include_directories(nanoarrow_ipc_json_integration
+if(NANOARROW_IPC AND (NANOARROW_BUILD_INTEGRATION_TESTS OR NANOARROW_BUILD_TESTS))
+  add_executable(nanoarrow_ipc_integration src/nanoarrow/integration/ipc_integration.cc)
+  target_include_directories(nanoarrow_ipc_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
-  target_link_libraries(nanoarrow_ipc_json_integration PRIVATE nanoarrow_testing
-                                                               nanoarrow_ipc flatccrt)
+  target_link_libraries(nanoarrow_ipc_integration PRIVATE nanoarrow_testing
+                                                          nanoarrow_ipc flatccrt gtest gmock)
 endif()
 
 if(NANOARROW_DEVICE)
@@ -522,6 +522,8 @@ if(NANOARROW_BUILD_TESTS)
     target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB
                           nanoarrow_coverage_config)
     target_link_libraries(nanoarrow_ipc_decoder_test gmock_main)
+
+    gtest_discover_tests(nanoarrow_ipc_integration)
   endif()
 
   if(NANOARROW_DEVICE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,11 +232,7 @@ if(NANOARROW_IPC AND (NANOARROW_BUILD_INTEGRATION_TESTS OR NANOARROW_BUILD_TESTS
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
   target_link_libraries(nanoarrow_ipc_integration
-                        PRIVATE nanoarrow_testing
-                                nanoarrow_ipc
-                                flatccrt
-                                gtest
-                                gmock
+                        PRIVATE nanoarrow_testing nanoarrow_ipc flatccrt
                                 nanoarrow_coverage_config)
 endif()
 
@@ -527,8 +523,6 @@ if(NANOARROW_BUILD_TESTS)
     target_link_libraries(nanoarrow_ipc_files_test nanoarrow_testing ZLIB::ZLIB
                           nanoarrow_coverage_config)
     target_link_libraries(nanoarrow_ipc_decoder_test gmock_main)
-
-    gtest_discover_tests(nanoarrow_ipc_integration)
   endif()
 
   if(NANOARROW_DEVICE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,16 +226,13 @@ if(NANOARROW_IPC)
 endif()
 
 if(NANOARROW_IPC AND NANOARROW_BUILD_INTEGRATION_TESTS)
-  add_executable(nanoarrow_ipc_json_integration
-                 src/nanoarrow/ipc/json_integration.cc)
+  add_executable(nanoarrow_ipc_json_integration src/nanoarrow/ipc/json_integration.cc)
   target_include_directories(nanoarrow_ipc_json_integration
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
-  target_link_libraries(nanoarrow_ipc_json_integration
-                        PRIVATE nanoarrow_testing
-                                nanoarrow_ipc
-                                flatccrt)
+  target_link_libraries(nanoarrow_ipc_json_integration PRIVATE nanoarrow_testing
+                                                               nanoarrow_ipc flatccrt)
 endif()
 
 if(NANOARROW_DEVICE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,8 +231,13 @@ if(NANOARROW_IPC AND (NANOARROW_BUILD_INTEGRATION_TESTS OR NANOARROW_BUILD_TESTS
                              PUBLIC $<BUILD_INTERFACE:${NANOARROW_BUILD_INCLUDE_DIR}>
                                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
                                     $<INSTALL_INTERFACE:include>)
-  target_link_libraries(nanoarrow_ipc_integration PRIVATE nanoarrow_testing
-                                                          nanoarrow_ipc flatccrt gtest gmock)
+  target_link_libraries(nanoarrow_ipc_integration
+                        PRIVATE nanoarrow_testing
+                                nanoarrow_ipc
+                                flatccrt
+                                gtest
+                                gmock
+                                nanoarrow_coverage_config)
 endif()
 
 if(NANOARROW_DEVICE)

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -149,14 +149,14 @@ struct ArrowArrayStream {
   NANOARROW_RETURN_NOT_OK((x_ <= max_) ? NANOARROW_OK : EINVAL)
 
 #if defined(NANOARROW_DEBUG)
-#define _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(NAME, EXPR, ERROR_PTR_EXPR, EXPR_STR) \
-  do {                                                                                 \
-    const int NAME = (EXPR);                                                           \
-    if (NAME) {                                                                        \
-      ArrowErrorSet((ERROR_PTR_EXPR), "%s failed with errno %d\n* %s:%d", EXPR_STR,    \
-                    NAME, __FILE__, __LINE__);                                         \
-      return NAME;                                                                     \
-    }                                                                                  \
+#define _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(NAME, EXPR, ERROR_PTR_EXPR, EXPR_STR)  \
+  do {                                                                                  \
+    const int NAME = (EXPR);                                                            \
+    if (NAME) {                                                                         \
+      ArrowErrorSet((ERROR_PTR_EXPR), "%s failed with errno %d(%s)\n* %s:%d", EXPR_STR, \
+                    NAME, strerror(NAME), __FILE__, __LINE__);                          \
+      return NAME;                                                                      \
+    }                                                                                   \
   } while (0)
 #else
 #define _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(NAME, EXPR, ERROR_PTR_EXPR, EXPR_STR) \

--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -62,46 +62,6 @@ ArrowErrorCode JsonToArrow(struct ArrowError*);
 ArrowErrorCode StreamToFile(struct ArrowError*);
 ArrowErrorCode FileToStream(struct ArrowError*);
 
-int main(int argc, char** argv) try {
-  std::string command = GetEnv("COMMAND");
-
-  ArrowErrorCode error_code;
-  struct ArrowError error;
-
-  if (command == "VALIDATE") {
-    std::cout << "Validating that " << GetEnv("ARROW_PATH") << " reads identical to "
-              << GetEnv("JSON_PATH") << std::endl;
-
-    error_code = Validate(&error);
-  } else if (command == "JSON_TO_ARROW") {
-    std::cout << "Producing " << GetEnv("ARROW_PATH") << " from " << GetEnv("JSON_PATH")
-              << std::endl;
-
-    error_code = JsonToArrow(&error);
-  } else if (command == "STREAM_TO_FILE") {
-    error_code = StreamToFile(&error);
-  } else if (command == "FILE_TO_STREAM") {
-    error_code = FileToStream(&error);
-  } else {
-    if (argc == 1 || argv[1] == std::string{"-h"} || argv[1] == std::string{"--help"}) {
-      // skip printing usage if for example --gtest_list_tests is used;
-      // that command obviously doesn't need the extra noise
-      std::cerr << kUsage;
-    }
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-  }
-
-  if (error_code != NANOARROW_OK) {
-    std::cerr << "Command " << command << " failed (" << error_code << "="
-              << strerror(error_code) << "): " << error.message << std::endl;
-  }
-  return error_code;
-} catch (std::exception const& e) {
-  std::cerr << "Uncaught exception: " << e.what() << std::endl;
-  return 1;
-}
-
 struct File {
   ~File() {
     if (file_ != nullptr) {
@@ -370,4 +330,44 @@ TEST(Integration, ErrorMessages) {
     EXPECT_THAT(std::string(error.message),
                 testing::HasSubstr("Expected file of more than 8 bytes, got 3"));
   }
+}
+
+int main(int argc, char** argv) try {
+  std::string command = GetEnv("COMMAND");
+
+  ArrowErrorCode error_code;
+  struct ArrowError error;
+
+  if (command == "VALIDATE") {
+    std::cout << "Validating that " << GetEnv("ARROW_PATH") << " reads identical to "
+              << GetEnv("JSON_PATH") << std::endl;
+
+    error_code = Validate(&error);
+  } else if (command == "JSON_TO_ARROW") {
+    std::cout << "Producing " << GetEnv("ARROW_PATH") << " from " << GetEnv("JSON_PATH")
+              << std::endl;
+
+    error_code = JsonToArrow(&error);
+  } else if (command == "STREAM_TO_FILE") {
+    error_code = StreamToFile(&error);
+  } else if (command == "FILE_TO_STREAM") {
+    error_code = FileToStream(&error);
+  } else {
+    if (argc == 1 || argv[1] == std::string{"-h"} || argv[1] == std::string{"--help"}) {
+      // skip printing usage if for example --gtest_list_tests is used;
+      // that command obviously doesn't need the extra noise
+      std::cerr << kUsage;
+    }
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+  }
+
+  if (error_code != NANOARROW_OK) {
+    std::cerr << "Command " << command << " failed (" << error_code << "="
+              << strerror(error_code) << "): " << error.message << std::endl;
+  }
+  return error_code;
+} catch (std::exception const& e) {
+  std::cerr << "Uncaught exception: " << e.what() << std::endl;
+  return 1;
 }

--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -23,6 +23,8 @@
 #include <nanoarrow/nanoarrow_ipc.hpp>
 #include <nanoarrow/nanoarrow_testing.hpp>
 
+#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
+
 std::string GetEnv(char const* name) {
   char const* val = std::getenv(name);
   return val ? val : "";

--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -123,8 +123,7 @@ struct File {
 
     size_t bytes_read = 0;
     while (bytes_read < contents.size()) {
-      bytes_read +=
-          fread(contents.data() + bytes_read, 1, contents.size() - bytes_read, file_);
+      bytes_read += fread(&contents[bytes_read], 1, contents.size() - bytes_read, file_);
     }
     return contents;
   }
@@ -370,4 +369,3 @@ TEST(Integration, ErrorMessages) {
                 testing::HasSubstr("Expected file of more than 8 bytes, got 3"));
   }
 }
-

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -662,8 +662,11 @@ ArrowErrorCode ArrowIpcEncoderEncodeFooter(struct ArrowIpcEncoder* encoder,
       ns(Footer_recordBatches_extend(builder, n_blocks));
   FLATCC_RETURN_IF_NULL(flatcc_RecordBatch_blocks, error);
   for (int64_t i = 0; i < n_blocks; i++) {
-    struct ns(Block) block = {blocks[i].offset, (int32_t)blocks[i].metadata_length,
-                              blocks[i].body_length};
+    struct ns(Block) block = {
+        blocks[i].offset,
+        blocks[i].metadata_length,
+        blocks[i].body_length,
+    };
     flatcc_RecordBatch_blocks[i] = block;
   }
   FLATCC_RETURN_UNLESS_0(Footer_recordBatches_end(builder), error);

--- a/src/nanoarrow/ipc/encoder_test.cc
+++ b/src/nanoarrow/ipc/encoder_test.cc
@@ -78,7 +78,8 @@ TEST(NanoarrowIpcTest, NanoarrowIpcFooterEncoding) {
   ASSERT_EQ(ArrowIpcEncoderInit(encoder.get()), NANOARROW_OK);
 
   nanoarrow::ipc::UniqueFooter footer;
-  ASSERT_EQ(ArrowSchemaInitFromType(&footer->schema, NANOARROW_TYPE_STRUCT), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInitFromType(&footer->schema, NANOARROW_TYPE_STRUCT),
+            NANOARROW_OK);
 
   nanoarrow::UniqueBuffer footer_buffer, raw_schema_buffer;
   struct ArrowError error;
@@ -86,16 +87,16 @@ TEST(NanoarrowIpcTest, NanoarrowIpcFooterEncoding) {
   EXPECT_EQ(ArrowIpcEncoderEncodeFooter(encoder.get(), footer.get(), &error),
             NANOARROW_OK)
       << error.message;
-  EXPECT_EQ(
-      ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false, footer_buffer.get()),
-      NANOARROW_OK);
+  EXPECT_EQ(ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false,
+                                          footer_buffer.get()),
+            NANOARROW_OK);
 
   EXPECT_EQ(ArrowIpcEncoderEncodeSchema(encoder.get(), &footer->schema, &error),
             NANOARROW_OK)
       << error.message;
-  EXPECT_EQ(
-      ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false, raw_schema_buffer.get()),
-      NANOARROW_OK);
+  EXPECT_EQ(ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false,
+                                          raw_schema_buffer.get()),
+            NANOARROW_OK);
 
   EXPECT_GT(footer_buffer->size_bytes, raw_schema_buffer->size_bytes);
 }

--- a/src/nanoarrow/ipc/encoder_test.cc
+++ b/src/nanoarrow/ipc/encoder_test.cc
@@ -30,6 +30,7 @@ struct ArrowIpcEncoderPrivate {
 };
 }
 
+#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
 static_assert(sizeof(NANOARROW_IPC_FILE_PADDED_MAGIC) == 8);
 
 TEST(NanoarrowIpcTest, NanoarrowIpcEncoderConstruction) {

--- a/src/nanoarrow/ipc/json_integration.cc
+++ b/src/nanoarrow/ipc/json_integration.cc
@@ -1,0 +1,406 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdlib>
+#include <fstream>
+
+#include <nanoarrow/nanoarrow_ipc.hpp>
+#include <nanoarrow/nanoarrow_testing.hpp>
+
+#include "flatcc/flatcc_builder.h"
+#include "nanoarrow/ipc/flatcc_generated.h"
+
+struct File {
+  File() = default;
+
+  ~File() {
+    if (file_ != nullptr) {
+      fclose(file_);
+    }
+  }
+
+  ArrowErrorCode open(std::string path, std::string mode,
+                      struct ArrowError* error) {
+    file_ = fopen(path.c_str(), mode.c_str());
+    if (file_ != nullptr) {
+      return NANOARROW_OK;
+    }
+    ArrowErrorSet(error, "Opening file '%s' failed with errno=%d", path.c_str(), errno);
+    return EINVAL;
+  }
+
+  operator FILE*() const { return file_; }
+
+  FILE* file_;
+};
+
+struct Table {
+  nanoarrow::UniqueSchema schema;
+  std::vector<nanoarrow::UniqueArray> batches;
+};
+
+std::string GetEnv(char const* name) {
+  if (char const* val = std::getenv(name)) {
+    return val;
+  }
+  return "";
+}
+
+constexpr char kPaddedMagic[8] = "ARROW1\0";
+
+std::string ReadFileIntoString(std::string const& path) {
+  std::ifstream stream{path};
+  std::string contents(stream.seekg(0, std::ios_base::end).tellg(), '\0');
+  stream.seekg(0).read(contents.data(), contents.size());
+  return contents;
+}
+
+ArrowErrorCode ReadTableFromArrayStream(struct ArrowArrayStream* stream, Table* table,
+                                        struct ArrowError* error) {
+  NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetSchema(stream, table->schema.get(), error));
+
+  while (true) {
+    nanoarrow::UniqueArray batch;
+    NANOARROW_RETURN_NOT_OK(ArrowArrayStreamGetNext(stream, batch.get(), error));
+    if (batch->release == nullptr) {
+      break;
+    }
+    table->batches.push_back(std::move(batch));
+  }
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode ReadTableFromJson(std::string const& json, Table* table,
+                                 struct ArrowError* error) {
+  nanoarrow::testing::TestingJSONReader reader;
+  nanoarrow::UniqueArrayStream array_stream;
+  NANOARROW_RETURN_NOT_OK(
+      reader.ReadDataFile(json, array_stream.get(), reader.kNumBatchReadAll, error));
+  return ReadTableFromArrayStream(array_stream.get(), table, error);
+}
+
+ArrowErrorCode ReadTableFromIpcFile(std::string const& path, Table* table,
+                                    struct ArrowError* error) {
+  // FIXME this API needs to be public; it's a bit smelly to pretend that we support
+  // reading files when this bespoke program is the only one which can do it
+  //
+  // For now: just check the first 8 bytes of the file and read a stream (ignoring the
+  // Footer).
+  File ipc_file;
+  NANOARROW_RETURN_NOT_OK(ipc_file.open(path, "rb", error));
+
+  char prefix[sizeof(kPaddedMagic)] = {};
+  if (fread(&prefix, 1, sizeof(prefix), ipc_file) < sizeof(prefix)) {
+    ArrowErrorSet(error, "Expected file of more than %lu bytes, got %ld", sizeof(prefix),
+                  ftell(ipc_file));
+    return EINVAL;
+  }
+
+  if (memcmp(&prefix, kPaddedMagic, sizeof(prefix)) != 0) {
+    ArrowErrorSet(error, "File did not begin with 'ARROW1\\0\\0'");
+    return EINVAL;
+  }
+
+  nanoarrow::ipc::UniqueInputStream input_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcInputStreamInitFile(input_stream.get(), ipc_file,
+                                  /*close_on_release=*/false),
+      error);
+
+  nanoarrow::UniqueArrayStream array_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcArrayStreamReaderInit(array_stream.get(), input_stream.get(),
+                                    /*options=*/nullptr),
+      error);
+
+  return ReadTableFromArrayStream(array_stream.get(), table, error);
+}
+
+ArrowErrorCode WriteTableAsStream(Table const& table,
+                                  struct ArrowIpcOutputStream* output_stream,
+                                  struct ArrowError* error,
+                                  struct ArrowBuffer* blocks = nullptr) {
+  nanoarrow::ipc::UniqueWriter writer;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowIpcWriterInit(writer.get(), output_stream),
+                                     error);
+
+  NANOARROW_RETURN_NOT_OK(
+      ArrowIpcWriterWriteSchema(writer.get(), table.schema.get(), error));
+
+  nanoarrow::UniqueArrayView array_view;
+  NANOARROW_RETURN_NOT_OK(
+      ArrowArrayViewInitFromSchema(array_view.get(), table.schema.get(), error));
+
+  for (const auto& batch : table.batches) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(array_view.get(), batch.get(), error));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowIpcWriterWriteArrayView(writer.get(), array_view.get(), error));
+  }
+
+  if (blocks != nullptr) {
+    struct ArrowIpcWriterPrivate {
+      struct ArrowIpcEncoder encoder;
+      struct ArrowIpcOutputStream output_stream;
+      struct ArrowBuffer buffer;
+      struct ArrowBuffer body_buffer;
+
+      int64_t offset;
+      struct ArrowBuffer blocks;
+    };
+    ArrowBufferMove(&static_cast<ArrowIpcWriterPrivate*>(writer->private_data)->blocks,
+                    blocks);
+  }
+
+  return ArrowIpcWriterWriteArrayView(writer.get(), nullptr, error);
+}
+
+ArrowErrorCode WriteTableToIpcFile(std::string const& path, Table const& table,
+                                   struct ArrowError* error) {
+  // FIXME this API needs to be public; it's a bit smelly to pretend that we support
+  // writing files when this bespoke program is the only one which can do it
+  //
+  // For now: just write the leading magic, the stream + EOS, and a manual Footer.
+  File ipc_file;
+  NANOARROW_RETURN_NOT_OK(ipc_file.open(path, "wb", error));
+
+  nanoarrow::ipc::UniqueOutputStream output_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcOutputStreamInitFile(output_stream.get(), ipc_file,
+                                   /*close_on_release=*/false),
+      error);
+
+  struct ArrowBufferView magic = {{kPaddedMagic}, sizeof(kPaddedMagic)};
+  NANOARROW_RETURN_NOT_OK(ArrowIpcOutputStreamWrite(output_stream.get(), magic, error));
+
+  nanoarrow::UniqueBuffer blocks;
+  NANOARROW_RETURN_NOT_OK(
+      WriteTableAsStream(table, output_stream.get(), error, blocks.get()));
+
+  nanoarrow::ipc::UniqueEncoder encoder;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowIpcEncoderInit(encoder.get()), error);
+
+#define ns(x) FLATBUFFERS_WRAP_NAMESPACE(org_apache_arrow_flatbuf, x)
+
+#define FLATCC_RETURN_UNLESS_0_NO_NS(x, error)                        \
+  if ((x) != 0) {                                                     \
+    ArrowErrorSet(error, "%s:%d: %s failed", __FILE__, __LINE__, #x); \
+    return ENOMEM;                                                    \
+  }
+
+#define FLATCC_RETURN_UNLESS_0(x, error) FLATCC_RETURN_UNLESS_0_NO_NS(ns(x), error)
+
+#define FLATCC_RETURN_IF_NULL(x, error)                                 \
+  if (!(x)) {                                                           \
+    ArrowErrorSet(error, "%s:%d: %s was null", __FILE__, __LINE__, #x); \
+    return ENOMEM;                                                      \
+  }
+
+  struct ArrowIpcEncoderPrivate {
+    flatcc_builder_t builder;
+    struct ArrowBuffer buffers;
+    struct ArrowBuffer nodes;
+    int encoding_footer;
+  };
+
+  auto* builder = &static_cast<ArrowIpcEncoderPrivate*>(encoder->private_data)->builder;
+
+  FLATCC_RETURN_UNLESS_0(Footer_start_as_root(builder), error);
+
+  FLATCC_RETURN_UNLESS_0(Footer_version_add(builder, ns(MetadataVersion_V5)), error);
+
+  static_cast<ArrowIpcEncoderPrivate*>(encoder->private_data)->encoding_footer = 1;
+  FLATCC_RETURN_UNLESS_0(Footer_schema_start(builder), error);
+  NANOARROW_RETURN_NOT_OK(
+      ArrowIpcEncoderEncodeSchema(encoder.get(), table.schema.get(), error));
+  FLATCC_RETURN_UNLESS_0(Footer_schema_end(builder), error);
+
+  auto* blocks_ptr = reinterpret_cast<struct ns(Block)*>(blocks->data);
+  int64_t n = blocks->size_bytes / sizeof(struct ns(Block));
+  for (int i = 0; i < n; i++) {
+    // Offsets were written relative to the stream, so we need to adjust them to account
+    // for the leading padded magic
+    blocks_ptr[i].offset += sizeof(kPaddedMagic);
+  }
+  FLATCC_RETURN_UNLESS_0(Footer_recordBatches_create(builder, blocks_ptr, n), error);
+
+  FLATCC_RETURN_IF_NULL(ns(Footer_end_as_root(builder)), error);
+
+  nanoarrow::UniqueBuffer footer_buffer;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false,
+                                    footer_buffer.get()),
+      error);
+
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcOutputStreamInitFile(output_stream.get(), ipc_file,
+                                   /*close_on_release=*/false),
+      error);
+
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowBufferAppendInt32(footer_buffer.get(),
+                             static_cast<int32_t>(footer_buffer->size_bytes)),
+      error);
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowBufferAppend(footer_buffer.get(), kPaddedMagic, strlen(kPaddedMagic)), error);
+
+  struct ArrowBufferView footer = {{footer_buffer->data}, footer_buffer->size_bytes};
+  NANOARROW_RETURN_NOT_OK(ArrowIpcOutputStreamWrite(output_stream.get(), footer, error));
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode Validate(struct ArrowError* error) {
+  auto json_path = GetEnv("JSON_PATH");
+  Table json_table;
+  NANOARROW_RETURN_NOT_OK(
+      ReadTableFromJson(ReadFileIntoString(json_path), &json_table, error));
+
+  auto arrow_path = GetEnv("ARROW_PATH");
+  Table arrow_table;
+  NANOARROW_RETURN_NOT_OK(ReadTableFromIpcFile(arrow_path, &arrow_table, error));
+
+  nanoarrow::testing::TestingJSONComparison comparison;
+  NANOARROW_RETURN_NOT_OK(
+      comparison.CompareSchema(arrow_table.schema.get(), json_table.schema.get(), error));
+  if (comparison.num_differences() != 0) {
+    std::stringstream differences;
+    comparison.WriteDifferences(differences);
+    ArrowErrorSet(error, "Found %d differences between schemas:\n%s\n",
+                  (int)comparison.num_differences(), differences.str().c_str());
+    return EINVAL;
+  }
+
+  if (arrow_table.batches.size() != json_table.batches.size()) {
+    ArrowErrorSet(error, "%s had %d batches but\n%s had %d batches\n",  //
+                  json_path.c_str(), (int)json_table.batches.size(),    //
+                  arrow_path.c_str(), (int)arrow_table.batches.size());
+    return EINVAL;
+  }
+
+  NANOARROW_RETURN_NOT_OK(comparison.SetSchema(arrow_table.schema.get(), error));
+  for (size_t i = 0; i < arrow_table.batches.size(); i++) {
+    const auto& json_batch = json_table.batches[i];
+    const auto& arrow_batch = arrow_table.batches[i];
+    NANOARROW_RETURN_NOT_OK(comparison.CompareBatch(arrow_batch.get(), json_batch.get(),
+                                                    error, "Batch " + std::to_string(i)));
+  }
+  if (comparison.num_differences() != 0) {
+    std::stringstream differences;
+    comparison.WriteDifferences(differences);
+    ArrowErrorSet(error, "Found %d differences between batches:\n%s\n",
+                  (int)comparison.num_differences(), differences.str().c_str());
+    return EINVAL;
+  }
+
+  return NANOARROW_OK;
+}
+
+ArrowErrorCode JsonToArrow(struct ArrowError* error) {
+  Table table;
+  NANOARROW_RETURN_NOT_OK(
+      ReadTableFromJson(ReadFileIntoString(GetEnv("JSON_PATH")), &table, error));
+  return WriteTableToIpcFile(GetEnv("ARROW_PATH"), table, error);
+}
+
+ArrowErrorCode StreamToFile(struct ArrowError* error) {
+  // wrap stdin into ArrowIpcInputStream
+  nanoarrow::ipc::UniqueInputStream input_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcInputStreamInitFile(input_stream.get(), stdin, /*close_on_release=*/true),
+      error);
+
+  nanoarrow::UniqueArrayStream array_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcArrayStreamReaderInit(array_stream.get(), input_stream.get(),
+                                    /*options=*/nullptr),
+      error);
+
+  Table table;
+  NANOARROW_RETURN_NOT_OK(ReadTableFromArrayStream(array_stream.get(), &table, error));
+  return WriteTableToIpcFile(GetEnv("ARROW_PATH"), table, error);
+}
+
+ArrowErrorCode FileToStream(struct ArrowError* error) {
+  Table table;
+  NANOARROW_RETURN_NOT_OK(ReadTableFromIpcFile(GetEnv("ARROW_PATH"), &table, error));
+
+  // wrap stdout into ArrowIpcOutputStream
+  nanoarrow::ipc::UniqueOutputStream output_stream;
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowIpcOutputStreamInitFile(output_stream.get(), stdout,
+                                   /*close_on_release=*/true),
+      error);
+
+  return WriteTableAsStream(table, output_stream.get(), error);
+}
+
+int main() try {
+  std::string command = GetEnv("COMMAND");
+
+  ArrowErrorCode error_code;
+  struct ArrowError error;
+  if (command == "VALIDATE") {
+    std::cout << "Validating that " << GetEnv("ARROW_PATH") << " reads identical to "
+              << GetEnv("JSON_PATH") << std::endl;
+
+    error_code = Validate(&error);
+  } else if (command == "JSON_TO_ARROW") {
+    std::cout << "Producing " << GetEnv("ARROW_PATH") << " from " << GetEnv("JSON_PATH")
+              << std::endl;
+
+    error_code = JsonToArrow(&error);
+  } else if (command == "STREAM_TO_FILE") {
+    error_code = StreamToFile(&error);
+  } else if (command == "FILE_TO_STREAM") {
+    error_code = FileToStream(&error);
+  } else {
+    std::cerr << R"(USAGE:
+  # assert that f.arrow reads identical to f.json
+  env COMMAND=VALIDATE    \
+      ARROW_PATH=f.arrow  \
+      JSON_PATH=f.json    \
+      nanoarrow_ipc_json_integration
+
+  # produce f.arrow from f.json
+  env COMMAND=JSON_TO_ARROW  \
+      ARROW_PATH=f.arrow     \
+      JSON_PATH=f.json       \
+      nanoarrow_ipc_json_integration
+
+  # copy f.stream into f.arrow
+  env COMMAND=STREAM_TO_FILE  \
+      ARROW_PATH=f.arrow      \
+      nanoarrow_ipc_json_integration < f.stream
+
+  # copy f.arrow into f.stream
+  env COMMAND=FILE_TO_STREAM  \
+      ARROW_PATH=f.arrow      \
+      nanoarrow_ipc_json_integration > f.stream
+)";
+    return EINVAL;
+  }
+
+  if (error_code != NANOARROW_OK) {
+    std::cerr << "Command " << command << " failed (" << error_code << "="
+              << strerror(error_code) << "): " << error.message << std::endl;
+  }
+  return error_code;
+} catch (std::exception const& e) {
+  std::cerr << "Uncaught exception: " << e.what() << std::endl;
+  return 1;
+}

--- a/src/nanoarrow/ipc/json_integration.cc
+++ b/src/nanoarrow/ipc/json_integration.cc
@@ -33,8 +33,7 @@ struct File {
     }
   }
 
-  ArrowErrorCode open(std::string path, std::string mode,
-                      struct ArrowError* error) {
+  ArrowErrorCode open(std::string path, std::string mode, struct ArrowError* error) {
     file_ = fopen(path.c_str(), mode.c_str());
     if (file_ != nullptr) {
       return NANOARROW_OK;

--- a/src/nanoarrow/ipc/reader.c
+++ b/src/nanoarrow/ipc/reader.c
@@ -79,6 +79,8 @@ static void ArrowIpcInputStreamBufferRelease(struct ArrowIpcInputStream* stream)
 
 ArrowErrorCode ArrowIpcInputStreamInitBuffer(struct ArrowIpcInputStream* stream,
                                              struct ArrowBuffer* input) {
+  NANOARROW_DCHECK(stream != NULL);
+
   struct ArrowIpcInputStreamBufferPrivate* private_data =
       (struct ArrowIpcInputStreamBufferPrivate*)ArrowMalloc(
           sizeof(struct ArrowIpcInputStreamBufferPrivate));
@@ -154,8 +156,9 @@ static ArrowErrorCode ArrowIpcInputStreamFileRead(struct ArrowIpcInputStream* st
 
 ArrowErrorCode ArrowIpcInputStreamInitFile(struct ArrowIpcInputStream* stream,
                                            void* file_ptr, int close_on_release) {
+  NANOARROW_DCHECK(stream != NULL);
   if (file_ptr == NULL) {
-    return EINVAL;
+    return errno ? errno : EINVAL;
   }
 
   struct ArrowIpcInputStreamFilePrivate* private_data =

--- a/src/nanoarrow/ipc/writer.c
+++ b/src/nanoarrow/ipc/writer.c
@@ -296,9 +296,10 @@ ArrowErrorCode ArrowIpcWriterWriteArrayView(struct ArrowIpcWriter* writer,
       error);
 
   if (private->writing_file) {
+    _NANOARROW_CHECK_RANGE(private->buffer.size_bytes, 0, INT32_MAX);
     struct ArrowIpcFileBlock block = {
         .offset = private->bytes_written,
-        .metadata_length = private->buffer.size_bytes,
+        .metadata_length = (int32_t) private->buffer.size_bytes,
         .body_length = private->body_buffer.size_bytes,
     };
     NANOARROW_RETURN_NOT_OK_WITH_ERROR(

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -417,6 +417,36 @@ ArrowErrorCode ArrowIpcArrayStreamReaderInit(
     struct ArrowArrayStream* out, struct ArrowIpcInputStream* input_stream,
     struct ArrowIpcArrayStreamReaderOptions* options);
 
+/// \brief The magic which appears at the beginning and end of an IPC file, 0-padded.
+#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
+
+/// \brief Represents a byte range in an IPC file.
+struct ArrowIpcFileBlock {
+  /// \brief offset relative to the first byte of the file.
+  int64_t offset;
+  /// \brief length of encapsulated metadata Message (including padding)
+  int64_t metadata_length;
+  /// \brief length of contiguous body buffers (including padding)
+  int64_t body_length;
+};
+
+/// \brief A Footer for use in an IPC file
+///
+/// This structure is intended to be allocated by the caller, initialized using
+/// ArrowIpcFooterInit(), and released with ArrowIpcFooterReset().
+struct ArrowIpcFooter {
+  /// \brief the Footer's embedded Schema
+  struct ArrowSchema schema;
+  /// \brief all blocks containing RecordBatch Messages
+  struct ArrowBuffer record_batch_blocks;
+};
+
+/// \brief Initialize a Footer
+void ArrowIpcFooterInit(struct ArrowIpcFooter* footer);
+
+/// \brief Release all resources attached to an footer
+void ArrowIpcFooterReset(struct ArrowIpcFooter* footer);
+
 /// \brief Encoder for Arrow IPC messages
 ///
 /// This structure is intended to be allocated by the caller,
@@ -461,6 +491,16 @@ ArrowErrorCode ArrowIpcEncoderEncodeSchema(struct ArrowIpcEncoder* encoder,
 ArrowErrorCode ArrowIpcEncoderEncodeSimpleRecordBatch(
     struct ArrowIpcEncoder* encoder, const struct ArrowArrayView* array_view,
     struct ArrowBuffer* body_buffer, struct ArrowError* error);
+
+/// \brief Encode a Footer for use in an IPC file
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+///
+/// Returns ENOMEM if allocation fails, NANOARROW_OK otherwise.
+ArrowErrorCode ArrowIpcEncoderEncodeFooter(struct ArrowIpcEncoder* encoder,
+                                           const struct ArrowIpcFooter* footer,
+                                           struct ArrowError* error);
 
 /// \brief An user-extensible output data sink
 struct ArrowIpcOutputStream {
@@ -552,6 +592,18 @@ ArrowErrorCode ArrowIpcWriterWriteArrayView(struct ArrowIpcWriter* writer,
 ArrowErrorCode ArrowIpcWriterWriteArrayStream(struct ArrowIpcWriter* writer,
                                               struct ArrowArrayStream* in,
                                               struct ArrowError* error);
+
+/// \brief Start writing an IPC file
+///
+/// Writes the Arrow IPC magic and sets the writer up to track written blocks.
+ArrowErrorCode ArrowIpcWriterStartFile(struct ArrowIpcWriter* writer,
+                                       struct ArrowError* error);
+
+/// \brief Finish writing an IPC file
+///
+/// Writes the IPC file's Footer, footer size, and ending magic.
+ArrowErrorCode ArrowIpcWriterFinalizeFile(struct ArrowIpcWriter* writer,
+                                          struct ArrowError* error);
 /// @}
 #ifdef __cplusplus
 }

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -81,6 +81,14 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterWriteArrayView)
 #define ArrowIpcWriterWriteArrayStream \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterWriteArrayStream)
+#define ArrowIpcWriterStartFile \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterStartFile)
+#define ArrowIpcWriterFinalizeFile \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcWriterFinalizeFile)
+#define ArrowIpcFooterInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcFooterInit)
+#define ArrowIpcFooterReset NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcFooterReset)
+#define ArrowIpcEncoderEncodeFooter \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowIpcEncoderEncodeFooter)
 
 #endif
 
@@ -567,12 +575,6 @@ ArrowErrorCode ArrowIpcWriterFinalizeFile(struct ArrowIpcWriter* writer,
 /// @}
 
 // Internal APIs:
-
-/// \brief The magic which appears at the beginning and end of an IPC file, 0-padded.
-///
-/// \warning This API is currently only public for use in integration testing;
-///          use at your own risk.
-#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
 
 /// \brief Represents a byte range in an IPC file.
 ///

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -417,36 +417,6 @@ ArrowErrorCode ArrowIpcArrayStreamReaderInit(
     struct ArrowArrayStream* out, struct ArrowIpcInputStream* input_stream,
     struct ArrowIpcArrayStreamReaderOptions* options);
 
-/// \brief The magic which appears at the beginning and end of an IPC file, 0-padded.
-#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
-
-/// \brief Represents a byte range in an IPC file.
-struct ArrowIpcFileBlock {
-  /// \brief offset relative to the first byte of the file.
-  int64_t offset;
-  /// \brief length of encapsulated metadata Message (including padding)
-  int64_t metadata_length;
-  /// \brief length of contiguous body buffers (including padding)
-  int64_t body_length;
-};
-
-/// \brief A Footer for use in an IPC file
-///
-/// This structure is intended to be allocated by the caller, initialized using
-/// ArrowIpcFooterInit(), and released with ArrowIpcFooterReset().
-struct ArrowIpcFooter {
-  /// \brief the Footer's embedded Schema
-  struct ArrowSchema schema;
-  /// \brief all blocks containing RecordBatch Messages
-  struct ArrowBuffer record_batch_blocks;
-};
-
-/// \brief Initialize a Footer
-void ArrowIpcFooterInit(struct ArrowIpcFooter* footer);
-
-/// \brief Release all resources attached to an footer
-void ArrowIpcFooterReset(struct ArrowIpcFooter* footer);
-
 /// \brief Encoder for Arrow IPC messages
 ///
 /// This structure is intended to be allocated by the caller,
@@ -491,16 +461,6 @@ ArrowErrorCode ArrowIpcEncoderEncodeSchema(struct ArrowIpcEncoder* encoder,
 ArrowErrorCode ArrowIpcEncoderEncodeSimpleRecordBatch(
     struct ArrowIpcEncoder* encoder, const struct ArrowArrayView* array_view,
     struct ArrowBuffer* body_buffer, struct ArrowError* error);
-
-/// \brief Encode a Footer for use in an IPC file
-///
-/// \warning This API is currently only public for use in integration testing;
-///          use at your own risk.
-///
-/// Returns ENOMEM if allocation fails, NANOARROW_OK otherwise.
-ArrowErrorCode ArrowIpcEncoderEncodeFooter(struct ArrowIpcEncoder* encoder,
-                                           const struct ArrowIpcFooter* footer,
-                                           struct ArrowError* error);
 
 /// \brief An user-extensible output data sink
 struct ArrowIpcOutputStream {
@@ -605,6 +565,64 @@ ArrowErrorCode ArrowIpcWriterStartFile(struct ArrowIpcWriter* writer,
 ArrowErrorCode ArrowIpcWriterFinalizeFile(struct ArrowIpcWriter* writer,
                                           struct ArrowError* error);
 /// @}
+
+// Internal APIs:
+
+/// \brief The magic which appears at the beginning and end of an IPC file, 0-padded.
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+#define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"
+
+/// \brief Represents a byte range in an IPC file.
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+struct ArrowIpcFileBlock {
+  /// \brief offset relative to the first byte of the file.
+  int64_t offset;
+  /// \brief length of encapsulated metadata Message (including padding)
+  int32_t metadata_length;
+  /// \brief length of contiguous body buffers (including padding)
+  int64_t body_length;
+};
+
+/// \brief A Footer for use in an IPC file
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+///
+/// This structure is intended to be allocated by the caller, initialized using
+/// ArrowIpcFooterInit(), and released with ArrowIpcFooterReset().
+struct ArrowIpcFooter {
+  /// \brief the Footer's embedded Schema
+  struct ArrowSchema schema;
+  /// \brief all blocks containing RecordBatch Messages
+  struct ArrowBuffer record_batch_blocks;
+};
+
+/// \brief Initialize a Footer
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+void ArrowIpcFooterInit(struct ArrowIpcFooter* footer);
+
+/// \brief Release all resources attached to an footer
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+void ArrowIpcFooterReset(struct ArrowIpcFooter* footer);
+
+/// \brief Encode a Footer for use in an IPC file
+///
+/// \warning This API is currently only public for use in integration testing;
+///          use at your own risk.
+///
+/// Returns ENOMEM if allocation fails, NANOARROW_OK otherwise.
+ArrowErrorCode ArrowIpcEncoderEncodeFooter(struct ArrowIpcEncoder* encoder,
+                                           const struct ArrowIpcFooter* footer,
+                                           struct ArrowError* error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nanoarrow/nanoarrow_ipc.hpp
+++ b/src/nanoarrow/nanoarrow_ipc.hpp
@@ -42,6 +42,22 @@ inline void release_pointer(struct ArrowIpcDecoder* data) {
 }
 
 template <>
+inline void init_pointer(struct ArrowIpcFooter* data) {
+  ArrowIpcFooterInit(data);
+}
+
+template <>
+inline void move_pointer(struct ArrowIpcFooter* src, struct ArrowIpcFooter* dst) {
+  ArrowSchemaMove(&src->schema, &dst->schema);
+  ArrowBufferMove(&src->record_batch_blocks, &dst->record_batch_blocks);
+}
+
+template <>
+inline void release_pointer(struct ArrowIpcFooter* data) {
+  ArrowIpcFooterReset(data);
+}
+
+template <>
 inline void init_pointer(struct ArrowIpcEncoder* data) {
   data->private_data = nullptr;
 }
@@ -127,6 +143,9 @@ namespace ipc {
 
 /// \brief Class wrapping a unique struct ArrowIpcDecoder
 using UniqueDecoder = internal::Unique<struct ArrowIpcDecoder>;
+
+/// \brief Class wrapping a unique struct ArrowIpcFooter
+using UniqueFooter = internal::Unique<struct ArrowIpcFooter>;
 
 /// \brief Class wrapping a unique struct ArrowIpcEncoder
 using UniqueEncoder = internal::Unique<struct ArrowIpcEncoder>;


### PR DESCRIPTION
- Adds a new executable for use with the archery integration tests
  - When reading files, it ignores the Footer entirely
  - A few private workarounds are added, most notably the stream writer tracks Blocks in order to populate the Footer
- Tested against patched archery https://github.com/apache/arrow/compare/main...bkietz:arrow:nanoarrow-integration-tests
  - issue to add nanoarrow to the tests https://github.com/apache/arrow/issues/43680