### PR TITLE
fix: remove deprecated operator"" syntax usage

### DIFF
--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -92,9 +92,16 @@ namespace literals {
 /// @{
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_asv
+#if !defined(__clang__) && (defined(__GNUC__) && __GNUC__ < 6)
+inline ArrowStringView operator"" _asv(const char* data, std::size_t size_bytes) {
+  return {data, static_cast<int64_t>(size_bytes)};
+}
+#else
 inline ArrowStringView operator""_asv(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
+#endif
+// N.B. older GCC requires the space above, newer Clang forbids the space
 
 // @}
 

--- a/src/nanoarrow/nanoarrow.hpp
+++ b/src/nanoarrow/nanoarrow.hpp
@@ -92,7 +92,7 @@ namespace literals {
 /// @{
 
 /// \brief User literal operator allowing ArrowStringView construction like "str"_asv
-inline ArrowStringView operator"" _asv(const char* data, std::size_t size_bytes) {
+inline ArrowStringView operator""_asv(const char* data, std::size_t size_bytes) {
   return {data, static_cast<int64_t>(size_bytes)};
 }
 


### PR DESCRIPTION
Clang warns about this.  Apparently GCC 4.9 may warn about the fixed syntax, though!

Spotted in the ADBC CI:

```
 /adbc/c/vendor/nanoarrow/nanoarrow.hpp:94:35: error: identifier '_asv' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
   94 | inline ArrowStringView operator"" _asv(const char* data, std::size_t size_bytes) {
      |                        ~~~~~~~~~~~^~~~
      |                        operator""_asv
```