### PR TITLE
fix: Ensure footer test passes on big endian

### DIFF
--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1288,9 +1288,9 @@ ArrowErrorCode ArrowIpcDecoderDecodeFooter(struct ArrowIpcDecoder* decoder,
   struct ArrowIpcFileBlock* record_batches =
       (struct ArrowIpcFileBlock*)private_data->footer.record_batch_blocks.data;
   for (int64_t i = 0; i < n; i++) {
-    record_batches[i].offset = blocks[i].offset;
-    record_batches[i].metadata_length = blocks[i].metaDataLength;
-    record_batches[i].body_length = blocks[i].bodyLength;
+    record_batches[i].offset = ns(Block_offset(blocks + i));
+    record_batches[i].metadata_length = ns(Block_metaDataLength(blocks + i));
+    record_batches[i].body_length = ns(Block_bodyLength(blocks + i));
   }
 
   decoder->footer = &private_data->footer;

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -1012,11 +1012,6 @@ TEST_P(ArrowSchemaParameterizedTestFixture, NanoarrowIpcNanoarrowFooterRoundtrip
   memcpy(&roundtripped_block, decoder->footer->record_batch_blocks.data,
          sizeof(roundtripped_block));
 
-#ifdef __BIG_ENDIAN__
-  roundtripped_block.offset = bswap64(roundtripped_block.offset);
-  roundtripped_block.metadata_length = bswap32(roundtripped_block.metadata_length);
-  roundtripped_block.body_length = bswap64(roundtripped_block.body_length);
-#endif
   EXPECT_EQ(roundtripped_block.offset, dummy_block.offset);
   EXPECT_EQ(roundtripped_block.metadata_length, dummy_block.metadata_length);
   EXPECT_EQ(roundtripped_block.body_length, dummy_block.body_length);

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -984,7 +984,13 @@ TEST_P(ArrowSchemaParameterizedTestFixture, NanoarrowIpcNanoarrowFooterRoundtrip
   EXPECT_EQ(
       ArrowIpcEncoderFinalizeBuffer(encoder.get(), /*encapsulate=*/false, buffer.get()),
       NANOARROW_OK);
+
+#ifdef __BIG_ENDIAN__
+  uint32_t footer_size_le = bswap32(static_cast<int32_t>(buffer->size_bytes));
+  EXPECT_EQ(ArrowBufferAppendInt32(buffer.get(), footer_size_le), NANOARROW_OK);
+#else
   EXPECT_EQ(ArrowBufferAppendInt32(buffer.get(), buffer->size_bytes), NANOARROW_OK);
+#endif
   EXPECT_EQ(ArrowBufferAppendStringView(buffer.get(), "ARROW1"_asv), NANOARROW_OK);
 
   struct ArrowBufferView buffer_view;
@@ -1005,6 +1011,12 @@ TEST_P(ArrowSchemaParameterizedTestFixture, NanoarrowIpcNanoarrowFooterRoundtrip
   struct ArrowIpcFileBlock roundtripped_block;
   memcpy(&roundtripped_block, decoder->footer->record_batch_blocks.data,
          sizeof(roundtripped_block));
+
+#ifdef __BIG_ENDIAN__
+  roundtripped_block.offset = bswap64(roundtripped_block.offset);
+  roundtripped_block.metadata_length = bswap32(roundtripped_block.metadata_length);
+  roundtripped_block.body_length = bswap64(roundtripped_block.body_length);
+#endif
   EXPECT_EQ(roundtripped_block.offset, dummy_block.offset);
   EXPECT_EQ(roundtripped_block.metadata_length, dummy_block.metadata_length);
   EXPECT_EQ(roundtripped_block.body_length, dummy_block.body_length);

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -986,7 +986,7 @@ TEST_P(ArrowSchemaParameterizedTestFixture, NanoarrowIpcNanoarrowFooterRoundtrip
       NANOARROW_OK);
 
 #ifdef __BIG_ENDIAN__
-  uint32_t footer_size_le = bswap32(static_cast<int32_t>(buffer->size_bytes));
+  uint32_t footer_size_le = bswap32(static_cast<uint32_t>(buffer->size_bytes));
   EXPECT_EQ(ArrowBufferAppendInt32(buffer.get(), footer_size_le), NANOARROW_OK);
 #else
   EXPECT_EQ(ArrowBufferAppendInt32(buffer.get(), buffer->size_bytes), NANOARROW_OK);


### PR DESCRIPTION
This PR fixes the verification run failure for big endian, which is currently failing on the `NanoarrowIpcNanoarrowFooterRoundtrip` tests. Checked with:

```bash
export NANOARROW_ARCH=s390x
docker compose run --rm verify
```