### PR TITLE
chore(ci): Temporarily disable CUDA integration jobs that are not being picked up

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -48,7 +48,9 @@ jobs:
           - {runner: ubuntu-latest, label: namespaced-build, cmake_args: "-DNANOARROW_NAMESPACE=SomeUserNamespace"}
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          # The self-hosted cuda runner is currently not picking up any jobs
+          # https://github.com/apache/arrow-nanoarrow/issues/646
+          # - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
 
     steps:


### PR DESCRIPTION
The self-hosted "cuda" runner is currently not picking up any jobs, causing CI to hang at "yellow" for several days for each run until the job times out. Until this is resolved, we need to disable that job (https://github.com/apache/arrow-nanoarrow/issues/646).