### PR TITLE
feat: Use feature options instead of boolean in Meson

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ cd builddir
 After setting up your project, be sure to enable the options you want:
 
 ```sh
-meson configure -Dtests=true -Dbenchmarks=true
+meson configure -Dtests=enabled -Dbenchmarks=enabled
 ```
 
 You can enable better test coverage if Apache Arrow is installed on your system
-with `-Dtest_with_arrow=true`. Depending on how you have installed Apache Arrow,
+with `-Dtest_with_arrow=enabled`. Depending on how you have installed Apache Arrow,
 you may also need to pass `--pkg-config-path <path to directory with arrow.pc>`.
 
 With the above out of the way, the `compile` command should take care of the rest:

--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -69,10 +69,10 @@ function main() {
     meson configure \
           -Dbuildtype=debugoptimized \
           -Db_sanitize="address,undefined" \
-          -Dtests=true \
-          -Dipc=true \
-          -Ddevice=true \
-          -Dbenchmarks=false \
+          -Dtests=enabled \
+          -Dipc=enabled \
+          -Ddevice=enabled \
+          -Dbenchmarks=disabled \
           -Db_coverage=false
 
     meson compile
@@ -82,10 +82,10 @@ function main() {
     meson configure \
           -Dbuildtype=debugoptimized \
           -Db_sanitize=none \
-          -Dtests=true \
-          -Dipc=true \
-          -Ddevice=true \
-          -Dbenchmarks=false \
+          -Dtests=enabled \
+          -Dipc=enabled \
+          -Ddevice=enabled \
+          -Dbenchmarks=disabled \
           -Db_coverage=false
     meson compile
     meson test --wrap='valgrind --track-origins=yes --leak-check=full' --print-errorlog
@@ -94,10 +94,10 @@ function main() {
     meson configure \
           -Dbuildtype=release \
           -Db_sanitize=none \
-          -Dtests=false \
-          -Dipc=true \
-          -Ddevice=true \
-          -Dbenchmarks=true \
+          -Dtests=disabled \
+          -Dipc=enabled \
+          -Ddevice=enabled \
+          -Dbenchmarks=enabled \
           -Db_coverage=false
     meson compile
     meson test --benchmark --print-errorlogs
@@ -106,10 +106,10 @@ function main() {
     meson configure \
           -Dbuildtype=release \
           -Db_sanitize=none \
-          -Dtests=true \
-          -Dipc=true \
-          -Ddevice=true \
-          -Dbenchmarks=false \
+          -Dtests=enabled \
+          -Dipc=enabled \
+          -Ddevice=enabled \
+          -Dbenchmarks=disabled \
           -Db_coverage=true
 
     meson compile

--- a/meson.build
+++ b/meson.build
@@ -102,12 +102,12 @@ nanoarrow_dep = declare_dependency(
     compile_args: nanoarrow_dep_args,
 )
 
-if get_option('ipc')
+if get_option('ipc').enabled()
     flatcc_dep = dependency('flatcc')
     ipc_lib_deps = [nanoarrow_dep, flatcc_dep]
     ipc_lib_c_args = []
 
-    if get_option('ipc_with_zstd')
+    if get_option('ipc_with_zstd').enabled()
         zstd_dep = dependency('libzstd')
         ipc_lib_deps += zstd_dep
         ipc_lib_c_args += '-DNANOARROW_IPC_WITH_ZSTD'
@@ -138,13 +138,15 @@ if get_option('ipc')
     )
 endif
 
-needs_device = get_option('device') or get_option('metal') or get_option('cuda')
+needs_device = get_option('device').enabled() or get_option('metal').enabled() or get_option(
+    'cuda',
+).enabled()
 if needs_device
     device_deps = [nanoarrow_dep]
     device_srcs = ['src/nanoarrow/device/device.c']
     device_defines = []
 
-    if get_option('metal')
+    if get_option('metal').enabled()
         metal_dep = dependency(
             'appleframeworks',
             modules: ['Foundation', 'Metal'],
@@ -156,7 +158,7 @@ if needs_device
         device_defines += '-DNANOARROW_DEVICE_WITH_METAL'
     endif
 
-    if get_option('cuda')
+    if get_option('cuda').enabled()
         error('CUDA support with the Meson build system is not implemented')
     endif
 
@@ -178,7 +180,7 @@ if needs_device
     )
 endif
 
-needs_testing = get_option('testing') or get_option('tests')
+needs_testing = get_option('testing').enabled() or get_option('tests').enabled()
 if needs_testing
     nlohmann_json_dep = dependency('nlohmann_json')
 
@@ -198,7 +200,7 @@ if needs_testing
     )
 endif
 
-if get_option('tests') or get_option('integration_tests')
+if get_option('tests').enabled() or get_option('integration_tests').enabled()
     c_data_integration_lib = library(
         'nanoarrow_c_data_integration',
         'src/nanoarrow/integration/c_data_integration.cc',
@@ -209,7 +211,7 @@ if get_option('tests') or get_option('integration_tests')
 
 endif
 
-if get_option('tests')
+if get_option('tests').enabled()
     # CMake configuration sets MEMORYCHECK_COMMAND_OPTIONS but with meson you instead
     # wrap the tests with valgrind via `meson test --wrap=valgrind`. See
     # https://mesonbuild.com/Unit-tests.html
@@ -218,12 +220,12 @@ if get_option('tests')
     # https://mesonbuild.com/Unit-tests.html#coverage
 
     arrow_dep = dependency('arrow', include_type: 'system', required: false)
-    if get_option('tests_with_arrow') and not arrow_dep.found()
+    if get_option('tests_with_arrow').enabled() and not arrow_dep.found()
         error('tests_with_arrow=true but could not find Arrow')
     endif
 
     test_cpp_args = []
-    if get_option('tests_with_arrow')
+    if get_option('tests_with_arrow').enabled()
         test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
     endif
 
@@ -282,7 +284,7 @@ if get_option('tests')
     )
     test('c-data-integration', c_data_integration_test)
 
-    if get_option('ipc')
+    if get_option('ipc').enabled()
         zlib_dep = dependency('zlib')
         ipc_test_files = {
             'ipc-decoder': {
@@ -344,7 +346,7 @@ if get_option('tests')
             test(device_test.replace('_', '-'), exc)
         endforeach
 
-        if get_option('metal')
+        if get_option('metal').enabled()
             exc = executable(
                 'nanoarrow-device-metal-test',
                 'src/nanoarrow/device/metal_test.cc',
@@ -357,13 +359,13 @@ if get_option('tests')
 endif
 
 
-if get_option('benchmarks')
+if get_option('benchmarks').enabled()
     subdir('dev/benchmarks')
 endif
 
 
-if get_option('apps')
-    if get_option('ipc')
+if get_option('apps').enabled()
+    if get_option('ipc').enabled()
         executable(
             'dump_stream',
             'src/apps/dump_stream.c',

--- a/meson.options
+++ b/meson.options
@@ -15,19 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('tests', type: 'boolean', description: 'Build tests', value: false)
-option('tests_with_arrow', type: 'boolean', description: 'Build tests with Arrow', value: false)
-option('benchmarks', type: 'boolean', description: 'Build benchmarks', value: false)
-option('apps', type: 'boolean', description: 'Build utility applications', value: false)
-option('ipc', type: 'boolean', description: 'Build IPC libraries', value: false)
-option('ipc_with_zstd', type: 'boolean', description: 'Build IPC libraries with ZSTD compression support', value: false)
-option('integration_tests', type: 'boolean',
-       description: 'Build cross-implementation Arrow integration tests',
-       value: false)
+option('tests', type: 'feature', description: 'Build tests')
+option('tests_with_arrow', type: 'feature', description: 'Build tests with Arrow')
+option('benchmarks', type: 'feature', description: 'Build benchmarks')
+option('apps', type: 'feature', description: 'Build utility applications')
+option('ipc', type: 'feature', description: 'Build IPC libraries')
+option('ipc_with_zstd', type: 'feature', description: 'Build IPC libraries with ZSTD compression support')
+option(
+    'integration_tests', type: 'feature',
+    description: 'Build cross-implementation Arrow integration tests',
+)
 option('namespace', type: 'string',
        description: 'A prefix for exported symbols')
-option('device', type: 'boolean', description: 'Build device libraries', value: false)
-option('testing', type: 'boolean', description: 'Build testing libraries', value: false)
-option('metal', type: 'boolean', description: 'Build Apple metal libraries',
-       value: false)
-option('cuda', type: 'boolean', description: 'Build CUDA libraries', value: false)
+option('device', type: 'feature', description: 'Build device libraries')
+option('testing', type: 'feature', description: 'Build testing libraries')
+option('metal', type: 'feature', description: 'Build Apple metal libraries')
+option('cuda', type: 'feature', description: 'Build CUDA libraries')

--- a/python/meson.build
+++ b/python/meson.build
@@ -29,9 +29,9 @@ project(
         'force_fallback_for=zstd',
         # We need to set these options at the project default_option level
         # due to https://github.com/mesonbuild/meson/issues/6728
-        'arrow-nanoarrow:ipc=true',
-        'arrow-nanoarrow:ipc_with_zstd=true',
-        'arrow-nanoarrow:device=true',
+        'arrow-nanoarrow:ipc=enabled',
+        'arrow-nanoarrow:ipc_with_zstd=enabled',
+        'arrow-nanoarrow:device=enabled',
         'arrow-nanoarrow:namespace=PythonPkg',
         'zstd:bin_programs=false',
     ],


### PR DESCRIPTION
The feature option is pretty similar to the previous boolean setting, but allows three states of enabled, disabled, and auto.

auto by default is disabled, but you can set `-Dauto_features=enabled` to have that toggle to enabled. By doing so, you can let users either start with nothing and opt-in to everything, or opt-in by default and then opt-out of the components they do not want