### PR TITLE
chore(ci): Use setup-python action on self-hosted arm64 runner

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -106,7 +106,6 @@ jobs:
           fetch-tags: true
 
       - uses: actions/setup-python@v5
-        if: matrix.config.label != 'linux-arm64'
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
This fixes the python-wheels action (failing on main).