### PR TITLE
fix: Fix potential integer overflows

### DIFF
--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -1218,7 +1218,7 @@ static inline struct ArrowStringView ArrowArrayViewGetStringUnsafe(
     case NANOARROW_TYPE_BINARY:
       view.data = data_view + offsets_view->data.as_int32[i];
       view.size_bytes =
-          offsets_view->data.as_int32[i + 1] - offsets_view->data.as_int32[i];
+          (int64_t)offsets_view->data.as_int32[i + 1] - offsets_view->data.as_int32[i];
       break;
     case NANOARROW_TYPE_LARGE_STRING:
     case NANOARROW_TYPE_LARGE_BINARY:
@@ -1258,7 +1258,7 @@ static inline struct ArrowBufferView ArrowArrayViewGetBytesUnsafe(
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_BINARY:
       view.size_bytes =
-          offsets_view->data.as_int32[i + 1] - offsets_view->data.as_int32[i];
+          (int64_t)offsets_view->data.as_int32[i + 1] - offsets_view->data.as_int32[i];
       view.data.as_uint8 = data_view + offsets_view->data.as_int32[i];
       break;
     case NANOARROW_TYPE_LARGE_STRING:

--- a/src/nanoarrow/common/schema.c
+++ b/src/nanoarrow/common/schema.c
@@ -1353,7 +1353,7 @@ ArrowErrorCode ArrowSchemaViewInit(struct ArrowSchemaView* schema_view,
 
   ArrowLayoutInit(&schema_view->layout, schema_view->storage_type);
   if (schema_view->storage_type == NANOARROW_TYPE_FIXED_SIZE_BINARY) {
-    schema_view->layout.element_size_bits[1] = schema_view->fixed_size * 8;
+    schema_view->layout.element_size_bits[1] = (int64_t)schema_view->fixed_size * 8;
   } else if (schema_view->storage_type == NANOARROW_TYPE_FIXED_SIZE_LIST) {
     schema_view->layout.child_size_elements = schema_view->fixed_size;
   }

--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -1081,7 +1081,7 @@ ArrowErrorCode ArrowIpcDecoderVerifyHeader(struct ArrowIpcDecoder* decoder,
 
   // Check that data contains at least the entire header (return ESPIPE to signal
   // that reading more data may help).
-  if (data.size_bytes < decoder->header_size_bytes - prefix_size_bytes) {
+  if (data.size_bytes < (int64_t)decoder->header_size_bytes - prefix_size_bytes) {
     ArrowErrorSet(error,
                   "Expected >= %d bytes of remaining data but found %" PRId64
                   " bytes in buffer",
@@ -1203,7 +1203,7 @@ ArrowErrorCode ArrowIpcDecoderDecodeHeader(struct ArrowIpcDecoder* decoder,
 
   // Check that data contains at least the entire header (return ESPIPE to signal
   // that reading more data may help).
-  if (data.size_bytes < decoder->header_size_bytes - prefix_size_bytes) {
+  if (data.size_bytes < (int64_t)decoder->header_size_bytes - prefix_size_bytes) {
     ArrowErrorSet(error,
                   "Expected >= %d bytes of remaining data but found %" PRId64
                   " bytes in buffer",


### PR DESCRIPTION
This patch extends int32 operands to 64 bits in arithmetic expressions where the result is assigned to int64 members, or compared with them.

Closes #735