### PR TITLE
chore(r): Remove conditional ALTREP usage and remove call to DATAPTR

### DIFF
--- a/r/src/altrep.h
+++ b/r/src/altrep.h
@@ -18,15 +18,14 @@
 #ifndef R_ALTREP_H_INCLUDED
 #define R_ALTREP_H_INCLUDED
 
-#include "Rversion.h"
+#include <R.h>
+#include <Rinternals.h>
+#include <Rversion.h>
+
+// Needs to be at the end of the R include list
+#include <R_ext/Altrep.h>
 
 #include <string.h>
-
-// ALTREP available in R >= 3.5
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 5, 0)
-
-#define HAS_ALTREP
-#include <R_ext/Altrep.h>
 
 // Returns the ALTREP class name or NULL if x is not an altrep
 // object.
@@ -38,12 +37,6 @@ static inline const char* nanoarrow_altrep_class(SEXP x) {
     return NULL;
   }
 }
-
-#else
-
-static inline const char* nanoarrow_altrep_class(SEXP x) { return NULL; }
-
-#endif
 
 // Performs the ALTREP type registration and should be called on package load
 void register_nanoarrow_altrep(DllInfo* info);


### PR DESCRIPTION
From the CRAN check page:

```
  File ‘nanoarrow/libs/nanoarrow.so’:
    Found non-API call to R: ‘DATAPTR’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
  and section ‘Moving into C API compliance’ for issues with the use of
  non-API entry points.
```

When fixing this I also saw that we have conditional ALTREP usage. ALTREP has been available since R 3.5.0, which is two versions before what our CI matrix checks. I removed the conditional bits that were no longer needed (i.e., we now always assume that `R_ext/altrep.h` is available).