### PR TITLE
feat: Add ArrowArrayView accessors to inspect buffer properties

### DIFF
--- a/python/tests/test_c_array.py
+++ b/python/tests/test_c_array.py
@@ -337,7 +337,7 @@ def test_c_array_from_iterable_bytes():
         na.c_array([buf_2d], na.binary())
 
 
-def test_c_array_from_iterable__view():
+def test_c_array_from_iterable_view():
     string = na.c_array(
         [b"abc", None, b"a string longer than 12 bytes"], na.binary_view()
     )

--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -163,8 +163,11 @@ SEXP nanoarrow_c_buffer_info(SEXP buffer_xptr) {
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
         buffer_type_string = "union_offset";
         break;
-      case NANOARROW_BUFFER_TYPE_DATA_VIEW:
-        buffer_type_string = "data_view";
+      case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
+        buffer_type_string = "variadic_data";
+        break;
+      case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
+        buffer_type_string = "variadic_size";
         break;
       default:
         buffer_type_string = "unknown";

--- a/r/tests/testthat/_snaps/array.md
+++ b/r/tests/testthat/_snaps/array.md
@@ -9,8 +9,8 @@
        $ offset    : int 0
        $ buffers   :List of 3
         ..$ :<nanoarrow_buffer validity<bool>[null] ``
-        ..$ :<nanoarrow_buffer data_view<string_view>[26][416 b]>`
-        ..$ :<nanoarrow_buffer data<int64>[null] ``
+        ..$ :<nanoarrow_buffer data<string_view>[26][416 b]>`
+        ..$ :<nanoarrow_buffer variadic_size<int64>[null] ``
        $ dictionary: NULL
        $ children  : list()
 
@@ -25,9 +25,9 @@
        $ offset    : int 0
        $ buffers   :List of 4
         ..$ :<nanoarrow_buffer validity<bool>[null] ``
-        ..$ :<nanoarrow_buffer data_view<string_view>[1][16 b]>`
-        ..$ :<nanoarrow_buffer data<string>[35 b]> `this string is longer than 12 ...`
-        ..$ :<nanoarrow_buffer data<int64>[1][8 b]> `35`
+        ..$ :<nanoarrow_buffer data<string_view>[1][16 b]>`
+        ..$ :<nanoarrow_buffer variadic_data<string>[35 b]> `this string is longer...`
+        ..$ :<nanoarrow_buffer variadic_size<int64>[1][8 b]> `35`
        $ dictionary: NULL
        $ children  : list()
 

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -696,11 +696,12 @@ void ArrowArrayViewSetLength(struct ArrowArrayView* array_view, int64_t length) 
             _ArrowRoundUpToMultipleOf8(array_view->layout.element_size_bits[i] * length) /
             8;
         continue;
-      case NANOARROW_BUFFER_TYPE_DATA_VIEW:
       case NANOARROW_BUFFER_TYPE_TYPE_ID:
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
         array_view->buffer_views[i].size_bytes = element_size_bytes * length;
         continue;
+      case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
+      case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
       case NANOARROW_BUFFER_TYPE_NONE:
         array_view->buffer_views[i].size_bytes = 0;
         continue;
@@ -863,9 +864,10 @@ static int ArrowArrayViewValidateMinimal(struct ArrowArrayView* array_view,
         break;
       case NANOARROW_BUFFER_TYPE_TYPE_ID:
       case NANOARROW_BUFFER_TYPE_UNION_OFFSET:
-      case NANOARROW_BUFFER_TYPE_DATA_VIEW:
         min_buffer_size_bytes = element_size_bytes * offset_plus_length;
         break;
+      case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
+      case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
       case NANOARROW_BUFFER_TYPE_NONE:
         continue;
     }

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -735,6 +735,7 @@ static int ArrowArrayViewSetArrayInternal(struct ArrowArrayView* array_view,
   array_view->length = array->length;
   array_view->null_count = array->null_count;
   array_view->variadic_buffer_sizes = NULL;
+  array_view->variadic_buffers = NULL;
   array_view->n_variadic_buffers = 0;
 
   int64_t buffers_required = 0;
@@ -768,6 +769,7 @@ static int ArrowArrayViewSetArrayInternal(struct ArrowArrayView* array_view,
     const int32_t nvariadic_buf = (int32_t)(n_buffers - nfixed_buf - 1);
     array_view->n_variadic_buffers = nvariadic_buf;
     buffers_required += nvariadic_buf + 1;
+    array_view->variadic_buffers = array->buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS;
     array_view->variadic_buffer_sizes = (int64_t*)array->buffers[n_buffers - 1];
   }
 

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -2529,7 +2529,7 @@ void TestArrowArrayViewBinaryView(enum ArrowType type, enum ArrowType buffer_dat
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendString(&array, "longer than 12 bytes"_asv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error) , NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
 
   // Check buffer properties
   EXPECT_EQ(ArrowArrayViewGetNumBuffers(&array_view), 4);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -2528,8 +2528,8 @@ void TestArrowArrayViewBinaryView(enum ArrowType type, enum ArrowType buffer_dat
   ASSERT_EQ(ArrowArrayInitFromType(&array, type), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendString(&array, "longer than 12 bytes"_asv), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, nullptr), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error) , NANOARROW_OK);
 
   // Check buffer properties
   EXPECT_EQ(ArrowArrayViewGetNumBuffers(&array_view), 4);

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -855,7 +855,7 @@ static inline struct ArrowBufferView ArrowArrayViewGetBufferView(
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
         break;
-      } else if (i ==
+      } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         struct ArrowBufferView view;
         view.data.as_int64 = array_view->variadic_buffer_sizes;
@@ -903,7 +903,7 @@ static inline enum ArrowType ArrowArrayViewGetBufferDataType(
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
         break;
-      } else if (i ==
+      } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         return NANOARROW_TYPE_INT64;
       } else if (array_view->storage_type == NANOARROW_TYPE_BINARY_VIEW) {
@@ -925,7 +925,7 @@ static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
         break;
-      } else if (i ==
+      } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         return sizeof(int64_t) * 8;
       } else {

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -922,8 +922,7 @@ static struct ArrowBufferView ArrowArrayViewGetBytesFromViewArrayUnsafe(
     return out;
   }
 
-  const int32_t buf_index = bv->ref.buffer_index + NANOARROW_BINARY_VIEW_FIXED_BUFFERS;
-  out.data.data = array_view->array->buffers[buf_index];
+  out.data.data = array_view->variadic_buffers[bv->ref.buffer_index];
   out.data.as_uint8 += bv->ref.offset;
   return out;
 }

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -870,7 +870,15 @@ static inline struct ArrowBufferView ArrowArrayViewGetBufferView(
         return view;
       }
     default:
-      return array_view->buffer_views[i];
+      // We need this check to avoid -Warray-bounds from complaining
+      if (i >= NANOARROW_MAX_FIXED_BUFFERS) {
+        struct ArrowBufferView view;
+        view.data.data = NULL;
+        view.size_bytes = 0;
+        return view;
+      } else {
+        return array_view->buffer_views[i];
+      }
   }
 }
 
@@ -888,7 +896,12 @@ enum ArrowBufferType ArrowArrayViewGetBufferType(struct ArrowArrayView* array_vi
         return NANOARROW_BUFFER_TYPE_VARIADIC_DATA;
       }
     default:
-      return array_view->layout.buffer_type[i];
+      // We need this check to avoid -Warray-bounds from complaining
+      if (i >= NANOARROW_MAX_FIXED_BUFFERS) {
+        return NANOARROW_BUFFER_TYPE_NONE;
+      } else {
+        return array_view->layout.buffer_type[i];
+      }
   }
 }
 
@@ -908,7 +921,12 @@ static inline enum ArrowType ArrowArrayViewGetBufferDataType(
         return NANOARROW_TYPE_STRING;
       }
     default:
-      return array_view->layout.buffer_data_type[i];
+      // We need this check to avoid -Warray-bounds from complaining
+      if (i >= NANOARROW_MAX_FIXED_BUFFERS) {
+        return NANOARROW_TYPE_UNINITIALIZED;
+      } else {
+        return array_view->layout.buffer_data_type[i];
+      }
   }
 }
 
@@ -926,7 +944,12 @@ static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
         return 0;
       }
     default:
-      return array_view->layout.element_size_bits[i];
+      // We need this check to avoid -Warray-bounds from complaining
+      if (i >= NANOARROW_MAX_FIXED_BUFFERS) {
+        return 0;
+      } else {
+        return array_view->layout.element_size_bits[i];
+      }
   }
 }
 

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -286,6 +286,8 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
 
     switch (private_data->layout.buffer_type[i]) {
       case NANOARROW_BUFFER_TYPE_NONE:
+      case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
+      case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
       case NANOARROW_BUFFER_TYPE_VALIDITY:
         continue;
       case NANOARROW_BUFFER_TYPE_DATA_OFFSET:
@@ -301,7 +303,6 @@ static inline ArrowErrorCode _ArrowArrayAppendEmptyInternal(struct ArrowArray* a
         i++;
         continue;
       case NANOARROW_BUFFER_TYPE_DATA:
-      case NANOARROW_BUFFER_TYPE_DATA_VIEW:
         // Zero out the next bit of memory
         if (private_data->layout.element_size_bits[i] % 8 == 0) {
           NANOARROW_RETURN_NOT_OK(ArrowBufferAppendFill(buffer, 0, size_bytes * n));

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -828,15 +828,24 @@ static inline void ArrowArrayViewMove(struct ArrowArrayView* src,
 }
 
 static inline int64_t ArrowArrayViewGetNumBuffers(struct ArrowArrayView* array_view) {
+  switch (array_view->storage_type) {
+    case NANOARROW_TYPE_BINARY_VIEW:
+    case NANOARROW_TYPE_STRING_VIEW:
+      return NANOARROW_BINARY_VIEW_FIXED_BUFFERS + array_view->n_variadic_buffers + 1;
+    default:
+      break;
+  }
+
   int64_t n_buffers = 0;
   for (int i = 0; i < NANOARROW_MAX_FIXED_BUFFERS; i++) {
-    n_buffers++;
     if (array_view->layout.buffer_type[i] == NANOARROW_BUFFER_TYPE_NONE) {
       break;
     }
+
+    n_buffers++;
   }
 
-  return n_buffers + array_view->n_variadic_buffers + 1;
+  return n_buffers;
 }
 
 static inline struct ArrowBufferView ArrowArrayViewGetBufferView(

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -854,7 +854,7 @@ static inline struct ArrowBufferView ArrowArrayViewGetBufferView(
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
-        break;
+        return array_view->buffer_views[i];
       } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         struct ArrowBufferView view;
@@ -870,10 +870,8 @@ static inline struct ArrowBufferView ArrowArrayViewGetBufferView(
         return view;
       }
     default:
-      break;
+      return array_view->buffer_views[i];
   }
-
-  return array_view->buffer_views[i];
 }
 
 enum ArrowBufferType ArrowArrayViewGetBufferType(struct ArrowArrayView* array_view,
@@ -882,7 +880,7 @@ enum ArrowBufferType ArrowArrayViewGetBufferType(struct ArrowArrayView* array_vi
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
-        break;
+        return array_view->layout.buffer_type[i];
       } else if (i ==
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         return NANOARROW_BUFFER_TYPE_VARIADIC_SIZE;
@@ -890,10 +888,8 @@ enum ArrowBufferType ArrowArrayViewGetBufferType(struct ArrowArrayView* array_vi
         return NANOARROW_BUFFER_TYPE_VARIADIC_DATA;
       }
     default:
-      break;
+      return array_view->layout.buffer_type[i];
   }
-
-  return array_view->layout.buffer_type[i];
 }
 
 static inline enum ArrowType ArrowArrayViewGetBufferDataType(
@@ -902,7 +898,7 @@ static inline enum ArrowType ArrowArrayViewGetBufferDataType(
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
-        break;
+        return array_view->layout.buffer_data_type[i];
       } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         return NANOARROW_TYPE_INT64;
@@ -912,10 +908,8 @@ static inline enum ArrowType ArrowArrayViewGetBufferDataType(
         return NANOARROW_TYPE_STRING;
       }
     default:
-      break;
+      return array_view->layout.buffer_data_type[i];
   }
-
-  return array_view->layout.buffer_data_type[i];
 }
 
 static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
@@ -924,7 +918,7 @@ static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
       if (i < NANOARROW_BINARY_VIEW_FIXED_BUFFERS) {
-        break;
+        return array_view->layout.element_size_bits[i];
       } else if (i >=
                  (array_view->n_variadic_buffers + NANOARROW_BINARY_VIEW_FIXED_BUFFERS)) {
         return sizeof(int64_t) * 8;
@@ -932,10 +926,8 @@ static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
         return 0;
       }
     default:
-      break;
+      return array_view->layout.element_size_bits[i];
   }
-
-  return array_view->layout.element_size_bits[i];
 }
 
 static inline int8_t ArrowArrayViewIsNull(const struct ArrowArrayView* array_view,

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -623,7 +623,8 @@ enum ArrowBufferType {
   NANOARROW_BUFFER_TYPE_UNION_OFFSET,
   NANOARROW_BUFFER_TYPE_DATA_OFFSET,
   NANOARROW_BUFFER_TYPE_DATA,
-  NANOARROW_BUFFER_TYPE_DATA_VIEW
+  NANOARROW_BUFFER_TYPE_VARIADIC_DATA,
+  NANOARROW_BUFFER_TYPE_VARIADIC_SIZE
 };
 
 /// \brief The maximum number of fixed buffers in an ArrowArrayView or ArrowLayout
@@ -815,6 +816,9 @@ struct ArrowArrayView {
 
   /// \brief Number of variadic buffers
   int32_t n_variadic_buffers;
+
+  /// \brief Pointers to variadic buffers of binary/string_view arrays
+  const void** variadic_buffers;
 
   /// \brief Size of each variadic buffer
   int64_t* variadic_buffer_sizes;

--- a/src/nanoarrow/common/schema_test.cc
+++ b/src/nanoarrow/common/schema_test.cc
@@ -918,7 +918,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_STRING_VIEW);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_STRING_VIEW);
   EXPECT_EQ(schema_view.layout.buffer_type[0], NANOARROW_BUFFER_TYPE_VALIDITY);
-  EXPECT_EQ(schema_view.layout.buffer_type[1], NANOARROW_BUFFER_TYPE_DATA_VIEW);
+  EXPECT_EQ(schema_view.layout.buffer_type[1], NANOARROW_BUFFER_TYPE_DATA);
   EXPECT_EQ(schema_view.layout.buffer_data_type[0], NANOARROW_TYPE_BOOL);
   EXPECT_EQ(schema_view.layout.buffer_data_type[1], NANOARROW_TYPE_STRING_VIEW);
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 1);
@@ -931,7 +931,7 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_BINARY_VIEW);
   EXPECT_EQ(schema_view.storage_type, NANOARROW_TYPE_BINARY_VIEW);
   EXPECT_EQ(schema_view.layout.buffer_type[0], NANOARROW_BUFFER_TYPE_VALIDITY);
-  EXPECT_EQ(schema_view.layout.buffer_type[1], NANOARROW_BUFFER_TYPE_DATA_VIEW);
+  EXPECT_EQ(schema_view.layout.buffer_type[1], NANOARROW_BUFFER_TYPE_DATA);
   EXPECT_EQ(schema_view.layout.buffer_data_type[0], NANOARROW_TYPE_BOOL);
   EXPECT_EQ(schema_view.layout.buffer_data_type[1], NANOARROW_TYPE_BINARY_VIEW);
   EXPECT_EQ(schema_view.layout.element_size_bits[0], 1);

--- a/src/nanoarrow/common/utils.c
+++ b/src/nanoarrow/common/utils.c
@@ -180,12 +180,12 @@ void ArrowLayoutInit(struct ArrowLayout* layout, enum ArrowType storage_type) {
       break;
 
     case NANOARROW_TYPE_BINARY_VIEW:
-      layout->buffer_type[1] = NANOARROW_BUFFER_TYPE_DATA_VIEW;
+      layout->buffer_type[1] = NANOARROW_BUFFER_TYPE_DATA;
       layout->buffer_data_type[1] = NANOARROW_TYPE_BINARY_VIEW;
       layout->element_size_bits[1] = 128;
       break;
     case NANOARROW_TYPE_STRING_VIEW:
-      layout->buffer_type[1] = NANOARROW_BUFFER_TYPE_DATA_VIEW;
+      layout->buffer_type[1] = NANOARROW_BUFFER_TYPE_DATA;
       layout->buffer_data_type[1] = NANOARROW_TYPE_STRING_VIEW;
       layout->element_size_bits[1] = 128;
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1053,6 +1053,48 @@ ArrowErrorCode ArrowArrayViewSetArrayMinimal(struct ArrowArrayView* array_view,
                                              const struct ArrowArray* array,
                                              struct ArrowError* error);
 
+/// \brief Get the number of buffers
+///
+/// The number of buffers referred to by this ArrowArrayView.  In may cases this can also
+/// be calculated from the ArrowLayout member of the ArrowArrayView or ArrowSchemaView;
+/// however, for binary view and string view types, the number of total buffers depends on
+/// the number of variadic buffers.
+static inline int64_t ArrowArrayViewGetNumBuffers(struct ArrowArrayView* array_view);
+
+/// \brief Get a view of a specific buffer from an ArrowArrayView
+///
+/// This is the ArrowArrayView equivalent of ArrowArray::buffers[i] that includes
+/// size information (if known).
+static inline struct ArrowBufferView ArrowArrayViewGetBufferView(
+    struct ArrowArrayView* array_view, int64_t i);
+
+/// \brief Get the function of a specific buffer in an ArrowArrayView
+///
+/// In may cases this can also be obtained from the ArrowLayout member of the
+/// ArrowArrayView or ArrowSchemaView; however, for binary view and string view types,
+/// the function of each buffer may be different between two arrays of the same type
+/// depending on the number of variadic buffers.
+static inline enum ArrowBufferType ArrowArrayViewGetBufferType(
+    struct ArrowArrayView* array_view, int64_t i);
+
+/// \brief Get the data type of a specific buffer in an ArrowArrayView
+///
+/// In may cases this can also be obtained from the ArrowLayout member of the
+/// ArrowArrayView or ArrowSchemaView; however, for binary view and string view types,
+/// the data type of each buffer may be different between two arrays of the same type
+/// depending on the number of variadic buffers.
+static inline enum ArrowType ArrowArrayViewGetBufferDataType(
+    struct ArrowArrayView* array_view, int64_t i);
+
+/// \brief Get the element size (in bits) of a specific buffer in an ArrowArrayView
+///
+/// In may cases this can also be obtained from the ArrowLayout member of the
+/// ArrowArrayView or ArrowSchemaView; however, for binary view and string view types,
+/// the element width of each buffer may be different between two arrays of the same type
+/// depending on the number of variadic buffers.
+static inline int64_t ArrowArrayViewGetBufferElementSizeBits(
+    struct ArrowArrayView* array_view, int64_t i);
+
 /// \brief Performs checks on the content of an ArrowArrayView
 ///
 /// If using ArrowArrayViewSetArray() to back array_view with an ArrowArray,

--- a/src/nanoarrow/testing/testing.cc
+++ b/src/nanoarrow/testing/testing.cc
@@ -1932,7 +1932,8 @@ ArrowErrorCode SetArrayColumnBuffers(const json& value, ArrowArrayView* array_vi
       }
       break;
     }
-    case NANOARROW_BUFFER_TYPE_DATA_VIEW:
+    case NANOARROW_BUFFER_TYPE_VARIADIC_DATA:
+    case NANOARROW_BUFFER_TYPE_VARIADIC_SIZE:
       return ENOTSUP;
     case NANOARROW_BUFFER_TYPE_NONE:
       break;


### PR DESCRIPTION
This PR abstracts accessors for the buffer_view, buffer type, buffer data type, and element bit width for the `ArrowArrayView`. Before adding string/binary view support, this was done by directly accessing the `layout` and `buffer_view` members; however, this required special-casing + some duplicated code in the string view in the R/Python bindings.

This PR also removes the dependence on the `ArrowArrayView::array` member, since this member is optional (i.e., the data backing an `ArrowArrayView` need not be related to an actual `ArrowArray`).