### PR TITLE
chore(ci): Fix tests for centos7 and s390x

### DIFF
--- a/r/tests/testthat/test-ipc.R
+++ b/r/tests/testthat/test-ipc.R
@@ -103,7 +103,7 @@ test_that("write_nanoarrow() works for file paths", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  df <- data.frame(letters = letters)
+  df <- data.frame(letters = letters, stringsAsFactors = FALSE)
   expect_identical(write_nanoarrow(df, tf), df)
   expect_identical(as.data.frame(read_nanoarrow(tf)), df)
 })
@@ -127,7 +127,7 @@ test_that("write_nanoarrow() works for URLs", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  df <- data.frame(letters = letters)
+  df <- data.frame(letters = letters, stringsAsFactors = FALSE)
   expect_identical(write_nanoarrow(df, paste0("file://", tf)), df)
   expect_identical(as.data.frame(read_nanoarrow(tf)), df)
 })
@@ -151,7 +151,7 @@ test_that("write_nanoarrow() works for compressed .gz file paths", {
   tf <- tempfile(fileext = ".gz")
   on.exit(unlink(tf))
 
-  df <- data.frame(letters = letters)
+  df <- data.frame(letters = letters, stringsAsFactors = FALSE)
   expect_identical(write_nanoarrow(df, tf), df)
   expect_identical(as.data.frame(read_nanoarrow(tf)), df)
 })
@@ -175,7 +175,7 @@ test_that("write_nanoarrow() works for compressed .bz2 file paths", {
   tf <- tempfile(fileext = ".bz2")
   on.exit(unlink(tf))
 
-  df <- data.frame(letters = letters)
+  df <- data.frame(letters = letters, stringsAsFactors = FALSE)
   expect_identical(write_nanoarrow(df, tf), df)
   expect_identical(as.data.frame(read_nanoarrow(tf)), df)
 })
@@ -212,7 +212,7 @@ test_that("write_nanoarrow() errors for compressed .zip file paths", {
   tf <- tempfile(fileext = ".zip")
   on.exit(unlink(tf))
 
-  df <- data.frame(letters = letters)
+  df <- data.frame(letters = letters, stringsAsFactors = FALSE)
   expect_error(
     write_nanoarrow(df, tf),
     "zip compression not supported"

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -1002,24 +1002,23 @@ void TestAppendToDataViewArray(
 
 TEST(ArrayTest, ArrayTestAppendToBinaryViewArray) {
   TestAppendToInlinedDataViewArray(
-      NANOARROW_TYPE_STRING_VIEW, [&](struct ArrowArray* array, const char* value) {
+      NANOARROW_TYPE_STRING_VIEW, [&](ArrowArray* array, const char* value) {
         return ArrowArrayAppendString(array, ArrowCharView(value));
       });
 
   TestAppendToDataViewArray(NANOARROW_TYPE_STRING_VIEW,
-                            [&](struct ArrowArray* array, const char* value) {
+                            [&](ArrowArray* array, const char* value) {
                               return ArrowArrayAppendString(array, ArrowCharView(value));
                             });
 };
 
 TEST(ArrayTest, ArrayTestAppendToStringViewArray) {
-  TestAppendToInlinedDataViewArray(
-      NANOARROW_TYPE_BINARY_VIEW, [&](struct ArrowArray* array, const char* value) {
-        return ArrowArrayAppendBytes(array,
-                                     {{value}, static_cast<int64_t>(strlen(value))});
-      });
+  TestAppendToInlinedDataViewArray(NANOARROW_TYPE_BINARY_VIEW, [&](ArrowArray* array,
+                                                                   const char* value) {
+    return ArrowArrayAppendBytes(array, {{value}, static_cast<int64_t>(strlen(value))});
+  });
 
-  TestAppendToDataViewArray(NANOARROW_TYPE_BINARY_VIEW, [&](struct ArrowArray* array,
+  TestAppendToDataViewArray(NANOARROW_TYPE_BINARY_VIEW, [&](ArrowArray* array,
                                                             const char* value) {
     return ArrowArrayAppendBytes(array, {{value}, static_cast<int64_t>(strlen(value))});
   });

--- a/src/nanoarrow/common/schema_test.cc
+++ b/src/nanoarrow/common/schema_test.cc
@@ -912,7 +912,13 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[2], 0);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "large_string");
   ArrowSchemaRelease(&schema);
+}
 
+TEST(SchemaViewTest, SchemaViewInitBinaryAndStringView) {
+#if defined(ARROW_VERSION_MAJOR) && ARROW_VERSION_MAJOR >= 15
+  struct ArrowSchema schema;
+  struct ArrowSchemaView schema_view;
+  struct ArrowError error;
   ARROW_EXPECT_OK(ExportType(*utf8_view(), &schema));
   EXPECT_EQ(ArrowSchemaViewInit(&schema_view, &schema, &error), NANOARROW_OK);
   EXPECT_EQ(schema_view.type, NANOARROW_TYPE_STRING_VIEW);
@@ -938,6 +944,9 @@ TEST(SchemaViewTest, SchemaViewInitBinaryAndString) {
   EXPECT_EQ(schema_view.layout.element_size_bits[1], 128);
   EXPECT_EQ(ArrowSchemaToStdString(&schema), "binary_view");
   ArrowSchemaRelease(&schema);
+#else
+  GTEST_SKIP() << "Arrow C++ StringView compatibility test needs Arrow C++ >= 15";
+#endif
 }
 
 TEST(SchemaViewTest, SchemaViewInitBinaryAndStringErrors) {


### PR DESCRIPTION
A few tests were failing on the centos7 run, which these days mostly checks for accidental C++17 or R >= 4.0 usage or Arrow > 9.0.0 usage in the tests.

Closes #640.

Checked with:

```bash
export NANOARROW_PLATFORM=centos7 
docker compose run --rm verify       
```

and

```bash
export NANOARROW_PLATFORM=alpine
export NANOARROW_ARCH=s390x
docker compose run --rm verify       
```