### PR TITLE
chore(ci): Use ARCHERY_INTEGRATION_TEST_TARGET_LANGUAGES to reduce integration test matrix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       dockerfile: ci/docker/integration.dockerfile
     volumes:
       - ${NANOARROW_DOCKER_SOURCE_DIR}:/arrow-integration/nanoarrow
+    environment:
+      ARCHERY_INTEGRATION_TARGET_LANGUAGES: "nanoarrow"
     command:
       ["echo '::group::Build nanoarrow' &&
         conda run --no-capture-output /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&


### PR DESCRIPTION
Thanks to https://github.com/apache/arrow/issues/44062 , we can run fewer jobs in our integration test matrix (and benefit from better GitHub actions grouping!).