### PR TITLE
chore(dev/release): Update sign targets

### DIFF
--- a/dev/release/02-sign.sh
+++ b/dev/release/02-sign.sh
@@ -80,9 +80,6 @@ main() {
     header "Upload signatures for source"
     upload_asset_signatures "${tag}" $(find "${download_dir}" -type f \( -name 'apache-arrow-nanoarrow-*.tar.gz' \))
 
-    header "Upload signatures for R"
-    upload_asset_signatures "${tag}" $(find "${download_dir}" -type f \( -name 'nanoarrow_*.tar.gz' \))
-
     header "Upload signatures for docs"
     upload_asset_signatures "${tag}" "${download_dir}/docs.tgz"
 


### PR DESCRIPTION
We don't upload R package to GitHub Releases by GH-541. So we don't need to sign it.

Closes #654.