### PR TITLE
chore(r): Fix -Wkeyword-macro for flatcc header when compiled with C23

### DIFF
--- a/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
+++ b/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
@@ -140,6 +140,9 @@ extern "C" {
 
 #endif /* __STDC__ */
 
+// For C23, alignas/alignof are keywords and will warn (-Wkeyword-macro) when #defined here
+#if !(defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+
 #ifndef alignas
 #define alignas _Alignas
 #endif
@@ -150,6 +153,8 @@ extern "C" {
 
 #define __alignas_is_defined 1
 #define __alignof_is_defined 1
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
+++ b/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
@@ -151,10 +151,10 @@ extern "C" {
 #define alignof _Alignof
 #endif
 
+#endif
+
 #define __alignas_is_defined 1
 #define __alignof_is_defined 1
-
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes #740.

I check with `usethis::edit_r_makevars()`:

```
CC=clang -std=c2x
CFLAGS=-Wkeyword-macro
```

The error doesn't reproduce on `r-hub/containers/clang20`, possibly because it's not using `-std=c23` or didn't build clang with the option to use that as the default C standard.