### PR TITLE
feat(r): Add float16 support for R bindings

### DIFF
--- a/r/src/infer_ptype.c
+++ b/r/src/infer_ptype.c
@@ -49,6 +49,7 @@ enum VectorType nanoarrow_infer_vector_type(enum ArrowType type) {
     case NANOARROW_TYPE_UINT32:
     case NANOARROW_TYPE_INT64:
     case NANOARROW_TYPE_UINT64:
+    case NANOARROW_TYPE_HALF_FLOAT:
     case NANOARROW_TYPE_FLOAT:
     case NANOARROW_TYPE_DOUBLE:
     case NANOARROW_TYPE_DECIMAL128:

--- a/r/src/materialize_dbl.h
+++ b/r/src/materialize_dbl.h
@@ -69,6 +69,7 @@ static inline int nanoarrow_materialize_dbl(struct RConverter* converter) {
     case NANOARROW_TYPE_UINT16:
     case NANOARROW_TYPE_INT32:
     case NANOARROW_TYPE_UINT32:
+    case NANOARROW_TYPE_HALF_FLOAT:
     case NANOARROW_TYPE_FLOAT:
       // No need to bounds check these types
       for (R_xlen_t i = 0; i < dst->length; i++) {

--- a/r/tests/testthat/test-as-array.R
+++ b/r/tests/testthat/test-as-array.R
@@ -197,6 +197,46 @@ test_that("as_nanoarrow_array() works for double() -> na_int64()", {
   expect_identical(convert_array(array), as.double(c(1:10, NA_real_)))
 })
 
+test_that("as_nanoarrow_array() works for double() -> na_float()", {
+  # Without nulls
+  array <- as_nanoarrow_array(as.double(1:10), schema = na_float())
+  expect_identical(infer_nanoarrow_schema(array)$format, "f")
+  expect_identical(as.raw(array$buffers[[1]]), raw())
+  expect_identical(array$offset, 0L)
+  expect_identical(array$null_count, 0L)
+  expect_identical(convert_array(array), as.double(1:10))
+
+  # With nulls
+  array <- as_nanoarrow_array(c(1:10, NA_real_), schema = na_float())
+  expect_identical(infer_nanoarrow_schema(array)$format, "f")
+  expect_identical(array$null_count, 1L)
+  expect_identical(
+    as.raw(array$buffers[[1]]),
+    packBits(c(rep(TRUE, 10), FALSE, rep(FALSE, 5)))
+  )
+  expect_identical(convert_array(array), c(1:10, NA_real_))
+})
+
+test_that("as_nanoarrow_array() works for double() -> na_half_float()", {
+  # Without nulls
+  array <- as_nanoarrow_array(as.double(1:10), schema = na_half_float())
+  expect_identical(infer_nanoarrow_schema(array)$format, "e")
+  expect_identical(as.raw(array$buffers[[1]]), raw())
+  expect_identical(array$offset, 0L)
+  expect_identical(array$null_count, 0L)
+  expect_identical(convert_array(array), as.double(1:10))
+
+  # With nulls
+  array <- as_nanoarrow_array(c(1:10, NA_real_), schema = na_half_float())
+  expect_identical(infer_nanoarrow_schema(array)$format, "e")
+  expect_identical(array$null_count, 1L)
+  expect_identical(
+    as.raw(array$buffers[[1]]),
+    packBits(c(rep(TRUE, 10), FALSE, rep(FALSE, 5)))
+  )
+  expect_identical(convert_array(array), c(1:10, NA_real_))
+})
+
 test_that("as_nanoarrow_array() works for integer64() -> na_int32()", {
   skip_if_not_installed("bit64")
 

--- a/r/tests/testthat/test-convert-array.R
+++ b/r/tests/testthat/test-convert-array.R
@@ -560,6 +560,7 @@ test_that("convert to vector works for valid double()", {
     uint32 = arrow::uint32(),
     int64 = arrow::int64(),
     uint64 = arrow::uint64(),
+    float16 = arrow::float16(),
     float32 = arrow::float32(),
     float64 = arrow::float64()
   )


### PR DESCRIPTION
I'd forgotten to do this after the addition of float16 <-> double conversion in the C library!

``` r
library(nanoarrow)

array <- as_nanoarrow_array(1.23 + 1:5, schema = na_half_float())
convert_array(array)
#> [1] 2.228516 3.228516 4.226562 5.226562 6.226562
```

<sup>Created on 2024-10-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>