### PR TITLE
fix: ArrowDecimalSetDigits() on s390x + test fixes for big endian

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,6 +50,8 @@ concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
+# TODO: this is a quick way to get the big endian check to run on ci
+
 jobs:
   verify:
     name: "${{ matrix.config.label }}"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -50,8 +50,6 @@ concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-# TODO: this is a quick way to get the big endian check to run on ci
-
 jobs:
   verify:
     name: "${{ matrix.config.label }}"

--- a/src/nanoarrow/common/utils_test.cc
+++ b/src/nanoarrow/common/utils_test.cc
@@ -19,6 +19,7 @@
 #include <string>
 
 #if defined(NANOARROW_BUILD_TESTS_WITH_ARROW)
+#include <arrow/config.h>
 #include <arrow/util/decimal.h>
 #endif
 #include <gmock/gmock-matchers.h>

--- a/src/nanoarrow/common/utils_test.cc
+++ b/src/nanoarrow/common/utils_test.cc
@@ -402,7 +402,7 @@ TEST(DecimalTest, DecimalNegateTest) {
     } else if (bitwidth == 64) {
       decimal.words[decimal.low_word_index] = std::numeric_limits<int64_t>::max();
     } else {
-      decimal.words[decimal.low_word_index] = std::numeric_limits<int32_t>::max();
+      ArrowDecimalSetInt(&decimal, std::numeric_limits<int32_t>::max());
     }
     ASSERT_EQ(ArrowDecimalSign(&decimal), 1);
     ArrowDecimalNegate(&decimal);
@@ -416,8 +416,7 @@ TEST(DecimalTest, DecimalNegateTest) {
       EXPECT_EQ(decimal.words[decimal.low_word_index],
                 std::numeric_limits<int64_t>::max());
     } else {
-      EXPECT_EQ(decimal.words[decimal.low_word_index],
-                std::numeric_limits<int32_t>::max());
+      EXPECT_EQ(ArrowDecimalGetIntUnsafe(&decimal), std::numeric_limits<int32_t>::max());
     }
 
     if (bitwidth > 64) {
@@ -612,7 +611,7 @@ TEST(DecimalTest, DecimalRoundtripPowerOfTenTest) {
 
         buffer.size_bytes = 0;
         ASSERT_EQ(ArrowDecimalAppendDigitsToBuffer(&decimal, &buffer), NANOARROW_OK);
-        EXPECT_EQ(std::string(reinterpret_cast<char*>(buffer.data), buffer.size_bytes),
+        ASSERT_EQ(std::string(reinterpret_cast<char*>(buffer.data), buffer.size_bytes),
                   ss.str());
       }
     }

--- a/src/nanoarrow/common/utils_test.cc
+++ b/src/nanoarrow/common/utils_test.cc
@@ -583,7 +583,7 @@ TEST(DecimalTest, DecimalRoundtripPowerOfTenTest) {
   std::vector<std::pair<int, int>> bitwidth_and_max_precision = {
       {32, 9}, {64, 18}, {128, 38}, {256, 76}};
 
-  for (const auto item : bitwidth_and_max_precision) {
+  for (const auto& item : bitwidth_and_max_precision) {
     SCOPED_TRACE(item.first);
 
     struct ArrowDecimal decimal;

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -372,6 +372,8 @@ void TestDecodeInt32Batch(const uint8_t* batch, size_t batch_len,
 
   ASSERT_EQ(ArrowIpcDecoderInit(decoder.get()), NANOARROW_OK);
   ASSERT_EQ(ArrowIpcDecoderSetSchema(decoder.get(), schema.get(), &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowIpcDecoderSetEndianness(decoder.get(), NANOARROW_IPC_ENDIANNESS_LITTLE),
+            NANOARROW_OK);
 
   ASSERT_EQ(ArrowIpcDecoderDecodeHeader(decoder.get(), data, &error), NANOARROW_OK);
   struct ArrowBufferView body;

--- a/src/nanoarrow/ipc/files_test.cc
+++ b/src/nanoarrow/ipc/files_test.cc
@@ -526,14 +526,16 @@ TEST_P(TestFileFixture, NanoarrowIpcTestFileIPCCheckJSON) {
   param.TestIPCCheckJSON(dir_builder.str());
 }
 
+// At least one Windows MSVC version does not allow the #if defined()
+// to be within a macro invocation, so we define these two cases
+// with some repetition.
+#if defined(NANOARROW_IPC_WITH_ZSTD)
 INSTANTIATE_TEST_SUITE_P(
     NanoarrowIpcTest, TestFileFixture,
     ::testing::Values(
-// Testing of other files
-#if defined(NANOARROW_IPC_WITH_ZSTD)
+        // Testing of other files
         TestFile::OK("2.0.0-compression/generated_uncompressible_zstd.stream"),
         TestFile::OK("2.0.0-compression/generated_zstd.stream"),
-#endif
         TestFile::OK("0.17.1/generated_union.stream"),
         TestFile::OK("0.14.1/generated_datetime.stream"),
         TestFile::OK("0.14.1/generated_decimal.stream"),
@@ -545,5 +547,21 @@ INSTANTIATE_TEST_SUITE_P(
         TestFile::OK("0.14.1/generated_primitive_zerolength.stream")
         // Comment to keep line from wrapping
         ));
+#else
+INSTANTIATE_TEST_SUITE_P(NanoarrowIpcTest, TestFileFixture,
+                         ::testing::Values(
+                             // Testing of other files
+                             TestFile::OK("0.17.1/generated_union.stream"),
+                             TestFile::OK("0.14.1/generated_datetime.stream"),
+                             TestFile::OK("0.14.1/generated_decimal.stream"),
+                             TestFile::OK("0.14.1/generated_interval.stream"),
+                             TestFile::OK("0.14.1/generated_map.stream"),
+                             TestFile::OK("0.14.1/generated_nested.stream"),
+                             TestFile::OK("0.14.1/generated_primitive.stream"),
+                             TestFile::OK("0.14.1/generated_primitive_no_batches.stream"),
+                             TestFile::OK("0.14.1/generated_primitive_zerolength.stream")
+                             // Comment to keep line from wrapping
+                             ));
+#endif
 
 #endif


### PR DESCRIPTION
This PR fixes Decimal32 and Decimal64 handling on big endian. The previous code used a cast on the least significant word to convert between 64-bit words and the 32 bit value; however, this is only correct on big endian. This was exposed by #720, which in turn exposed that the get/set digits behaviour was not tested for Decimal 32/64. This code was updated to use a `memcpy()` instead of a cast for the 32-bit case. The s390x workflow had been failing because of a segfaulting compiler for a while and so I'd missed that the decimal 32/64 change had broken it 😬 .

There is also one change to get the Windows verification job passing that I noticed when running the verify.yaml workflow to test big endian.

This can be checked locally with:

```shell
export NANOARROW_ARCH=s390x  
docker compose run --rm verify     
```

(and was also checked via the verify.yaml workflow)