### PR TITLE
feat(r): Support native creation of more numeric Arrow arrays from integer vectors

### DIFF
--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -96,7 +96,7 @@ static void as_array_int(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr
     for (int64_t i = 0; i < len; i++) {
       result = ArrowArrayAppendInt(array, x_data[i]);
       if (result != NANOARROW_OK) {
-        Rf_error("ArrowArrayAppendDouble() failed");
+        Rf_error("ArrowArrayAppendInt() failed");
       }
     }
   }

--- a/r/src/as_array.c
+++ b/r/src/as_array.c
@@ -48,19 +48,13 @@ static void call_as_nanoarrow_array(SEXP x_sexp, struct ArrowArray* array,
 
 static void as_array_int(SEXP x_sexp, struct ArrowArray* array, SEXP schema_xptr,
                          struct ArrowSchemaView* schema_view, struct ArrowError* error) {
-  // Consider integer -> any numeric type
+  // Consider integer -> numeric types that are easy to implement
   switch (schema_view->type) {
     case NANOARROW_TYPE_DOUBLE:
     case NANOARROW_TYPE_FLOAT:
     case NANOARROW_TYPE_HALF_FLOAT:
-    case NANOARROW_TYPE_UINT64:
     case NANOARROW_TYPE_INT64:
-    case NANOARROW_TYPE_UINT32:
     case NANOARROW_TYPE_INT32:
-    case NANOARROW_TYPE_UINT16:
-    case NANOARROW_TYPE_INT16:
-    case NANOARROW_TYPE_UINT8:
-    case NANOARROW_TYPE_INT8:
       break;
     default:
       call_as_nanoarrow_array(x_sexp, array, schema_xptr, "as_nanoarrow_array_from_c");

--- a/r/tests/testthat/test-as-array.R
+++ b/r/tests/testthat/test-as-array.R
@@ -111,7 +111,6 @@ test_that("as_nanoarrow_array() works for integer() -> na_int32()", {
 })
 
 test_that("as_nanoarrow_array() works for integer -> na_int64()", {
-  skip_if_not_installed("arrow")
   casted <- as_nanoarrow_array(1:10, schema = na_int64())
   expect_identical(infer_nanoarrow_schema(casted)$format, "l")
   expect_identical(convert_array(casted), as.double(1:10))


### PR DESCRIPTION
Before we had been punting to the arrow R package for this which wasn't necessary! This was exposed by a test that had been added for matrix support that wasn't skipped if arrow wasn't installed.

``` r
library(nanoarrow)
as_nanoarrow_array(1:10, schema = na_double())
#> <nanoarrow_array double[10]>
#>  $ length    : int 10
#>  $ null_count: int 0
#>  $ offset    : int 0
#>  $ buffers   :List of 2
#>   ..$ :<nanoarrow_buffer validity<bool>[null] ``
#>   ..$ :<nanoarrow_buffer data<double>[10][80 b]> `1 2 3 4 5 6 7 8 9 10`
#>  $ dictionary: NULL
#>  $ children  : list()
```

<sup>Created on 2024-12-26 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>