### PR TITLE
feat(python): Implement bindings to IPC writer

### DIFF
--- a/dev/benchmarks/python/ipc.py
+++ b/dev/benchmarks/python/ipc.py
@@ -43,12 +43,12 @@ class IpcReaderSuite:
         return os.path.join(self.fixtures_dir, name)
 
     def read_fixture_file(self, name):
-        with ipc.Stream.from_path(self.fixture_path(name)) as in_stream:
+        with ipc.InputStream.from_path(self.fixture_path(name)) as in_stream:
             list(na.c_array_stream(in_stream))
 
     def read_fixture_buffer(self, name):
         f = io.BytesIO(self.fixture_buffer[name])
-        with ipc.Stream.from_readable(f) as in_stream:
+        with ipc.InputStream.from_readable(f) as in_stream:
             list(na.c_array_stream(in_stream))
 
     def time_read_float64_basic_file(self):

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -17,7 +17,7 @@
 
 import itertools
 from functools import cached_property
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Union
 
 from nanoarrow._array import CArray, CArrayView
 from nanoarrow._array_stream import CMaterializedArrayStream
@@ -541,6 +541,20 @@ class Array(ArrayViewVisitable):
             "Use iter_scalar(), iter_py(), or iter_tuples() "
             "to iterate over elements of this Array"
         )
+
+    def serialize(self, dst=None) -> Union[bytes, None]:
+        from nanoarrow.ipc import Writer
+
+        if dst is None:
+            import io
+
+            with io.BytesIO() as dst:
+                writer = Writer.from_writable(dst)
+                writer.write(self, write_schema=False)
+                return dst.getvalue()
+        else:
+            writer = Writer.from_writable(dst)
+            writer.write(self, write_schema=False)
 
     def to_string(self, width_hint=80, items_hint=10) -> str:
         cls_name = _repr_utils.make_class_label(self, module="nanoarrow")

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -543,7 +543,7 @@ class Array(ArrayViewVisitable):
         )
 
     def serialize(self, dst=None) -> Union[bytes, None]:
-        """Write this Array into dst zero or more encapsulated IPC messages
+        """Write this Array into dst as zero or more encapsulated IPC messages
 
         Parameters
         ----------

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -550,11 +550,11 @@ class Array(ArrayViewVisitable):
 
             with io.BytesIO() as dst:
                 writer = Writer.from_writable(dst)
-                writer.write(self, write_schema=False)
+                writer.write_stream(self, write_schema=False)
                 return dst.getvalue()
         else:
             writer = Writer.from_writable(dst)
-            writer.write(self, write_schema=False)
+            writer.write_stream(self, write_schema=False)
 
     def to_string(self, width_hint=80, items_hint=10) -> str:
         cls_name = _repr_utils.make_class_label(self, module="nanoarrow")

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -552,17 +552,17 @@ class Array(ArrayViewVisitable):
             should be serialized. If omitted, this will create a ``io.BytesIO()``
             and return the serialized result.
         """
-        from nanoarrow.ipc import Writer
+        from nanoarrow.ipc import StreamWriter
 
         if dst is None:
             import io
 
             with io.BytesIO() as dst:
-                writer = Writer.from_writable(dst)
+                writer = StreamWriter.from_writable(dst)
                 writer.write_stream(self, write_schema=False)
                 return dst.getvalue()
         else:
-            writer = Writer.from_writable(dst)
+            writer = StreamWriter.from_writable(dst)
             writer.write_stream(self, write_schema=False)
 
     def to_string(self, width_hint=80, items_hint=10) -> str:

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -543,6 +543,15 @@ class Array(ArrayViewVisitable):
         )
 
     def serialize(self, dst=None) -> Union[bytes, None]:
+        """Write this Array into dst zero or more encapsulated IPC messages
+
+        Parameters
+        ----------
+        dst : file-like, optional
+            If present, a file-like object into which the chunks of this array
+            should be serialized. If omitted, this will create a ``io.BytesIO()``
+            and return the serialized result.
+        """
         from nanoarrow.ipc import Writer
 
         if dst is None:

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -219,9 +219,9 @@ class ArrayStream(ArrayViewVisitable):
         {'some_col': 2}
         {'some_col': 3}
         """
-        from nanoarrow.ipc import Stream
+        from nanoarrow.ipc import InputStream
 
-        with Stream.from_readable(obj) as ipc_stream:
+        with InputStream.from_readable(obj) as ipc_stream:
             return ArrayStream(ipc_stream)
 
     @staticmethod
@@ -246,9 +246,9 @@ class ArrayStream(ArrayViewVisitable):
         {'some_col': 2}
         {'some_col': 3}
         """
-        from nanoarrow.ipc import Stream
+        from nanoarrow.ipc import InputStream
 
-        with Stream.from_path(obj, *args, **kwargs) as ipc_stream:
+        with InputStream.from_path(obj, *args, **kwargs) as ipc_stream:
             return ArrayStream(ipc_stream)
 
     @staticmethod
@@ -275,7 +275,7 @@ class ArrayStream(ArrayViewVisitable):
         {'some_col': 2}
         {'some_col': 3}
         """
-        from nanoarrow.ipc import Stream
+        from nanoarrow.ipc import InputStream
 
-        with Stream.from_url(obj, *args, **kwargs) as ipc_stream:
+        with InputStream.from_url(obj, *args, **kwargs) as ipc_stream:
             return ArrayStream(ipc_stream)

--- a/python/src/nanoarrow/array_stream.py
+++ b/python/src/nanoarrow/array_stream.py
@@ -211,8 +211,8 @@ class ArrayStream(ArrayViewVisitable):
         Examples
         --------
         >>> import nanoarrow as na
-        >>> from nanoarrow.ipc import Stream
-        >>> with na.ArrayStream.from_readable(Stream.example_bytes()) as stream:
+        >>> from nanoarrow.ipc import InputStream
+        >>> with na.ArrayStream.from_readable(InputStream.example_bytes()) as stream:
         ...     stream.read_all()
         nanoarrow.Array<non-nullable struct<some_col: int32>>[3]
         {'some_col': 1}
@@ -233,11 +233,11 @@ class ArrayStream(ArrayViewVisitable):
         >>> import tempfile
         >>> import os
         >>> import nanoarrow as na
-        >>> from nanoarrow.ipc import Stream
+        >>> from nanoarrow.ipc import InputStream
         >>> with tempfile.TemporaryDirectory() as td:
         ...     path = os.path.join(td, "test.arrows")
         ...     with open(path, "wb") as f:
-        ...         nbytes = f.write(Stream.example_bytes())
+        ...         nbytes = f.write(InputStream.example_bytes())
         ...
         ...     with na.ArrayStream.from_path(path) as stream:
         ...         stream.read_all()
@@ -261,11 +261,11 @@ class ArrayStream(ArrayViewVisitable):
         >>> import tempfile
         >>> import os
         >>> import nanoarrow as na
-        >>> from nanoarrow.ipc import Stream
+        >>> from nanoarrow.ipc import InputStream
         >>> with tempfile.TemporaryDirectory() as td:
         ...     path = os.path.join(td, "test.arrows")
         ...     with open(path, "wb") as f:
-        ...         nbytes = f.write(Stream.example_bytes())
+        ...         nbytes = f.write(InputStream.example_bytes())
         ...
         ...     uri = pathlib.Path(path).as_uri()
         ...     with na.ArrayStream.from_url(uri) as stream:

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -272,13 +272,14 @@ class Writer:
         self._writer.write_end_of_stream()
         self.release()
 
-    def write(self, obj, schema=None):
+    def write(self, obj, schema=None, write_schema=True):
         if not self._is_valid():
             raise ValueError("Can't write to released Writer")
 
         with c_array_stream(obj, schema=schema) as stream:
             if self._iterator is None:
                 self._iterator = ArrayViewBaseIterator(stream._get_cached_schema())
+            if write_schema:
                 self._writer.write_schema(self._iterator._schema)
             for array in stream:
                 self._iterator._set_array(array)

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -243,7 +243,6 @@ class Stream:
 
 
 class Writer:
-
     def __init__(self):
         self._writer = None
         self._desc = None

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -243,7 +243,7 @@ class InputStream:
             return f"<{class_label} <invalid>>"
 
 
-class Writer:
+class StreamWriter:
     def __init__(self):
         self._writer = None
         self._desc = None
@@ -378,7 +378,7 @@ class Writer:
         {'some_col': 2}
         {'some_col': 3}
         """
-        out = Writer()
+        out = StreamWriter()
         stream = CIpcOutputStream.from_writable(obj, close_obj=False)
         out._desc = repr(obj)
 
@@ -424,7 +424,7 @@ class Writer:
         {'some_col': 2}
         {'some_col': 3}
         """
-        out = Writer()
+        out = StreamWriter()
         stream = CIpcOutputStream.from_writable(
             open(obj, "wb", *args, **kwargs), close_obj=True
         )

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -25,6 +25,7 @@ from nanoarrow._ipc_lib import (
     init_array_stream,
 )
 from nanoarrow._utils import obj_is_buffer
+from nanoarrow.array import c_array
 from nanoarrow.array_stream import c_array_stream
 from nanoarrow.iterator import ArrayViewBaseIterator
 
@@ -306,6 +307,21 @@ class StreamWriter:
 
         self._writer.write_end_of_stream()
         self.release()
+
+    def write_array(self, obj, schema=None, *, write_schema=None):
+        """Interpret obj as an array and write to stream
+
+        Parameters
+        ----------
+        obj : array-like
+            An array-like object as sanitized by :func:`c_array`.
+        schema : schema-like, optional
+            An optional schema, passed to :func:`c_array`.
+        write_schema : bool, optional
+            See :meth:`write_stream`.
+        """
+        obj = c_array(obj)
+        return self.write_stream(obj, schema, write_schema=write_schema)
 
     def write_stream(self, obj, schema=None, *, write_schema=None):
         """Interpret obj as a stream of arrays and write to stream

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -27,7 +27,6 @@ from nanoarrow._ipc_lib import (
 from nanoarrow._utils import obj_is_buffer
 from nanoarrow.array_stream import c_array_stream
 from nanoarrow.iterator import ArrayViewBaseIterator
-from nanoarrow.schema import c_schema
 
 from nanoarrow import _repr_utils
 

--- a/python/src/nanoarrow/ipc.py
+++ b/python/src/nanoarrow/ipc.py
@@ -124,8 +124,8 @@ class InputStream:
         """Wrap a local file as an IPC stream
 
         Wraps a pathlike object (specificially, one that can be passed to ``open()``)
-        as an owning InputStream. The file will be opened in binary mode and will be closed
-        when this stream or the resulting array stream is released.
+        as an owning InputStream. The file will be opened in binary mode and will be
+        closed when this stream or the resulting array stream is released.
 
         Parameters
         ----------
@@ -144,8 +144,8 @@ class InputStream:
         ...     with open(path, "wb") as f:
         ...         nbytes = f.write(InputStream.example_bytes())
         ...
-        ...     with InputStream.from_path(path) as inp, na.c_array_stream(inp) as stream:
-        ...         stream
+        ...     with InputStream.from_path(path) as inp, na.c_array_stream(inp) as s:
+        ...         s
         <nanoarrow.c_array_stream.CArrayStream>
         - get_schema(): struct<some_col: int32>
         """

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -470,6 +470,23 @@ class Schema:
         """
         return [self.field(i) for i in range(self.n_fields)]
 
+    def serialize(self, dst=None) -> Union[bytes, None]:
+        from nanoarrow.ipc import Writer
+        from nanoarrow.c_array_stream import CArrayStream
+
+        empty = CArrayStream.from_c_arrays([], self._c_schema, validate=False)
+
+        if dst is None:
+            import io
+
+            with io.BytesIO() as dst:
+                writer = Writer.from_writable(dst)
+                writer.write(empty)
+                return dst.getvalue()
+        else:
+            writer = Writer.from_writable(dst)
+            writer.write(empty)
+
     def __repr__(self) -> str:
         return _schema_repr(self)
 

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -472,6 +472,7 @@ class Schema:
 
     def serialize(self, dst=None) -> Union[bytes, None]:
         from nanoarrow.c_array_stream import CArrayStream
+
         from nanoarrow.ipc import Writer
 
         empty = CArrayStream.from_c_arrays([], self._c_schema, validate=False)

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -471,8 +471,8 @@ class Schema:
         return [self.field(i) for i in range(self.n_fields)]
 
     def serialize(self, dst=None) -> Union[bytes, None]:
-        from nanoarrow.ipc import Writer
         from nanoarrow.c_array_stream import CArrayStream
+        from nanoarrow.ipc import Writer
 
         empty = CArrayStream.from_c_arrays([], self._c_schema, validate=False)
 

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -471,6 +471,15 @@ class Schema:
         return [self.field(i) for i in range(self.n_fields)]
 
     def serialize(self, dst=None) -> Union[bytes, None]:
+        """Write this Schema into dst as an encapsulated IPC message
+
+        Parameters
+        ----------
+        dst : file-like, optional
+            If present, a file-like object into which the schema should be
+            serialized. If omitted, this will create a ``io.BytesIO()`` and
+            return the serialized result.
+        """
         from nanoarrow.c_array_stream import CArrayStream
 
         from nanoarrow.ipc import Writer

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -482,7 +482,7 @@ class Schema:
         """
         from nanoarrow.c_array_stream import CArrayStream
 
-        from nanoarrow.ipc import Writer
+        from nanoarrow.ipc import StreamWriter
 
         empty = CArrayStream.from_c_arrays([], self._c_schema, validate=False)
 
@@ -490,11 +490,11 @@ class Schema:
             import io
 
             with io.BytesIO() as dst:
-                writer = Writer.from_writable(dst)
+                writer = StreamWriter.from_writable(dst)
                 writer.write_stream(empty)
                 return dst.getvalue()
         else:
-            writer = Writer.from_writable(dst)
+            writer = StreamWriter.from_writable(dst)
             writer.write_stream(empty)
 
     def __repr__(self) -> str:

--- a/python/src/nanoarrow/schema.py
+++ b/python/src/nanoarrow/schema.py
@@ -482,11 +482,11 @@ class Schema:
 
             with io.BytesIO() as dst:
                 writer = Writer.from_writable(dst)
-                writer.write(empty)
+                writer.write_stream(empty)
                 return dst.getvalue()
         else:
             writer = Writer.from_writable(dst)
-            writer.write(empty)
+            writer.write_stream(empty)
 
     def __repr__(self) -> str:
         return _schema_repr(self)

--- a/python/tests/test_array_stream.py
+++ b/python/tests/test_array_stream.py
@@ -23,7 +23,7 @@ import tempfile
 import pytest
 
 import nanoarrow as na
-from nanoarrow.ipc import Stream
+from nanoarrow.ipc import InputStream
 
 
 def test_array_stream_iter():
@@ -120,7 +120,7 @@ def test_array_stream_context_manager():
 
 
 def test_array_stream_from_readable():
-    stream = na.ArrayStream.from_readable(Stream.example_bytes())
+    stream = na.ArrayStream.from_readable(InputStream.example_bytes())
     assert stream.schema.type == na.Type.STRUCT
     assert list(stream.read_all().iter_tuples()) == [(1,), (2,), (3,)]
 
@@ -129,7 +129,7 @@ def test_array_stream_from_path():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "test.arrows")
         with open(path, "wb") as f:
-            f.write(Stream.example_bytes())
+            f.write(InputStream.example_bytes())
 
         stream = na.ArrayStream.from_path(path)
         assert stream.schema.type == na.Type.STRUCT
@@ -140,7 +140,7 @@ def test_array_stream_from_url():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "test.arrows")
         with open(path, "wb") as f:
-            f.write(Stream.example_bytes())
+            f.write(InputStream.example_bytes())
 
         uri = pathlib.Path(path).as_uri()
         with na.ArrayStream.from_url(uri) as stream:

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -228,6 +228,6 @@ def test_writer_python_exception_on_write():
 
 
 def test_writer_error_on_write():
-    with pytest.raises(NanoarrowException, match="RecordBatches cannot be constructed"):
+    with pytest.raises(NanoarrowException):
         with Writer.from_writable(io.BytesIO()) as writer:
             writer.write_stream(na.c_array([], na.int32()))

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -125,7 +125,7 @@ def test_writer_from_writable():
 
     out = io.BytesIO()
     with StreamWriter.from_writable(out) as writer:
-        writer.write_stream(array)
+        writer.write_array(array)
 
     with na.ArrayStream.from_readable(out.getvalue()) as stream:
         assert stream.read_all().to_pylist() == na.Array(array).to_pylist()
@@ -143,7 +143,7 @@ def test_writer_from_path():
         path = os.path.join(td, "test.arrows")
 
         with StreamWriter.from_path(path) as writer:
-            writer.write_stream(array)
+            writer.write_array(array)
 
         with na.ArrayStream.from_path(path) as stream:
             assert stream.read_all().to_pylist() == na.Array(array).to_pylist()
@@ -175,13 +175,13 @@ def test_writer_write_stream_schema():
     with StreamWriter.from_writable(out) as writer:
         out.truncate(0)
         out.seek(0)
-        writer.write_stream(array, write_schema=False)
+        writer.write_array(array, write_schema=False)
         array_bytes = out.getvalue()
 
     with StreamWriter.from_writable(out) as writer:
         out.truncate(0)
         out.seek(0)
-        writer.write_stream(array, write_schema=True)
+        writer.write_array(array, write_schema=True)
         both_bytes = out.getvalue()
 
     assert (schema_bytes + array_bytes) == both_bytes
@@ -197,7 +197,7 @@ def test_writer_serialize_stream():
 
     out = io.BytesIO()
     with StreamWriter.from_writable(out) as writer:
-        writer.write_stream(array)
+        writer.write_array(array)
 
         # Check that we can't serialize after we've already written to stream
         with pytest.raises(ValueError, match="Can't serialize_stream"):

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -125,7 +125,7 @@ def test_writer_from_writable():
 
     out = io.BytesIO()
     with Writer.from_writable(out) as writer:
-        writer.write_all(array)
+        writer.write_stream(array)
 
     with na.ArrayStream.from_readable(out.getvalue()) as stream:
         assert stream.read_all().to_pylist() == na.Array(array).to_pylist()
@@ -141,7 +141,7 @@ def test_writer_from_writable():
 
     out = io.BytesIO()
     with Writer.from_writable(out) as writer:
-        writer.write_all(array)
+        writer.write_stream(array)
 
     with na.ArrayStream.from_readable(out.getvalue()) as stream:
         assert stream.read_all().to_pylist() == na.Array(array).to_pylist()
@@ -159,7 +159,7 @@ def test_writer_from_path():
         path = os.path.join(td, "test.arrows")
 
         with Writer.from_path(path) as writer:
-            writer.write_all(array)
+            writer.write_stream(array)
 
         with na.ArrayStream.from_path(path) as stream:
             assert stream.read_all().to_pylist() == na.Array(array).to_pylist()
@@ -178,4 +178,4 @@ def test_writer_python_exception_on_write():
 def test_writer_error_on_write():
     with pytest.raises(NanoarrowException, match="RecordBatches cannot be constructed"):
         with Writer.from_writable(io.BytesIO()) as writer:
-            writer.write(na.c_array([], na.int32()))
+            writer.write_stream(na.c_array([], na.int32()))

--- a/python/tests/test_ipc.py
+++ b/python/tests/test_ipc.py
@@ -24,18 +24,18 @@ import pytest
 from nanoarrow._utils import NanoarrowException
 
 import nanoarrow as na
-from nanoarrow.ipc import Stream, Writer
+from nanoarrow.ipc import InputStream, Writer
 
 
 def test_ipc_stream_example():
-    with Stream.example() as input:
+    with InputStream.example() as input:
         assert input._is_valid() is True
         assert "BytesIO object" in repr(input)
 
         stream = na.c_array_stream(input)
         assert input._is_valid() is False
         assert stream.is_valid() is True
-        assert repr(input) == "<nanoarrow.ipc.Stream <invalid>>"
+        assert repr(input) == "<nanoarrow.ipc.InputStream <invalid>>"
         with pytest.raises(RuntimeError, match="no longer valid"):
             stream = na.c_array_stream(input)
 
@@ -53,8 +53,8 @@ def test_ipc_stream_example():
 
 
 def test_ipc_stream_from_readable():
-    with io.BytesIO(Stream.example_bytes()) as f:
-        with Stream.from_readable(f) as input:
+    with io.BytesIO(InputStream.example_bytes()) as f:
+        with InputStream.from_readable(f) as input:
             assert input._is_valid() is True
             assert "BytesIO object" in repr(input)
 
@@ -68,9 +68,9 @@ def test_ipc_stream_from_path():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "test.arrows")
         with open(path, "wb") as f:
-            f.write(Stream.example_bytes())
+            f.write(InputStream.example_bytes())
 
-        with Stream.from_path(path) as input:
+        with InputStream.from_path(path) as input:
             assert repr(path) in repr(input)
             with na.c_array_stream(input) as stream:
                 batches = list(stream)
@@ -82,10 +82,10 @@ def test_ipc_stream_from_url():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, "test.arrows")
         with open(path, "wb") as f:
-            f.write(Stream.example_bytes())
+            f.write(InputStream.example_bytes())
 
         uri = pathlib.Path(path).as_uri()
-        with Stream.from_url(uri) as input:
+        with InputStream.from_url(uri) as input:
             with na.c_array_stream(input) as stream:
                 batches = list(stream)
                 assert len(batches) == 1
@@ -97,7 +97,7 @@ def test_ipc_stream_python_exception_on_read():
         def readinto(self, *args, **kwargs):
             raise RuntimeError("I error for all read requests")
 
-    input = Stream.from_readable(ExtraordinarilyInconvenientFile())
+    input = InputStream.from_readable(ExtraordinarilyInconvenientFile())
     with pytest.raises(
         NanoarrowException, match="RuntimeError: I error for all read requests"
     ):
@@ -105,8 +105,8 @@ def test_ipc_stream_python_exception_on_read():
 
 
 def test_ipc_stream_error_on_read():
-    with io.BytesIO(Stream.example_bytes()[:100]) as f:
-        with Stream.from_readable(f) as input:
+    with io.BytesIO(InputStream.example_bytes()[:100]) as f:
+        with InputStream.from_readable(f) as input:
 
             with pytest.raises(
                 NanoarrowException,

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -244,3 +244,18 @@ def test_schema_extension():
 def test_schema_alias_constructor():
     schema = na.schema(na.Type.INT32)
     assert isinstance(schema, na.Schema)
+
+
+def test_schema_serialize():
+    import io
+
+    schema = na.struct({"some_col": na.int32()}, nullable=False)
+
+    serialized = schema.serialize()
+    schema_roundtrip = na.ArrayStream.from_readable(serialized).schema
+    assert repr(schema_roundtrip) == repr(schema)
+
+    out = io.BytesIO()
+    schema.serialize(out)
+    schema_roundtrip = na.ArrayStream.from_readable(out.getvalue()).schema
+    assert repr(schema_roundtrip) == repr(schema)


### PR DESCRIPTION
This PR implements bindings to the IPC writer in the nanoarrow C library. This adds:

- An `ipc.StreamWriter()` class roughly mirroring pyarrow's `ipc.Stream()`
- `Schema.serialize()` and `Array.serialize()` to match pyarrow's `serialize()` methods.

```python
import io
import nanoarrow as na 
from nanoarrow.ipc import StreamWriter, InputStream

out = io.BytesIO()
writer = StreamWriter.from_writable(out)
writer.write_stream(InputStream.example())

na.Array(InputStream.from_readable(out.getvalue()))
#> nanoarrow.Array<non-nullable struct<some_col: int32>>[3]
#> {'some_col': 1}
#> {'some_col': 2}
#> {'some_col': 3}
```

