### PR TITLE
Add skips for Suggests packages

### DIFF
--- a/r/tests/testthat/test-array.R
+++ b/r/tests/testthat/test-array.R
@@ -87,6 +87,8 @@ test_that("as.vector() and as.data.frame() work for array", {
 })
 
 test_that("as_tibble() works for array()", {
+  skip_if_not_installed("tibble")
+
   struct_array <- as_nanoarrow_array(data.frame(a = 1:10))
   expect_identical(tibble::as_tibble(struct_array), tibble::tibble(a = 1:10))
 })

--- a/r/tests/testthat/test-as-array.R
+++ b/r/tests/testthat/test-as-array.R
@@ -605,6 +605,8 @@ test_that("as_nanoarrow_array() works for matrix -> na_fixed_size_list()", {
 })
 
 test_that("as_nanoarrow_array() works for blob::blob() -> na_fixed_size_binary()", {
+  skip_if_not_installed("blob")
+
   # Without nulls
   array <- as_nanoarrow_array(blob::as_blob(letters), schema = na_fixed_size_binary(1))
   expect_identical(infer_nanoarrow_schema(array)$format, "w:1")
@@ -634,6 +636,8 @@ test_that("as_nanoarrow_array() works for blob::blob() -> na_fixed_size_binary()
 })
 
 test_that("as_nanoarrow_array() works for blob::blob() -> na_large_binary()", {
+  skip_if_not_installed("blob")
+
   # Without nulls
   array <- as_nanoarrow_array(blob::as_blob(letters), schema = na_large_binary())
   expect_identical(infer_nanoarrow_schema(array)$format, "Z")
@@ -663,6 +667,8 @@ test_that("as_nanoarrow_array() works for blob::blob() -> na_large_binary()", {
 })
 
 test_that("as_nanoarrow_array() works for blob::blob() -> na_binary_view()", {
+  skip_if_not_installed("blob")
+
   # Without nulls
   array <- as_nanoarrow_array(blob::as_blob(letters), schema = na_binary_view())
   expect_identical(infer_nanoarrow_schema(array)$format, "vz")

--- a/r/tests/testthat/test-buffer.R
+++ b/r/tests/testthat/test-buffer.R
@@ -21,6 +21,8 @@ test_that("as_nanoarrow_buffer() works for nanoarrow_buffer", {
 })
 
 test_that("as_nanoarrow_buffer() works for R atomic types", {
+  skip_if_not_installed("blob")
+
   buffer_null <- as_nanoarrow_buffer(NULL)
   expect_identical(as.raw(buffer_null), raw(0))
   expect_identical(convert_buffer(buffer_null), blob::blob(raw(0)))

--- a/r/tests/testthat/test-convert-array-stream.R
+++ b/r/tests/testthat/test-convert-array-stream.R
@@ -60,6 +60,8 @@ test_that("convert array stream with explicit size works", {
 })
 
 test_that("convert array stream with functional ptype works", {
+  skip_if_not_installed("tibble")
+
   tibble_or_bust <- function(array, ptype) {
     if (is.data.frame(ptype)) {
       ptype <- tibble::as_tibble(ptype)
@@ -80,6 +82,8 @@ test_that("convert array stream with functional ptype works", {
 })
 
 test_that("convert array stream works for nested data.frames", {
+  skip_if_not_installed("tibble")
+
   tbl_nested_df <- tibble::tibble(a = 1L, b = "two", c = data.frame(a = 3))
 
   stream_nested <- as_nanoarrow_array_stream(tbl_nested_df)

--- a/r/tests/testthat/test-convert-array.R
+++ b/r/tests/testthat/test-convert-array.R
@@ -80,6 +80,8 @@ test_that("convert to vector works for data.frame", {
 })
 
 test_that("convert to vector works for partial_frame", {
+  skip_if_not_installed("vctrs")
+
   array <- as_nanoarrow_array(
     data.frame(a = 1L, b = "two", stringsAsFactors = FALSE)
   )
@@ -115,6 +117,8 @@ test_that("convert to vector works for dictionary<struct> -> data.frame()", {
 })
 
 test_that("convert to vector works for function()", {
+  skip_if_not_installed("tibble")
+
   tibble_or_bust <- function(array, ptype) {
     if (is.data.frame(ptype)) {
       ptype <- tibble::as_tibble(ptype)
@@ -135,6 +139,8 @@ test_that("convert to vector works for function()", {
 })
 
 test_that("convert to vector works for tibble", {
+  skip_if_not_installed("tibble")
+
   array <- as_nanoarrow_array(
     data.frame(a = 1L, b = "two", stringsAsFactors = FALSE)
   )
@@ -293,6 +299,8 @@ test_that("convert to vector works for struct-style vectors", {
 })
 
 test_that("convert to vector works for unspecified()", {
+  skip_if_not_installed("vctrs")
+
   array <- nanoarrow_array_init(na_na())
   array$length <- 10
   array$null_count <- 10
@@ -925,6 +933,8 @@ test_that("convert to vector works for binary_view -> blob::blob()", {
 })
 
 test_that("convert to vector works for null -> blob::blob()", {
+  skip_if_not_installed("blob")
+
   array <- nanoarrow_array_init(na_na())
   array$length <- 10
   array$null_count <- 10
@@ -937,6 +947,7 @@ test_that("convert to vector works for null -> blob::blob()", {
 
 test_that("convert to vector works for list -> vctrs::list_of", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   array_list <- as_nanoarrow_array(
     arrow::Array$create(
@@ -974,6 +985,7 @@ test_that("convert to vector works for list -> vctrs::list_of", {
 
 test_that("convert to vector works for large_list -> vctrs::list_of", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   array_list <- as_nanoarrow_array(
     arrow::Array$create(
@@ -1003,6 +1015,7 @@ test_that("convert to vector works for large_list -> vctrs::list_of", {
 
 test_that("convert to vector works for fixed_size_list -> vctrs::list_of", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   array_list <- as_nanoarrow_array(
     arrow::Array$create(
@@ -1031,6 +1044,8 @@ test_that("convert to vector works for fixed_size_list -> vctrs::list_of", {
 })
 
 test_that("convert to vector works for null -> vctrs::list_of()", {
+  skip_if_not_installed("vctrs")
+
   array <- nanoarrow_array_init(na_na())
   array$length <- 10
   array$null_count <- 10
@@ -1095,6 +1110,8 @@ test_that("convert to vector works for null -> Date", {
 })
 
 test_that("convert to vector works for hms", {
+  skip_if_not_installed("hms")
+
   array_time <- as_nanoarrow_array(hms::parse_hm("12:34"))
   expect_identical(
     convert_array(array_time),
@@ -1103,6 +1120,8 @@ test_that("convert to vector works for hms", {
 })
 
 test_that("convert to vector works for null -> hms", {
+  skip_if_not_installed("hms")
+
   array <- nanoarrow_array_init(na_na())
   array$length <- 10
   array$null_count <- 10
@@ -1217,6 +1236,7 @@ test_that("convert to vector works for null -> difftime", {
 
 test_that("convert to vector works for data frames nested inside lists", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   df_in_list <- vctrs::list_of(
     data.frame(x = 1:5),
@@ -1233,6 +1253,7 @@ test_that("convert to vector works for data frames nested inside lists", {
 
 test_that("convert to vector works for lists nested in data frames", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   df_in_list_in_df <- data.frame(
     x = vctrs::list_of(

--- a/r/tests/testthat/test-extension-vctrs.R
+++ b/r/tests/testthat/test-extension-vctrs.R
@@ -72,6 +72,7 @@ test_that("vctrs extension type respects `to` in convert_array()", {
 
 test_that("serialize_ptype() can roundtrip R objects", {
   skip_if_not_installed("jsonlite")
+  skip_if_not_installed("tibble")
 
   vectors <- list(
     null = NULL,

--- a/r/tests/testthat/test-infer-ptype.R
+++ b/r/tests/testthat/test-infer-ptype.R
@@ -32,6 +32,8 @@ test_that("infer_nanoarrow_ptype() works on arrays, schemas, and streams", {
 })
 
 test_that("infer_nanoarrow_ptype() works for basic types", {
+  skip_if_not_installed("vctrs")
+
   expect_identical(
     infer_nanoarrow_ptype(as_nanoarrow_array(vctrs::unspecified())),
     vctrs::unspecified()
@@ -71,6 +73,8 @@ test_that("infer_nanoarrow_ptype() works for basic types", {
 })
 
 test_that("infer_nanoarrow_ptype() infers ptypes for date/time types", {
+  skip_if_not_installed("hms")
+
   array_date <- as_nanoarrow_array(as.Date("2000-01-01"))
   expect_identical(
     infer_nanoarrow_ptype(array_date),
@@ -100,6 +104,7 @@ test_that("infer_nanoarrow_ptype() infers ptypes for date/time types", {
 
 test_that("infer_nanoarrow_ptype() infers ptypes for nested types", {
   skip_if_not_installed("arrow")
+  skip_if_not_installed("vctrs")
 
   array_list <- as_nanoarrow_array(vctrs::list_of(integer()))
   expect_identical(


### PR DESCRIPTION
This completes the existing set of `skip_if_not_installed()` directives