### PR TITLE
fix: Ensure that schema metadata is always present even if empty

### DIFF
--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -257,6 +257,7 @@ ArrowErrorCode Validate(struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK(arrow_table.FromIpcFile(arrow_path, error));
 
   nanoarrow::testing::TestingJSONComparison comparison;
+  comparison.set_compare_metadata_order(false);
   NANOARROW_RETURN_NOT_OK(
       comparison.CompareSchema(arrow_table.schema.get(), json_table.schema.get(), error));
   if (comparison.num_differences() != 0) {

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -428,13 +428,13 @@ static ArrowErrorCode ArrowIpcEncodeSchema(flatcc_builder_t* builder,
                                                &ns(Schema_fields_push_end), error));
   FLATCC_RETURN_UNLESS_0(Schema_fields_end(builder), error);
 
+  FLATCC_RETURN_UNLESS_0(Schema_custom_metadata_start(builder), error);
   if (schema->metadata) {
-    FLATCC_RETURN_UNLESS_0(Schema_custom_metadata_start(builder), error);
     NANOARROW_RETURN_NOT_OK(
         ArrowIpcEncodeMetadata(builder, schema, &ns(Schema_custom_metadata_push_start),
                                &ns(Schema_custom_metadata_push_end), error));
-    FLATCC_RETURN_UNLESS_0(Schema_custom_metadata_end(builder), error);
   }
+  FLATCC_RETURN_UNLESS_0(Schema_custom_metadata_end(builder), error);
 
   FLATCC_RETURN_UNLESS_0(Schema_features_start(builder), error);
   FLATCC_RETURN_UNLESS_0(Schema_features_end(builder), error);


### PR DESCRIPTION
An absent Schema.custom_metadata was causing flatcc to produce invalid flatbuffers on s390x. For now, just populate that field with an empty vector