### PR TITLE
chore: Enable discussions in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,8 +23,15 @@ github:
     squash:  true
   features:
     issues: true
+    discussions: true
+  labels:
+    - arrow
+  protected_branches:
+    main: {}
 
 notifications:
   commits:      commits@arrow.apache.org
+  discussions:  user@arrow.apache.org
+  issues_status: issues@arrow.apache.org
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org


### PR DESCRIPTION
Mailing list thread voting to enable them: https://lists.apache.org/thread/551ll326to6wflf2hp87vg01w1pq60ll

The ADBC PR I used as a template for this change: https://github.com/apache/arrow-adbc/pull/2649

I also synced a few other fields from ADBC's .asf.yaml that seemed relevant (protected branches, issues_status mailing list).