### PR TITLE
fix; Properly ingest Binary View types without variadic buffers

### DIFF
--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -115,7 +115,7 @@ static ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
       break;
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
-      array->n_buffers = NANOARROW_BINARY_VIEW_FIXED_BUFFERS;
+      array->n_buffers = NANOARROW_BINARY_VIEW_FIXED_BUFFERS + 1;
       break;
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_LARGE_STRING:

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -765,11 +765,9 @@ static int ArrowArrayViewSetArrayInternal(struct ArrowArrayView* array_view,
     const int32_t nfixed_buf = NANOARROW_BINARY_VIEW_FIXED_BUFFERS;
 
     const int32_t nvariadic_buf = (int32_t)(n_buffers - nfixed_buf - 1);
-    if (nvariadic_buf > 0) {
-      array_view->n_variadic_buffers = nvariadic_buf;
-      buffers_required += nvariadic_buf + 1;
-      array_view->variadic_buffer_sizes = (int64_t*)array->buffers[n_buffers - 1];
-    }
+    array_view->n_variadic_buffers = nvariadic_buf;
+    buffers_required += nvariadic_buf + 1;
+    array_view->variadic_buffer_sizes = (int64_t*)array->buffers[n_buffers - 1];
   }
 
   if (buffers_required != array->n_buffers) {

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -895,9 +895,9 @@ TEST(ArrayTest, ArrayTestAppendToLargeStringArray) {
   ArrowArrayRelease(&array);
 }
 
-template <enum ArrowType ArrowT, typename ValueT,
-          ArrowErrorCode (*AppendFunc)(struct ArrowArray*, ValueT)>
-void TestAppendToInlinedDataViewArray() {
+template <enum ArrowType ArrowT, typename ValueT>
+void TestAppendToInlinedDataViewArray(
+    std::function<ArrowErrorCode(struct ArrowArray*, ValueT)> AppendFunc) {
   struct ArrowArray array;
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, ArrowT), NANOARROW_OK);
@@ -934,9 +934,9 @@ void TestAppendToInlinedDataViewArray() {
   ArrowArrayRelease(&array);
 };
 
-template <enum ArrowType ArrowT, typename ValueT,
-          ArrowErrorCode (*AppendFunc)(struct ArrowArray*, ValueT)>
-void TestAppendToDataViewArray() {
+template <enum ArrowType ArrowT, typename ValueT>
+void TestAppendToDataViewArray(
+    std::function<ArrowErrorCode(struct ArrowArray*, ValueT)> AppendFunc) {
   struct ArrowArray array;
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, ArrowT), NANOARROW_OK);
@@ -1004,17 +1004,17 @@ void TestAppendToDataViewArray() {
 };
 
 TEST(ArrayTest, ArrayTestAppendToBinaryViewArray) {
-  TestAppendToInlinedDataViewArray<NANOARROW_TYPE_STRING_VIEW, struct ArrowStringView,
-                                   ArrowArrayAppendString>();
-  TestAppendToDataViewArray<NANOARROW_TYPE_STRING_VIEW, struct ArrowStringView,
-                            ArrowArrayAppendString>();
+  TestAppendToInlinedDataViewArray<NANOARROW_TYPE_STRING_VIEW, struct ArrowStringView>(
+      ArrowArrayAppendString);
+  TestAppendToDataViewArray<NANOARROW_TYPE_STRING_VIEW, struct ArrowStringView>(
+      ArrowArrayAppendString);
 };
 
 TEST(ArrayTest, ArrayTestAppendToStringViewArray) {
-  TestAppendToInlinedDataViewArray<NANOARROW_TYPE_BINARY_VIEW, struct ArrowBufferView,
-                                   ArrowArrayAppendBytes>();
-  TestAppendToDataViewArray<NANOARROW_TYPE_BINARY_VIEW, struct ArrowBufferView,
-                            ArrowArrayAppendBytes>();
+  TestAppendToInlinedDataViewArray<NANOARROW_TYPE_BINARY_VIEW, struct ArrowBufferView>(
+      ArrowArrayAppendBytes);
+  TestAppendToDataViewArray<NANOARROW_TYPE_BINARY_VIEW, struct ArrowBufferView>(
+      ArrowArrayAppendBytes);
 };
 
 TEST(ArrayTest, ArrayTestAppendToFixedSizeBinaryArray) {
@@ -3489,7 +3489,9 @@ TEST(ArrayViewTest, ArrayViewTestGetStringView) {
       string_view_builder, ArrowArrayViewGetStringUnsafe, get_string_view);
   TestGetFromBinaryView<StringViewBuilder, struct ArrowStringView>(
       string_view_builder, ArrowArrayViewGetStringUnsafe, get_string_view);
+}
 
+TEST(ArrayViewTest, ArrayViewTestGetBinaryView) {
   auto binary_view_builder = BinaryViewBuilder();
   const auto get_buffer_view = [](const struct ArrowBufferView* bv) {
     return bv->data.data;

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -525,6 +525,7 @@ static inline ArrowErrorCode ArrowArrayAddVariadicBuffers(struct ArrowArray* arr
     private_data->variadic_buffer_sizes[i] = 0;
   }
   private_data->n_variadic_buffers = n_bufs_needed;
+  array->n_buffers = NANOARROW_BINARY_VIEW_FIXED_BUFFERS + 1 + n_bufs_needed;
 
   return NANOARROW_OK;
 }


### PR DESCRIPTION
closes https://github.com/apache/arrow-nanoarrow/issues/634