### PR TITLE
docs: Ensure all headers are parsed by Doxygen

### DIFF
--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -98,7 +98,7 @@ main() {
    done
 
    # Build sphinx project
-   sphinx-build -W source _build/html
+   sphinx-build source _build/html
 
    show_header "Build R documentation"
 

--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -98,7 +98,7 @@ main() {
    done
 
    # Build sphinx project
-   sphinx-build source _build/html
+   sphinx-build -W source _build/html
 
    show_header "Build R documentation"
 

--- a/python/src/nanoarrow/array.py
+++ b/python/src/nanoarrow/array.py
@@ -116,7 +116,7 @@ class Array(ArrayViewVisitable):
     the Arrow C Stream interface.
 
     Note that an :class:`Array` is not necessarily contiguous in memory (i.e.,
-    it may consist of zero or more ``ArrowArray``s).
+    it may consist of zero or more ``ArrowArray`` objects).
 
     Parameters
     ----------

--- a/src/apidoc/Doxyfile
+++ b/src/apidoc/Doxyfile
@@ -187,7 +187,7 @@ FILE_PATTERNS          = *.c \
                          *.ucf \
                          *.qsf \
                          *.ice
-RECURSIVE              = NO
+RECURSIVE              = YES
 EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       =


### PR DESCRIPTION
Because we had moved some headers outside of src/nanoarrow into src/nanoarrow/common, they weren't getting included in the documentation!

We can't quite add  `-W` to the sphinx build command (error for warnings) because pandoc doesn't generate .rst files that are warning free (and we use pandoc to avoid having to write tutorials in restructured text).

Closes #676.