### PR TITLE
fix: don't require metadata order in nanoarrow_ipc_integration

### DIFF
--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -257,6 +257,7 @@ ArrowErrorCode Validate(struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK(arrow_table.FromIpcFile(arrow_path, error));
 
   nanoarrow::testing::TestingJSONComparison comparison;
+  comparison.set_compare_metadata_order(false);
   NANOARROW_RETURN_NOT_OK(
       comparison.CompareSchema(arrow_table.schema.get(), json_table.schema.get(), error));
   if (comparison.num_differences() != 0) {


### PR DESCRIPTION
Minor patch to the integration executable; Java produces IPC files with potentially reordered metadata: https://github.com/apache/arrow/actions/runs/10410485727/job/28832431571?pr=43715#step:9:9093