### PR TITLE
chore(ci): Verify on 32-bit Windows

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -70,9 +70,7 @@ jobs:
           R CMD INSTALL r --preclean
         shell: bash
 
-      # r-lib/actions/setup-r-dependencies pinned because the latest action on the
-      # v2 branch requires quarto-dev actions which have not yet been whitelisted by Apache Infra
-      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, arrow=?ignore-before-r=4.0.0
           needs: check

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -60,8 +60,8 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest, label: macos, extra_cmake_config: "-DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
-          - {os: windows-latest, label: windows, extra_cmake_install: "--config=Debug", extra_cmake_config: "-A x86 -DNANOARROW_ARROW_STATIC=ON -Dgtest_force_shared_crt=ON -DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
-          - {os: windows-latest, label: windows-win32, extra_cmake_install: "--config=Debug", extra_cmake_config: "-A Win32 -Dgtest_force_shared_crt=ON"}
+          - {os: windows-latest, label: windows, extra_cmake_config: "-DNANOARROW_ARROW_STATIC=ON -Dgtest_force_shared_crt=ON -DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
+          - {os: windows-latest, label: windows-win32, extra_cmake_config: "-A Win32 -Dgtest_force_shared_crt=ON"}
           - {os: ubuntu-latest, label: ubuntu, extra_cmake_config: "-DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
 
     steps:
@@ -79,7 +79,7 @@ jobs:
           use-public-rspm: true
           windows-path-include-rtools: false
           windows-path-include-mingw: false
-      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           needs: check
           working-directory: src/r

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -93,7 +93,7 @@ jobs:
           key: arrow-${{ runner.os }}-${{ runner.arch }}-2
 
       - name: Build Arrow C++
-        if: steps.cache-arrow-build.outputs.cache-hit != 'true' && label != 'windows-win32'
+        if: steps.cache-arrow-build.outputs.cache-hit != 'true' && matrix.config.label != 'windows-win32'
         shell: bash
         run: |
           src/ci/scripts/build-arrow-cpp-minimal.sh 18.0.0 arrow

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -59,9 +59,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest, label: macos}
-          - {os: windows-latest, label: windows, extra_cmake_install: "--config=Debug"}
-          - {os: ubuntu-latest, label: ubuntu}
+          - {os: macOS-latest, label: macos, extra_cmake_config: "-DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
+          - {os: windows-latest, label: windows, extra_cmake_install: "--config=Debug", extra_cmake_config: "-A x86 -DNANOARROW_ARROW_STATIC=ON -Dgtest_force_shared_crt=ON -DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
+          - {os: windows-latest, label: windows-win32, extra_cmake_install: "--config=Debug", extra_cmake_config: "-A Win32 -Dgtest_force_shared_crt=ON"}
+          - {os: ubuntu-latest, label: ubuntu, extra_cmake_config: "-DNANOARROW_BUILD_TESTS_WITH_ARROW=ON"}
 
     steps:
       - uses: actions/checkout@v4
@@ -89,33 +90,21 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-1
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-2
 
       - name: Build Arrow C++
-        if: steps.cache-arrow-build.outputs.cache-hit != 'true'
+        if: steps.cache-arrow-build.outputs.cache-hit != 'true' && label != 'windows-win32'
         shell: bash
         run: |
-          src/ci/scripts/build-arrow-cpp-minimal.sh 15.0.2 arrow
+          src/ci/scripts/build-arrow-cpp-minimal.sh 18.0.0 arrow
 
-      - name: Set CMake options (Windows)
-        if: matrix.config.label == 'windows'
+      - name: Set CMake options
         shell: bash
         run: |
           cat << EOF | tr '\n' ' ' >> $GITHUB_ENV
           NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS}
-          -DNANOARROW_ARROW_STATIC=ON
-          -DNANOARROW_BUILD_TESTS_WITH_ARROW=ON
-          -DArrow_DIR=$(pwd -W)/arrow/lib/cmake/Arrow
-          -Dgtest_force_shared_crt=ON
-
-      - name: Set CMake options (POSIX)
-        if: matrix.config.label != 'windows'
-        shell: bash
-        run: |
-          cat << EOF | tr '\n' ' ' >> $GITHUB_ENV
-          NANOARROW_CMAKE_OPTIONS=${NANOARROW_CMAKE_OPTIONS}
-          -DNANOARROW_BUILD_TESTS_WITH_ARROW=ON
-          -DArrow_DIR=$(pwd)/arrow/lib/cmake/Arrow
+          ${{ matrix.config.extra_cmake_config }}
+          -DCMAKE_PREFIX_PATH=$(pwd)/arrow
 
       - name: Run dev/release/verify-release-candidate.sh
         shell: bash


### PR DESCRIPTION
Closes #357, succeeds #358, and removes a workaround that existed before a specific action had been whitelisted by infra (it now is!).