### PR TITLE
feat: Use hidden symbol linkage in Meson configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,12 +30,6 @@ project(
     ],
 )
 
-# This bit depends on proper symbol exporting which hasn't yet been implemented
-# generally for all of nanoarrow's libraries
-# if meson.get_compiler('cpp').get_id() == 'gcc' or meson.get_compiler('cpp').get_id() == 'clang'
-#   add_project_arguments(['-fvisibility=hidden'], language: 'cpp')
-# endif
-
 cc = meson.get_compiler('c')
 add_project_arguments(
     cc.get_supported_arguments(['-Wno-misleading-indentation']),
@@ -99,6 +93,7 @@ nanoarrow_lib = library(
     'src/nanoarrow/common/utils.c',
     include_directories: [incdir],
     install: true,
+    gnu_symbol_visibility: 'hidden',
 )
 
 nanoarrow_dep = declare_dependency(
@@ -134,6 +129,7 @@ if get_option('ipc')
         dependencies: ipc_lib_deps,
         install: true,
         c_args: ipc_lib_c_args,
+        gnu_symbol_visibility: 'hidden',
     )
     nanoarrow_ipc_dep = declare_dependency(
         include_directories: [incdir],
@@ -172,6 +168,7 @@ if needs_device
         dependencies: device_deps,
         install: true,
         cpp_args: device_defines,
+        gnu_symbol_visibility: 'hidden',
     )
 
     nanoarrow_device_dep = declare_dependency(
@@ -191,6 +188,7 @@ if needs_testing
         dependencies: [nanoarrow_dep, nlohmann_json_dep],
         include_directories: incdir,
         install: true,
+        gnu_symbol_visibility: 'hidden',
     )
 
     nanoarrow_testing_dep = declare_dependency(
@@ -206,6 +204,7 @@ if get_option('tests') or get_option('integration_tests')
         'src/nanoarrow/integration/c_data_integration.cc',
         dependencies: [nanoarrow_testing_dep, nanoarrow_dep],
         include_directories: incdir,
+        gnu_symbol_visibility: 'hidden',
     )
 
 endif

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -310,8 +310,8 @@ NANOARROW_DLL ArrowErrorCode ArrowDecimalAppendDigitsToBuffer(
     const struct ArrowDecimal* decimal, struct ArrowBuffer* buffer);
 
 /// \brief Get the decimal value of an ArrowDecimal as a string
-ArrowErrorCode ArrowDecimalAppendStringToBuffer(const struct ArrowDecimal* decimal,
-                                                struct ArrowBuffer* buffer);
+NANOARROW_DLL ArrowErrorCode ArrowDecimalAppendStringToBuffer(
+    const struct ArrowDecimal* decimal, struct ArrowBuffer* buffer);
 
 /// \brief Get the half float value of a float
 static inline uint16_t ArrowFloatToHalfFloat(float value);

--- a/src/nanoarrow/nanoarrow_ipc.h
+++ b/src/nanoarrow/nanoarrow_ipc.h
@@ -161,7 +161,7 @@ enum ArrowIpcCompressionType {
 #define NANOARROW_IPC_FEATURE_COMPRESSED_BODY 2
 
 /// \brief Checks the nanoarrow runtime to make sure the run/build versions match
-ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error);
+NANOARROW_DLL ArrowErrorCode ArrowIpcCheckRuntime(struct ArrowError* error);
 
 /// \brief Get the endianness of the current runtime
 static inline enum ArrowIpcEndianness ArrowIpcSystemEndianness(void) {
@@ -533,7 +533,7 @@ struct ArrowIpcEncoder {
 NANOARROW_DLL ArrowErrorCode ArrowIpcEncoderInit(struct ArrowIpcEncoder* encoder);
 
 /// \brief Release all resources attached to an encoder
-void ArrowIpcEncoderReset(struct ArrowIpcEncoder* encoder);
+NANOARROW_DLL void ArrowIpcEncoderReset(struct ArrowIpcEncoder* encoder);
 
 /// \brief Finalize the most recently encoded message into a buffer
 ///


### PR DESCRIPTION
This is a follow up to #719 enabling hidden symbol visibility in the Meson configuration