### PR TITLE
fix: Remove unreachable code

### DIFF
--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -764,7 +764,6 @@ static inline ArrowErrorCode ArrowArrayFinishElement(struct ArrowArray* array) {
         }
       }
       break;
-      return NANOARROW_OK;
     default:
       return EINVAL;
   }


### PR DESCRIPTION
Identified as a compiler error in MSVC when testing against ADBC.