### PR TITLE
chore(ci): Ensure integration workflow passes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       - ${NANOARROW_DOCKER_SOURCE_DIR}:/arrow-integration/nanoarrow
     environment:
       ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS: "nanoarrow"
+      # Rust writes invalid flatbuffers:
+      # https://github.com/apache/arrow-rs/issues/5052
+      ARCHERY_INTEGRATION_WITH_NANOARROW: "0"
     command:
       ["echo '::group::Build nanoarrow' &&
         conda run --no-capture-output /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS: "nanoarrow"
       # Rust writes invalid flatbuffers:
       # https://github.com/apache/arrow-rs/issues/5052
-      ARCHERY_INTEGRATION_WITH_NANOARROW: "0"
+      ARCHERY_INTEGRATION_WITH_RUST: "0"
     command:
       ["echo '::group::Build nanoarrow' &&
         conda run --no-capture-output /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1024,12 +1024,11 @@ static inline int ArrowIpcDecoderReadHeaderPrefix(struct ArrowIpcDecoder* decode
 
 ArrowErrorCode ArrowIpcDecoderPeekHeader(struct ArrowIpcDecoder* decoder,
                                          struct ArrowBufferView data,
+                                         int32_t* prefix_size_bytes,
                                          struct ArrowError* error) {
   ArrowIpcDecoderResetHeaderInfo(decoder);
-  int32_t prefix_size_bytes;
   NANOARROW_RETURN_NOT_OK(
-      ArrowIpcDecoderReadHeaderPrefix(decoder, &data, &prefix_size_bytes, error));
-  NANOARROW_UNUSED(prefix_size_bytes);
+      ArrowIpcDecoderReadHeaderPrefix(decoder, &data, prefix_size_bytes, error));
   return NANOARROW_OK;
 }
 
@@ -1187,15 +1186,12 @@ ArrowErrorCode ArrowIpcDecoderDecodeHeader(struct ArrowIpcDecoder* decoder,
   decoder->body_size_bytes = ns(Message_bodyLength(message));
 
   switch (decoder->metadata_version) {
-    case ns(MetadataVersion_V5):
-    case ns(MetadataVersion_V4):
-      break;
     case ns(MetadataVersion_V1):
     case ns(MetadataVersion_V2):
     case ns(MetadataVersion_V3):
-      ArrowErrorSet(error, "Expected metadata version V4 or V5 but found %s",
-                    ns(MetadataVersion_name(ns(Message_version(message)))));
-      return EINVAL;
+    case ns(MetadataVersion_V4):
+    case ns(MetadataVersion_V5):
+      break;
     default:
       ArrowErrorSet(error, "Unexpected value for Message metadata version (%d)",
                     decoder->metadata_version);

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1282,6 +1282,9 @@ ArrowErrorCode ArrowIpcDecoderDecodeFooter(struct ArrowIpcDecoder* decoder,
       data.data.as_uint8 + data.size_bytes - footer_and_size_and_magic_size;
   ns(Footer_table_t) footer = ns(Footer_as_root(footer_data));
 
+  NANOARROW_RETURN_NOT_OK(
+      ArrowIpcDecoderDecodeSchemaHeader(decoder, ns(Footer_schema(footer)), error));
+
   NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderDecodeSchemaImpl(
       ns(Footer_schema(footer)), &private_data->footer.schema, error));
 

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1186,12 +1186,15 @@ ArrowErrorCode ArrowIpcDecoderDecodeHeader(struct ArrowIpcDecoder* decoder,
   decoder->body_size_bytes = ns(Message_bodyLength(message));
 
   switch (decoder->metadata_version) {
-    case ns(MetadataVersion_V1):
-    case ns(MetadataVersion_V2):
-    case ns(MetadataVersion_V3):
     case ns(MetadataVersion_V4):
     case ns(MetadataVersion_V5):
       break;
+      ArrowErrorSet(error, "Expected metadata version V4 or V5 but found %s",
+                    ns(MetadataVersion_name(ns(Message_version(message)))));
+      return EINVAL;
+    case ns(MetadataVersion_V1):
+    case ns(MetadataVersion_V2):
+    case ns(MetadataVersion_V3):
     default:
       ArrowErrorSet(error, "Unexpected value for Message metadata version (%d)",
                     decoder->metadata_version);

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -192,7 +192,10 @@ TEST(NanoarrowIpcTest, NanoarrowIpcPeekSimpleSchema) {
   data.size_bytes = sizeof(kSimpleSchema);
 
   ArrowIpcDecoderInit(&decoder);
-  EXPECT_EQ(ArrowIpcDecoderPeekHeader(&decoder, data, &error), NANOARROW_OK);
+  int32_t prefix_size_bytes = 0;
+  EXPECT_EQ(ArrowIpcDecoderPeekHeader(&decoder, data, &prefix_size_bytes, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(prefix_size_bytes, 8);
   EXPECT_EQ(decoder.header_size_bytes, sizeof(kSimpleSchema));
   EXPECT_EQ(decoder.body_size_bytes, 0);
 

--- a/src/nanoarrow/ipc/reader.c
+++ b/src/nanoarrow/ipc/reader.c
@@ -264,6 +264,8 @@ static int ArrowIpcArrayStreamReaderNextHeader(
   NANOARROW_RETURN_NOT_OK(ArrowIpcDecoderPeekHeader(
       &private_data->decoder, input_view, &prefix_size_bytes, &private_data->error));
 
+  printf("expected: %d; got: %d\n", (int)private_data->expected_header_prefix_size,
+         (int)prefix_size_bytes);
   if (private_data->expected_header_prefix_size != kExpectedHeaderPrefixSizeNotSet &&
       prefix_size_bytes != private_data->expected_header_prefix_size) {
     ArrowErrorSet(&private_data->error,
@@ -315,7 +317,7 @@ static int ArrowIpcArrayStreamReaderNextHeader(
 
   // Set the expected number of prefix bytes for reading the next message
   // if we haven't encountered a message yet.
-  if (private_data->expected_header_prefix_size != kExpectedHeaderPrefixSizeNotSet) {
+  if (private_data->expected_header_prefix_size == kExpectedHeaderPrefixSizeNotSet) {
     switch (private_data->decoder.metadata_version) {
       // Earlier versions raise an in header verification
       case NANOARROW_IPC_METADATA_VERSION_V4:

--- a/src/nanoarrow/ipc/reader.c
+++ b/src/nanoarrow/ipc/reader.c
@@ -235,7 +235,7 @@ static int ArrowIpcArrayStreamReaderNextHeader(
     // propagated higher (e.g., if the stream is empty and there's no schema message)
     ArrowErrorSet(&private_data->error, "No data available on stream");
     return ENODATA;
-  } else if (private_data->expected_header_prefix_size == 4) {
+  } else if (bytes_read == 4 && private_data->expected_header_prefix_size == 4) {
     // Special case very, very old IPC streams that used 0x00000000 as the
     // end-of-stream indicator.
     uint32_t last_four_bytes = 0;

--- a/src/nanoarrow/ipc/reader.c
+++ b/src/nanoarrow/ipc/reader.c
@@ -280,7 +280,8 @@ static int ArrowIpcArrayStreamReaderNextHeader(
   // decoder can handle this; however, verification will fail because flatbuffers
   // must be 8-byte aligned. To handle this case, we prepend the continuation
   // token to the start of the stream and ensure that we read four fewer bytes
-  // the next time we issue a read.
+  // the next time we issue a read. We may be able to remove this case in the future:
+  // https://github.com/apache/arrow-nanoarrow/issues/648
   int64_t extra_bytes_already_read = 0;
   if (prefix_size_bytes == 4) {
     NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBufferReserve(&private_data->header, 4),

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -251,8 +251,13 @@ void ArrowIpcDecoderReset(struct ArrowIpcDecoder* decoder);
 /// these bytes and returns ESPIPE if there are not enough remaining bytes in data to read
 /// the entire header message, EINVAL if the first 8 bytes are not valid, ENODATA if the
 /// Arrow end-of-stream indicator has been reached, or NANOARROW_OK otherwise.
+///
+/// Pre-1.0 messages were not prefixed with 0xFFFFFFFF. For these messages, a value
+/// of 4 will be placed into prefix_size_bytes; otherwise a value of 8 will be placed
+/// into prefix_size_bytes.
 ArrowErrorCode ArrowIpcDecoderPeekHeader(struct ArrowIpcDecoder* decoder,
                                          struct ArrowBufferView data,
+                                         int32_t* prefix_size_bytes,
                                          struct ArrowError* error);
 
 /// \brief Verify a message header


### PR DESCRIPTION
Closes #641.

Unfortunately we just have to skip checking Rust compatibility due to https://github.com/apache/arrow-rs/issues/5052 (e.g., https://github.com/apache/arrow-rs/pull/6449 ).

This PR also ensures compatibility with big endian Arrow files and Arrow files from before the continuation token. Support for those had already been added in the decoder but hadn't made it to the stream reader yet.

Local check:

```bash
# Assumes arrow-testing, arrow-nanoarrow, and arrow are all checked out in the same dir
export gold_dir=../arrow-testing/data/arrow-ipc-stream/integration 
export ARROW_NANOARROW_PATH=$(pwd)/build 
pip install -e "../arrow/dev/archery/[all]"
archery integration --with-nanoarrow=true --run-ipc \
    --gold-dirs=$gold_dir/0.14.1 \
    --gold-dirs=$gold_dir/0.17.1 \
    --gold-dirs=$gold_dir/1.0.0-bigendian \
    --gold-dirs=$gold_dir/1.0.0-littleendian \
    --gold-dirs=$gold_dir/2.0.0-compression \
    --gold-dirs=$gold_dir/4.0.0-shareddict
```