### PR TITLE
fix: ensure 1 is written for boolean True

### DIFF
--- a/src/nanoarrow/integration/ipc_integration.cc
+++ b/src/nanoarrow/integration/ipc_integration.cc
@@ -32,26 +32,26 @@ constexpr auto kUsage = R"(USAGE:
   env COMMAND=VALIDATE    \
       ARROW_PATH=f.arrow  \
       JSON_PATH=f.json    \
-      nanoarrow_ipc_json_integration
+      nanoarrow_ipc_integration
 
   # produce f.arrow from f.json
   env COMMAND=JSON_TO_ARROW  \
       ARROW_PATH=f.arrow     \
       JSON_PATH=f.json       \
-      nanoarrow_ipc_json_integration
+      nanoarrow_ipc_integration
 
   # copy f.stream into f.arrow
   env COMMAND=STREAM_TO_FILE  \
       ARROW_PATH=f.arrow      \
-      nanoarrow_ipc_json_integration < f.stream
+      nanoarrow_ipc_integration < f.stream
 
   # copy f.arrow into f.stream
   env COMMAND=FILE_TO_STREAM  \
       ARROW_PATH=f.arrow      \
-      nanoarrow_ipc_json_integration > f.stream
+      nanoarrow_ipc_integration > f.stream
 
   # run all internal test cases
-  nanoarrow_ipc_json_integration
+  nanoarrow_ipc_integration
 )";
 
 ArrowErrorCode Validate(struct ArrowError*);

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1046,9 +1046,11 @@ ArrowErrorCode ArrowIpcDecoderVerifyHeader(struct ArrowIpcDecoder* decoder,
   }
 
   // Run flatbuffers verification
-  if (ns(Message_verify_as_root(data.data.as_uint8, message_body_size) !=
-         flatcc_verify_ok)) {
-    ArrowErrorSet(error, "Message flatbuffer verification failed");
+  enum flatcc_verify_error_no verify_error =
+      ns(Message_verify_as_root(data.data.as_uint8, message_body_size);
+         if (verify_error != flatcc_verify_ok)) {
+    ArrowErrorSet(error, "Message flatbuffer verification failed (%d) %s",
+                  (int)verify_error, flatcc_verify_error_string(verify_error));
     return EINVAL;
   }
 
@@ -1123,9 +1125,11 @@ ArrowErrorCode ArrowIpcDecoderVerifyFooter(struct ArrowIpcDecoder* decoder,
       data.data.as_uint8 + data.size_bytes - footer_and_size_and_magic_size;
 
   // Run flatbuffers verification
-  if (ns(Footer_verify_as_root(footer_data, decoder->header_size_bytes) !=
-         flatcc_verify_ok)) {
-    ArrowErrorSet(error, "Footer flatbuffer verification failed");
+  enum flatcc_verify_error_no verify_error =
+      ns(Footer_verify_as_root(footer_data, decoder->header_size_bytes));
+  if (verify_error != flatcc_verify_ok) {
+    ArrowErrorSet(error, "Footer flatbuffer verification failed (%d) %s",
+                  (int)verify_error, flatcc_verify_error_string(verify_error));
     return EINVAL;
   }
 

--- a/src/nanoarrow/ipc/encoder.c
+++ b/src/nanoarrow/ipc/encoder.c
@@ -380,8 +380,8 @@ static ArrowErrorCode ArrowIpcEncodeField(flatcc_builder_t* builder,
                                           const struct ArrowSchema* schema,
                                           struct ArrowError* error) {
   FLATCC_RETURN_UNLESS_0(Field_name_create_str(builder, schema->name), error);
-  FLATCC_RETURN_UNLESS_0(Field_nullable_add(builder, schema->flags & ARROW_FLAG_NULLABLE),
-                         error);
+  FLATCC_RETURN_UNLESS_0(
+      Field_nullable_add(builder, (schema->flags & ARROW_FLAG_NULLABLE) != 0), error);
 
   struct ArrowSchemaView schema_view;
   NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));


### PR DESCRIPTION
During encoding, `Field.nullable` was not coerced to 0 or 1 (I was expecting `flatcc` to do that). However the Go reader recognizes anything other than `Field.nullable == 1` as a non-nullable field
https://github.com/google/flatbuffers/issues/8389

some typos and better error messages are included