### PR TITLE
chore: fix dead code on clone of zero size shared buffer

### DIFF
--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -200,10 +200,8 @@ ArrowErrorCode ArrowIpcSharedBufferInit(struct ArrowIpcSharedBuffer* shared,
 
 static void ArrowIpcSharedBufferClone(struct ArrowIpcSharedBuffer* shared,
                                       struct ArrowBuffer* shared_out) {
-  if (shared->private_src.data == NULL) {
+  if (shared->private_src.size_bytes == 0) {
     ArrowBufferInit(shared_out);
-    shared_out->size_bytes = shared_out->size_bytes;
-    shared_out->capacity_bytes = shared_out->capacity_bytes;
     return;
   }
 


### PR DESCRIPTION
This in theory shouldn't happen because the outer code checks for a zero size specification from the IPC message header; however, we can at least make sure it is correct. (I didn't add a test because this is a static internal function).

Closes #734.