### PR TITLE
fix: Improve validation of offset buffers for sliced arrays

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,6 +25,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/integration.yaml
+      - ci/docker/integration.dockerfile
       - docker-compose.yml
   schedule:
     - cron: '5 0 * * 0'

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -42,7 +42,8 @@ ENV ARROW_RUST_EXE_PATH=/build/rust/debug
 ENV BUILD_DOCS_CPP=OFF
 
 # Clone the arrow monorepo
-RUN git clone https://github.com/apache/arrow.git /arrow-integration --recurse-submodules
+RUN git clone https://github.com/bkietz/arrow.git /arrow-integration --recurse-submodules && \
+    cd /arrow-integration && git switch nanoarrow-integration-tests
 
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -42,8 +42,7 @@ ENV ARROW_RUST_EXE_PATH=/build/rust/debug
 ENV BUILD_DOCS_CPP=OFF
 
 # Clone the arrow monorepo
-RUN git clone https://github.com/bkietz/arrow.git /arrow-integration --recurse-submodules && \
-    cd /arrow-integration && git switch nanoarrow-integration-tests
+RUN git clone https://github.com/apache/arrow.git /arrow-integration --recurse-submodules
 
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     volumes:
       - ${NANOARROW_DOCKER_SOURCE_DIR}:/arrow-integration/nanoarrow
     environment:
-      ARCHERY_INTEGRATION_TARGET_LANGUAGES: "nanoarrow"
+      ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS: "nanoarrow"
     command:
       ["echo '::group::Build nanoarrow' &&
         conda run --no-capture-output /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -998,6 +998,11 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
         }
 
         last_offset = array_view->buffer_views[1].data.as_int32[offset_plus_length];
+        if (last_offset < 0) {
+          ArrowErrorSet(error, "Expected last offset >= 0 but found %" PRId64,
+                        last_offset);
+          return EINVAL;
+        }
 
         // If the data buffer size is unknown, assign it; otherwise, check it
         if (array_view->buffer_views[2].size_bytes == -1) {
@@ -1029,6 +1034,11 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
         }
 
         last_offset = array_view->buffer_views[1].data.as_int64[offset_plus_length];
+        if (first_offset < 0) {
+          ArrowErrorSet(error, "Expected last offset >= 0 but found %" PRId64,
+                        last_offset);
+          return EINVAL;
+        }
 
         // If the data buffer size is unknown, assign it; otherwise, check it
         if (array_view->buffer_views[2].size_bytes == -1) {
@@ -1073,6 +1083,12 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
         }
 
         last_offset = array_view->buffer_views[1].data.as_int32[offset_plus_length];
+        if (last_offset < 0) {
+          ArrowErrorSet(error, "Expected last offset >= 0 but found %" PRId64,
+                        last_offset);
+          return EINVAL;
+        }
+
         if (array_view->children[0]->length < last_offset) {
           ArrowErrorSet(error,
                         "Expected child of %s array to have length >= %" PRId64
@@ -1095,6 +1111,12 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
         }
 
         last_offset = array_view->buffer_views[1].data.as_int64[offset_plus_length];
+        if (last_offset < 0) {
+          ArrowErrorSet(error, "Expected last offset >= 0 but found %" PRId64,
+                        last_offset);
+          return EINVAL;
+        }
+
         if (array_view->children[0]->length < last_offset) {
           ArrowErrorSet(error,
                         "Expected child of large list array to have length >= %" PRId64

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1034,7 +1034,7 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
         }
 
         last_offset = array_view->buffer_views[1].data.as_int64[offset_plus_length];
-        if (first_offset < 0) {
+        if (last_offset < 0) {
           ArrowErrorSet(error, "Expected last offset >= 0 but found %" PRId64,
                         last_offset);
           return EINVAL;

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -990,7 +990,7 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_BINARY:
       if (array_view->buffer_views[1].size_bytes != 0) {
-        first_offset = array_view->buffer_views[1].data.as_int32[0];
+        first_offset = array_view->buffer_views[1].data.as_int32[array_view->offset];
         if (first_offset < 0) {
           ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
                         first_offset);
@@ -1021,7 +1021,7 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_LARGE_STRING:
     case NANOARROW_TYPE_LARGE_BINARY:
       if (array_view->buffer_views[1].size_bytes != 0) {
-        first_offset = array_view->buffer_views[1].data.as_int64[0];
+        first_offset = array_view->buffer_views[1].data.as_int64[array_view->offset];
         if (first_offset < 0) {
           ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
                         first_offset);
@@ -1065,7 +1065,7 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
     case NANOARROW_TYPE_LIST:
     case NANOARROW_TYPE_MAP:
       if (array_view->buffer_views[1].size_bytes != 0) {
-        first_offset = array_view->buffer_views[1].data.as_int32[0];
+        first_offset = array_view->buffer_views[1].data.as_int32[array_view->offset];
         if (first_offset < 0) {
           ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
                         first_offset);
@@ -1087,7 +1087,7 @@ static int ArrowArrayViewValidateDefault(struct ArrowArrayView* array_view,
 
     case NANOARROW_TYPE_LARGE_LIST:
       if (array_view->buffer_views[1].size_bytes != 0) {
-        first_offset = array_view->buffer_views[1].data.as_int64[0];
+        first_offset = array_view->buffer_views[1].data.as_int64[array_view->offset];
         if (first_offset < 0) {
           ArrowErrorSet(error, "Expected first offset >= 0 but found %" PRId64,
                         first_offset);

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1256,15 +1256,13 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
           struct ArrowBufferView offset_minimal;
           offset_minimal.data.as_int32 =
               array_view->buffer_views[i].data.as_int32 + array_view->offset;
-          offset_minimal.size_bytes =
-              (array_view->offset + array_view->length + 1) * sizeof(int32_t);
+          offset_minimal.size_bytes = (array_view->length + 1) * sizeof(int32_t);
           NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt32(offset_minimal, error));
         } else if (array_view->length > 0) {
           struct ArrowBufferView offset_minimal;
           offset_minimal.data.as_int64 =
               array_view->buffer_views[i].data.as_int64 + array_view->offset;
-          offset_minimal.size_bytes =
-              (array_view->offset + array_view->length + 1) * sizeof(int64_t);
+          offset_minimal.size_bytes = (array_view->length + 1) * sizeof(int64_t);
           NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt64(offset_minimal, error));
         }
         break;

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1274,13 +1274,16 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
       // Only validate the portion of the buffer that is strictly required,
       // which includes not validating the offset buffer of a zero-length array.
       case NANOARROW_BUFFER_TYPE_DATA_OFFSET:
-        if (array_view->layout.element_size_bits[i] == 32 && array_view->length > 0) {
+        if (array_view->length == 0) {
+          continue;
+        }
+        if (array_view->layout.element_size_bits[i] == 32) {
           struct ArrowBufferView offset_minimal;
           offset_minimal.data.as_int32 =
               array_view->buffer_views[i].data.as_int32 + array_view->offset;
           offset_minimal.size_bytes = (array_view->length + 1) * sizeof(int32_t);
           NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt32(offset_minimal, error));
-        } else if (array_view->length > 0) {
+        } else {
           struct ArrowBufferView offset_minimal;
           offset_minimal.data.as_int64 =
               array_view->buffer_views[i].data.as_int64 + array_view->offset;

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -2256,6 +2256,10 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, 0);
   EXPECT_EQ(array_view.buffer_views[2].size_bytes, 0);
 
+  // This should pass validation even if all buffers are empty
+  ASSERT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK);
+
   ArrowArrayViewSetLength(&array_view, 5);
   EXPECT_EQ(array_view.buffer_views[0].size_bytes, 1);
   EXPECT_EQ(array_view.buffer_views[1].size_bytes, (5 + 1) * sizeof(int64_t));
@@ -2304,16 +2308,40 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
   int64_t* offsets =
       const_cast<int64_t*>(reinterpret_cast<const int64_t*>(array.buffers[1]));
 
-  offsets[0] = -1;
-  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), EINVAL);
-  EXPECT_STREQ(error.message, "Expected first offset >= 0 but found -1");
-  offsets[0] = 0;
+  // For a sliced array, this can still pass validation
+  array.offset = 1;
+  array.length = array_view.length - 1;
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK);
 
+  // Check for negative element sizes
+  array.offset = 0;
+  array.length = array.length + 1;
+  offsets[0] = 0;
   offsets[1] = -1;
   EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
             EINVAL);
   EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
+
+  // Sliced array should also fail validation because the first element is negative
+  array.offset = 0;
+  array.length = array_view.length + 1;
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            EINVAL);
+  EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
+
+  // Check sequential offsets whose diff causes overflow
+  array.offset = 0;
+  array.length = array.length + 1;
+  offsets[1] = 2080374784;
+  offsets[2] = INT_MIN;
+  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            EINVAL);
+  EXPECT_STREQ(error.message, "[2] Expected element size >= 0");
 
   ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -2306,7 +2306,7 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
   ASSERT_EQ(ArrowBufferAppendInt64(ArrowArrayBuffer(&array, 1), 0), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppendInt64(ArrowArrayBuffer(&array, 1), 4), NANOARROW_OK);
   ASSERT_EQ(ArrowBufferAppendInt64(ArrowArrayBuffer(&array, 1), 7), NANOARROW_OK);
-  ASSERT_EQ(ArrowBufferReserve(ArrowArrayBuffer(&array, 2), 4), NANOARROW_OK);
+  ASSERT_EQ(ArrowBufferReserve(ArrowArrayBuffer(&array, 2), 7), NANOARROW_OK);
   ArrowBufferAppendUnsafe(ArrowArrayBuffer(&array, 2), "abcd", 4);
   ArrowBufferAppendUnsafe(ArrowArrayBuffer(&array, 2), "efg", 3);
   array.length = 2;

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -2337,16 +2337,6 @@ TEST(ArrayTest, ArrayViewTestLargeString) {
             EINVAL);
   EXPECT_STREQ(error.message, "[1] Expected element size >= 0");
 
-  // Check sequential offsets whose diff causes overflow
-  array.offset = 0;
-  array.length = array.length + 1;
-  offsets[1] = 2080374784;
-  offsets[2] = INT_MIN;
-  EXPECT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewValidate(&array_view, NANOARROW_VALIDATION_LEVEL_FULL, &error),
-            EINVAL);
-  EXPECT_STREQ(error.message, "[2] Expected element size >= 0");
-
   ArrowArrayRelease(&array);
   ArrowArrayViewReset(&array_view);
 }


### PR DESCRIPTION
This PR updates validation of offset buffers in string/binary, large string/binary, list, and large list types such that portions of the buffers not strictly required by the slice referenced by `offset` and `length` are not accessed/validated. This came up in the IPC integration tests because C# exports full buffers rather than the portions of buffers strictly required.

This highlights how our test suite would benefit from helpers to reduce repetition (although I'd prefer to handle that at a later time if possible).