### PR TITLE
chore: Fall back on shared libzstd if libzstd_static is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,14 @@ if(NANOARROW_IPC)
   if(NANOARROW_IPC_WITH_ZSTD)
     find_package(zstd REQUIRED)
     set(NANOARROW_IPC_EXTRA_FLAGS "-DNANOARROW_IPC_WITH_ZSTD")
-    set(NANOARROW_IPC_EXTRA_LIBS zstd::libzstd_static)
+
+    # libzstd_static is not available from conda
+    # This could be configurable if shared zstd is a must
+    if(TARGET zstd::libzstd_static)
+      set(NANOARROW_IPC_EXTRA_LIBS zstd::libzstd_static)
+    else()
+      set(NANOARROW_IPC_EXTRA_LIBS zstd::libzstd)
+    endif()
   endif()
 
   if(NOT NANOARROW_BUNDLE)

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -42,7 +42,8 @@ ENV ARROW_RUST_EXE_PATH=/build/rust/debug
 ENV BUILD_DOCS_CPP=OFF
 
 # Clone the arrow monorepo
-RUN git clone https://github.com/apache/arrow.git /arrow-integration --recurse-submodules
+RUN git clone https://github.com/paleolimbot/arrow.git /arrow-integration --recurse-submodules && \
+    cd arrow-integration && git switch archery-update-nanoarrow-skip
 
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -52,6 +52,9 @@ RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
 # provided arrow docker image https://github.com/apache/arrow/issues/41637
 RUN cd /arrow-integration/rust && rustup override set 1.77
 
+# Install system zstd (Arrow C++ seems to use the bundled version)
+RUN apt-get update && apt-get install -y libzstd-dev
+
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
     conda run --no-capture-output \

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -52,8 +52,8 @@ RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
 # provided arrow docker image https://github.com/apache/arrow/issues/41637
 RUN cd /arrow-integration/rust && rustup override set 1.77
 
-# Install system zstd (Arrow C++ seems to use the bundled version)
-RUN apt-get update && apt-get install -y libzstd-dev
+# Install conda zstd (Arrow C++ seems to use the bundled version)
+RUN conda install -c conda-forge zstd
 
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -53,7 +53,7 @@ RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
 RUN cd /arrow-integration/rust && rustup override set 1.77
 
 # Install conda zstd (Arrow C++ seems to use the bundled version)
-RUN conda install -c conda-forge zstd
+RUN conda install -c conda-forge zstd-static
 
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -42,8 +42,7 @@ ENV ARROW_RUST_EXE_PATH=/build/rust/debug
 ENV BUILD_DOCS_CPP=OFF
 
 # Clone the arrow monorepo
-RUN git clone https://github.com/paleolimbot/arrow.git /arrow-integration --recurse-submodules && \
-    cd arrow-integration && git switch archery-update-nanoarrow-skip
+RUN git clone https://github.com/apache/arrow.git /arrow-integration --recurse-submodules
 
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
@@ -51,9 +50,6 @@ RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
 # Workaround: stable rust is not compatible with glibc provided by the
 # provided arrow docker image https://github.com/apache/arrow/issues/41637
 RUN cd /arrow-integration/rust && rustup override set 1.77
-
-# Install conda zstd (Arrow C++ seems to use the bundled version)
-RUN conda install -c conda-forge zstd-static
 
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \


### PR DESCRIPTION
This PR updates the CMake such that it works in conda after a `conda install zstd` (which doesn't provide `libzstd_static`, but does provide `libzstd`). This is needed to unskip the integration tests for zstd because the integration image uses conda ( https://github.com/apache/arrow/pull/45205 ).

Previous commits tested https://github.com/apache/arrow/pull/45205 by specifically pulling that branch instead of apache/arrow. When zstd is installed...the tests pass!