### PR TITLE
feat(r): Allow opt-out of warning for unregistered extension types

### DIFF
--- a/r/R/convert-array.R
+++ b/r/R/convert-array.R
@@ -24,6 +24,10 @@
 #' dispatching on `to`: developers may implement their own S3 methods for
 #' custom vector types.
 #'
+#' Note that unregistered extension types will by default issue a warning.
+#' Use `options(nanoarrow.warn_unregistered_extension = FALSE)` to disable
+#' this behaviour.
+#'
 #' @param array A [nanoarrow_array][as_nanoarrow_array].
 #' @param to A target prototype object describing the type to which `array`
 #'   should be converted, or `NULL` to use the default conversion as

--- a/r/R/extension.R
+++ b/r/R/extension.R
@@ -164,6 +164,12 @@ nanoarrow_extension_array <- function(storage_array, extension_name,
 }
 
 warn_unregistered_extension_type <- function(x) {
+  # Allow an opt-out of this warning for consumers that don't have
+  # control over their source and want to drop unknown extensions
+  if (!getOption("nanoarrow.warn_unregistered_extension", TRUE)) {
+    return()
+  }
+
   # Warn that we're about to ignore an extension type
   if (!is.null(x$name) && !identical(x$name, "")) {
     warning(

--- a/r/R/extension.R
+++ b/r/R/extension.R
@@ -171,22 +171,21 @@ warn_unregistered_extension_type <- function(x) {
   }
 
   # Warn that we're about to ignore an extension type
+  message <- sprintf(
+    paste0(
+      "Converting unknown extension %s as storage type\n",
+      "Disable warning with ",
+      "options(nanoarrow.warn_unregistered_extension = FALSE)"
+    ),
+    nanoarrow_schema_formatted(x)
+  )
+
+  # Add the field name if we know it
   if (!is.null(x$name) && !identical(x$name, "")) {
-    warning(
-      sprintf(
-        "%s: Converting unknown extension %s as storage type",
-        x$name,
-        nanoarrow_schema_formatted(x)
-      )
-    )
-  } else {
-    warning(
-      sprintf(
-        "Converting unknown extension %s as storage type",
-        nanoarrow_schema_formatted(x)
-      )
-    )
+    message <- paste0(x$name, ": ", message)
   }
+
+  warning(message)
 }
 
 # Mutable registry to look up extension specifications

--- a/r/man/convert_array.Rd
+++ b/r/man/convert_array.Rd
@@ -28,6 +28,10 @@ dispatching on \code{to}: developers may implement their own S3 methods for
 custom vector types.
 }
 \details{
+Note that unregistered extension types will by default issue a warning.
+Use \code{options(nanoarrow.warn_unregistered_extension = FALSE)} to disable
+this behaviour.
+
 Conversions are implemented for the following R vector types:
 \itemize{
 \item \code{\link[=logical]{logical()}}: Any numeric type can be converted to \code{\link[=logical]{logical()}} in addition

--- a/r/tests/testthat/test-extension.R
+++ b/r/tests/testthat/test-extension.R
@@ -127,15 +127,23 @@ test_that("as_nanoarrow_array() dispatches on registered extension spec", {
 })
 
 test_that("inferring the type of an unregistered extension warns", {
+  unknown_extension <- na_extension(na_int32(), "definitely not registered")
   expect_warning(
-    infer_nanoarrow_ptype(na_extension(na_int32(), "definitely not registered")),
+    infer_nanoarrow_ptype(unknown_extension),
     "Converting unknown extension"
+  )
+
+  # Check that warning contains a field name if present
+  struct_with_unknown_ext <- na_struct(list(some_col = unknown_extension))
+  expect_warning(
+    infer_nanoarrow_ptype(struct_with_unknown_ext),
+    "some_col: Converting unknown extension"
   )
 
   previous_opts <- options(nanoarrow.warn_unregistered_extension = FALSE)
   on.exit(options(previous_opts))
   expect_warning(
-    infer_nanoarrow_ptype(na_extension(na_int32(), "definitely not registered")),
+    infer_nanoarrow_ptype(unknown_extension),
     NA
   )
 })

--- a/r/tests/testthat/test-extension.R
+++ b/r/tests/testthat/test-extension.R
@@ -126,6 +126,20 @@ test_that("as_nanoarrow_array() dispatches on registered extension spec", {
   )
 })
 
+test_that("inferring the type of an unregistered extension warns", {
+  expect_warning(
+    infer_nanoarrow_ptype(na_extension(na_int32(), "definitely not registered")),
+    "Converting unknown extension"
+  )
+
+  previous_opts <- options(nanoarrow.warn_unregistered_extension = FALSE)
+  on.exit(options(previous_opts))
+  expect_warning(
+    infer_nanoarrow_ptype(na_extension(na_int32(), "definitely not registered")),
+    NA
+  )
+})
+
 test_that("extensions can infer a schema of a nanoarrow_vctr() subclass", {
   register_nanoarrow_extension(
     "some_ext",


### PR DESCRIPTION
Closes #631.

``` r
# Using pak::pak("apache/arrow-nanoarrow/r#632")
library(nanoarrow)
array <- as_nanoarrow_array(data.frame(x = 1:5, y = letters[1:5]))
array$children$z <- nanoarrow_extension_array(letters[1:5], "some_extension")

# warns!
tibble::as_tibble(array)
#> Warning in warn_unregistered_extension_type(x): z: Converting unknown extension
#> some_extension{string} as storage type
#> Warning in warn_unregistered_extension_type(storage): z: Converting unknown
#> extension some_extension{string} as storage type
#> # A tibble: 5 × 3
#>       x y     z    
#>   <int> <chr> <chr>
#> 1     1 a     a    
#> 2     2 b     b    
#> 3     3 c     c    
#> 4     4 d     d    
#> 5     5 e     e

# doesn't!
options(nanoarrow.warn_unregistered_extension = FALSE)
tibble::as_tibble(array)
#> # A tibble: 5 × 3
#>       x y     z    
#>   <int> <chr> <chr>
#> 1     1 a     a    
#> 2     2 b     b    
#> 3     3 c     c    
#> 4     4 d     d    
#> 5     5 e     e
```

<sup>Created on 2024-09-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>