### PR TITLE
fix: Remove rust version pin for integration test job

### DIFF
--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -47,10 +47,6 @@ RUN git clone https://github.com/apache/arrow.git /arrow-integration --recurse-s
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs /arrow-integration/rust
 
-# Workaround: stable rust is not compatible with glibc provided by the
-# provided arrow docker image https://github.com/apache/arrow/issues/41637
-RUN cd /arrow-integration/rust && rustup override set 1.77
-
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
     conda run --no-capture-output \


### PR DESCRIPTION
Apply https://github.com/apache/arrow/pull/45790 / https://github.com/apache/arrow-rs/pull/7292 to fix the failing integration test job.

```
 ------
   > [integration 5/5] RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0"     conda run --no-capture-output     /arrow-integration/ci/scripts/integration_arrow_build.sh     /arrow-integration     /build:
  4.312   Downloaded cfg-if v1.0.0
  4.314   Downloaded async-stream v0.3.6
  4.317   Downloaded anstyle v1.0.10
  4.319   Downloaded adler2 v2.0.0
  4.321   Downloaded http-body v1.0.1
  4.374 error: package `half v2.5.0` cannot be built because it requires rustc 1.81 or newer, while the currently active rustc version is 1.77.2
  4.374 Either upgrade to rustc 1.81 or newer, or use
  4.374 cargo update half@2.5.0 --precise ver
  4.374 where `ver` is the latest version of `half` supporting rustc 1.77.2
  4.386 ERROR conda.cli.main_run:execute(125): `conda run /arrow-integration/ci/scripts/integration_arrow_build.sh /arrow-integration /build` failed. (See above for error)
  ------
  failed to solve: process "/bin/bash -c -l ARCHERY_INTEGRATION_WITH_NANOARROW=\"0\"     conda run --no-capture-output     /arrow-integration/ci/scripts/integration_arrow_build.sh     /arrow-integration     /build" did not complete successfully: exit code: 101
```