### PR TITLE
fix: Silence warning when compiling nanoarrow.hpp on at least one version of MSVC

### DIFF
--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -844,6 +844,8 @@ class ViewArrayStream {
  public:
   ViewArrayStream(ArrowArrayStream* stream, ArrowErrorCode* code, ArrowError* error)
       : code_{code}, error_{error} {
+    // Using a slightly more verbose constructor to silence a warning that occurs
+    // on some versions of MSVC.
     range_.next.self = this;
     range_.next.stream = stream;
   }

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -843,7 +843,10 @@ class ViewArrayAsFixedSizeBytes {
 class ViewArrayStream {
  public:
   ViewArrayStream(ArrowArrayStream* stream, ArrowErrorCode* code, ArrowError* error)
-      : range_{Next{this, stream, UniqueArray()}}, code_{code}, error_{error} {}
+      : code_{code}, error_{error} {
+    range_.next.self = this;
+    range_.next.stream = stream;
+  }
 
   ViewArrayStream(ArrowArrayStream* stream, ArrowError* error)
       : ViewArrayStream{stream, &internal_code_, error} {}


### PR DESCRIPTION
Encountered in an ADBC build:

https://github.com/apache/arrow-adbc/actions/runs/10424783996/job/28874300812#step:10:830

```
D:\a\arrow-adbc\arrow-adbc\adbc\c\vendor\nanoarrow\nanoarrow.hpp(829,21): warning C4355: 'this': used in base member initializer list [D:\a\arrow-adbc\arrow-adbc\adbc\build\driver\framework\adbc_driver_framework.vcxproj]
```