### PR TITLE
test: Fix meson build and clean up some warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -194,7 +194,7 @@ if get_option('tests')
       ipc_test_files = {
           'ipc-decoder': {
               'src': 'decoder',
-              'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep],
+              'deps': [nanoarrow_ipc_dep, arrow_dep, gtest_dep, gmock_dep],
               'timeout': 30,
           },
           'ipc-reader': {

--- a/src/nanoarrow/common/buffer_test.cc
+++ b/src/nanoarrow/common/buffer_test.cc
@@ -137,6 +137,8 @@ TEST(BufferTest, BufferTestMove) {
 }
 
 TEST(BufferTest, BufferTestFill) {
+  EXPECT_EQ(ArrowBufferAppendFill(NULL, 0, 0), NANOARROW_OK);
+
   struct ArrowBuffer buffer;
   ArrowBufferInit(&buffer);
 

--- a/src/nanoarrow/common/inline_buffer.h
+++ b/src/nanoarrow/common/inline_buffer.h
@@ -289,11 +289,11 @@ static inline ArrowErrorCode ArrowBufferAppendBufferView(struct ArrowBuffer* buf
 
 static inline ArrowErrorCode ArrowBufferAppendFill(struct ArrowBuffer* buffer,
                                                    uint8_t value, int64_t size_bytes) {
-  NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, size_bytes));
-
   if (size_bytes == 0) {
     return NANOARROW_OK;
   }
+
+  NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, size_bytes));
 
   memset(buffer->data + buffer->size_bytes, value, size_bytes);
   buffer->size_bytes += size_bytes;

--- a/src/nanoarrow/common/inline_buffer.h
+++ b/src/nanoarrow/common/inline_buffer.h
@@ -291,6 +291,10 @@ static inline ArrowErrorCode ArrowBufferAppendFill(struct ArrowBuffer* buffer,
                                                    uint8_t value, int64_t size_bytes) {
   NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, size_bytes));
 
+  if (size_bytes == 0) {
+    return NANOARROW_OK;
+  }
+
   memset(buffer->data + buffer->size_bytes, value, size_bytes);
   buffer->size_bytes += size_bytes;
   return NANOARROW_OK;

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -472,16 +472,16 @@ TEST_P(ArrowTypeParameterizedTestFixture, NanoarrowIpcArrowTypeRoundtrip) {
 }
 
 std::string ArrowSchemaMetadataToString(const char* metadata) {
-  struct ArrowMetadataReader reader;
+  struct ArrowMetadataReader reader {};
   auto st = ArrowMetadataReaderInit(&reader, metadata);
-  NANOARROW_DCHECK(st == NANOARROW_OK);
+  EXPECT_EQ(st, NANOARROW_OK);
 
   bool comma = false;
   std::string out;
   while (reader.remaining_keys > 0) {
     struct ArrowStringView key, value;
     auto st = ArrowMetadataReaderRead(&reader, &key, &value);
-    NANOARROW_DCHECK(st == NANOARROW_OK);
+    EXPECT_EQ(st, NANOARROW_OK);
     if (comma) {
       out += ", ";
     }


### PR DESCRIPTION
The meson build is broken without this dependency. Also fixed up a few warnings around unused variables and the use of uninitialized struct members