### PR TITLE
chore: Update valgrind suppressions after internal flatcc update

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verification
+name: verify
 
 on:
   push:

--- a/src/nanoarrow/ipc/writer.c
+++ b/src/nanoarrow/ipc/writer.c
@@ -350,8 +350,8 @@ ArrowErrorCode ArrowIpcWriterWriteArrayStream(struct ArrowIpcWriter* writer,
   struct ArrowArrayView array_view;
   ArrowArrayViewInitFromType(&array_view, NANOARROW_TYPE_UNINITIALIZED);
 
-  NANOARROW_RETURN_NOT_OK(ArrowIpcWriterWriteArrayStreamImpl(writer, in, &schema, &array,
-                                                             &array_view, error));
+  ArrowErrorCode result =
+      ArrowIpcWriterWriteArrayStreamImpl(writer, in, &schema, &array, &array_view, error);
 
   if (schema.release != NULL) {
     ArrowSchemaRelease(&schema);
@@ -362,7 +362,8 @@ ArrowErrorCode ArrowIpcWriterWriteArrayStream(struct ArrowIpcWriter* writer,
   }
 
   ArrowArrayViewReset(&array_view);
-  return NANOARROW_OK;
+
+  return result;
 }
 
 #define NANOARROW_IPC_FILE_PADDED_MAGIC "ARROW1\0"

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -66,10 +66,3 @@
    fun:base64_encode
    fun:R_base64_encode
 }
-
-# TODO https://github.com/apache/arrow-nanoarrow/issues/579 remove this
-{
-   <flatcc>:flatcc uses realloc() and valgrind thinks something was free'd
-   Memcheck:Addr4
-   fun:flatcc_builder_create_cached_vtable
-}


### PR DESCRIPTION
Also fixes a leak that was identified by the R bindings to the IPC writer.

Closes #579 (apparently the flatcc update was sufficient to eliminate the suppression!)