### PR TITLE
chore(ci): Use Github linux arm64 runners instead of the self-hosted ones

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -47,9 +47,9 @@ jobs:
           - { runs_on: "ubuntu-latest", platform: "archlinux", arch: "amd64", service: "verify" }
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "amd64", service: "verify" }
 
-          - { runs_on: ["self-hosted", "arm"], platform: "ubuntu", arch: "arm64", service: "verify" }
-          - { runs_on: ["self-hosted", "arm"], platform: "fedora", arch: "arm64", service: "verify" }
-          - { runs_on: ["self-hosted", "arm"], platform: "alpine", arch: "arm64", service: "verify" }
+          - { runs_on: "ubuntu-24.04-arm", platform: "ubuntu", arch: "arm64", service: "verify" }
+          - { runs_on: "ubuntu-24.04-arm", platform: "fedora", arch: "arm64", service: "verify" }
+          - { runs_on: "ubuntu-24.04-arm", platform: "alpine", arch: "arm64", service: "verify" }
 
           - { runs_on: "ubuntu-latest", platform: "alpine", arch: "s390x", service: "verify" }
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -53,6 +53,9 @@ jobs:
         fetch-tags: true
 
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+
     - name: Check that cmake is installed
       run: |
         cmake --version

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -101,7 +101,7 @@ jobs:
           - {os: "windows-2019", label: "windows-amd64", platform: "auto", arch: "AMD64"}
           - {os: "macOS-13", label: "macOS", platform: "auto", arch: "auto"}
           - {os: "macOS-14", label: "macOS-arm64", platform: "auto", arch: "auto"}
-          - {os: ["self-hosted", "arm"], label: "linux-arm64", platform: "auto", arch: "auto"}
+          - {os: "ubuntu-24.04-arm", label: "linux-arm64", platform: "auto", arch: "auto"}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The linux arm64 runners are now GA for open source repos: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/