### PR TITLE
feat: Add `ArrowDecimalAppendStringToBuffer()`

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -50,6 +50,8 @@
 #define ArrowDecimalSetDigits NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDecimalSetDigits)
 #define ArrowDecimalAppendDigitsToBuffer \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDecimalAppendDigitsToBuffer)
+  #define ArrowDecimalAppendStringToBuffer \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowDecimalAppendStringToBuffer)
 #define ArrowSchemaInit NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaInit)
 #define ArrowSchemaInitFromType \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowSchemaInitFromType)
@@ -290,6 +292,10 @@ ArrowErrorCode ArrowDecimalSetDigits(struct ArrowDecimal* decimal,
 
 /// \brief Get the integer value of an ArrowDecimal as string
 ArrowErrorCode ArrowDecimalAppendDigitsToBuffer(const struct ArrowDecimal* decimal,
+                                                struct ArrowBuffer* buffer);
+
+/// \brief Get the decimal value of an ArrowDecimal as a string
+ArrowErrorCode ArrowDecimalAppendStringToBuffer(const struct ArrowDecimal* decimal,
                                                 struct ArrowBuffer* buffer);
 
 /// \brief Get the half float value of a float


### PR DESCRIPTION
We've had `ArrowDecimalAppendDigitsToBuffer()` (because it was required for integration testing), but this only gets the underlying integer representation (e.g., 1234), not the "logical" decimal representation (e.g., 1.234). This logical representation gets returned in database results (e.g., it's what ADBC does for postgres) and can be used to support convert to double where an implementation can parse a string (e.g., in R).

This was extracted out of https://github.com/apache/arrow-nanoarrow/pull/717 , which is a fix for an ADBC issue ( https://github.com/apache/arrow-adbc/issues/2508 ).