### PR TITLE
fix: Only validate relevant type_ids for array view slice

### DIFF
--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -1278,17 +1278,17 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
           continue;
         }
         if (array_view->layout.element_size_bits[i] == 32) {
-          struct ArrowBufferView offset_minimal;
-          offset_minimal.data.as_int32 =
+          struct ArrowBufferView sliced_offsets;
+          sliced_offsets.data.as_int32 =
               array_view->buffer_views[i].data.as_int32 + array_view->offset;
-          offset_minimal.size_bytes = (array_view->length + 1) * sizeof(int32_t);
-          NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt32(offset_minimal, error));
+          sliced_offsets.size_bytes = (array_view->length + 1) * sizeof(int32_t);
+          NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt32(sliced_offsets, error));
         } else {
-          struct ArrowBufferView offset_minimal;
-          offset_minimal.data.as_int64 =
+          struct ArrowBufferView sliced_offsets;
+          sliced_offsets.data.as_int64 =
               array_view->buffer_views[i].data.as_int64 + array_view->offset;
-          offset_minimal.size_bytes = (array_view->length + 1) * sizeof(int64_t);
-          NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt64(offset_minimal, error));
+          sliced_offsets.size_bytes = (array_view->length + 1) * sizeof(int64_t);
+          NANOARROW_RETURN_NOT_OK(ArrowAssertIncreasingInt64(sliced_offsets, error));
         }
         break;
       default:
@@ -1298,13 +1298,13 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
 
   if (array_view->storage_type == NANOARROW_TYPE_DENSE_UNION ||
       array_view->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
-    struct ArrowBufferView type_ids;
-    type_ids.size_bytes = array_view->length * sizeof(int8_t);
+    struct ArrowBufferView sliced_type_ids;
+    sliced_type_ids.size_bytes = array_view->length * sizeof(int8_t);
     if (array_view->length > 0) {
-      type_ids.data.as_int8 =
+      sliced_type_ids.data.as_int8 =
           array_view->buffer_views[0].data.as_int8 + array_view->offset;
     } else {
-      type_ids.data.as_int8 = NULL;
+      sliced_type_ids.data.as_int8 = NULL;
     }
 
     if (array_view->union_type_id_map == NULL) {
@@ -1317,11 +1317,12 @@ static int ArrowArrayViewValidateFull(struct ArrowArrayView* array_view,
     } else if (_ArrowParsedUnionTypeIdsWillEqualChildIndices(
                    array_view->union_type_id_map, array_view->n_children,
                    array_view->n_children)) {
-      NANOARROW_RETURN_NOT_OK(
-          ArrowAssertRangeInt8(type_ids, 0, (int8_t)(array_view->n_children - 1), error));
+      NANOARROW_RETURN_NOT_OK(ArrowAssertRangeInt8(
+          sliced_type_ids, 0, (int8_t)(array_view->n_children - 1), error));
     } else {
-      NANOARROW_RETURN_NOT_OK(ArrowAssertInt8In(
-          type_ids, array_view->union_type_id_map + 128, array_view->n_children, error));
+      NANOARROW_RETURN_NOT_OK(ArrowAssertInt8In(sliced_type_ids,
+                                                array_view->union_type_id_map + 128,
+                                                array_view->n_children, error));
     }
   }
 

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -770,7 +770,7 @@ static inline int8_t ArrowArrayViewUnionTypeId(const struct ArrowArrayView* arra
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_DENSE_UNION:
     case NANOARROW_TYPE_SPARSE_UNION:
-      return array_view->buffer_views[0].data.as_int8[i];
+      return array_view->buffer_views[0].data.as_int8[array_view->offset + i];
     default:
       return -1;
   }
@@ -790,9 +790,9 @@ static inline int64_t ArrowArrayViewUnionChildOffset(
     const struct ArrowArrayView* array_view, int64_t i) {
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_DENSE_UNION:
-      return array_view->buffer_views[1].data.as_int32[i];
+      return array_view->buffer_views[1].data.as_int32[array_view->offset + i];
     case NANOARROW_TYPE_SPARSE_UNION:
-      return i;
+      return array_view->offset + i;
     default:
       return -1;
   }


### PR DESCRIPTION
Similar to #626 but for union type_id arrays. This should fix the two remaining failures in the integration tests between the IPC implementations in the Arrow repository and the nanoarrow IPC implementation https://github.com/apache/arrow/pull/43715.