### PR TITLE
chore(ci): Update library installs for self-hosted CUDA runner

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -59,17 +59,13 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y valgrind
 
-      # The self-hosted runner for CUDA does not have cmake preinstalled.
-      # We need at least CMake 3.17 for FindCUDAToolkit.
-      - name: Ensure CMake
+      # The self-hosted runner for CUDA needs a number of packages installed that
+      # are already installed on the GitHub runner
+      - name: Install build dependencies
         if: matrix.config.label == 'with-cuda'
         run: |
-          mkdir tmp_cmake && cd tmp_cmake
-          CMAKE_VERSION="3.22.1"
-          curl -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz |
-            tar -zxf -
-          CMAKE_PATH=$(find $(pwd) -name "bin")
-          echo "PATH=${CMAKE_PATH}:${PATH}" >> $GITHUB_ENV
+          sudo apt-get update && \
+            sudo apt-get install -y cmake build-essential cuda-toolkit tzdata
           # Debug install location of cuda toolkit
           ldconfig -p | grep libcuda
 
@@ -82,7 +78,7 @@ jobs:
           # The self-hosted runner needs its own Arrow build since it is running
           # a much older linux distribution. When the Arrow C++ requirement for tests is
           # dropped, we don't have to use this at all as part of the CI configuration.
-          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-1
+          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-2
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
@@ -154,6 +150,7 @@ jobs:
         run: |
           cd python
           python3 -m pip install ".[test]" -vv
+          python3 -m pip install cupy-cuda12x
 
       - name: Test Python bindings with CUDA
         if: matrix.config.label == 'with-cuda'


### PR DESCRIPTION
The self-hosted CUDA runner was updated and contains a different set of packages than the old one. A few updates required!