### PR TITLE
fix: Fix valgrind error suggesting use of an uninitialized value

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -127,7 +127,9 @@ jobs:
           path: build/Testing/Temporary/MemoryChecker.*.log
 
   meson-build:
-    runs-on: ubuntu-latest
+    # Can't quite be ubuntu-latest yet
+    # https://github.com/apache/arrow-nanoarrow/issues/753
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -139,6 +141,8 @@ jobs:
           sudo apt-get update && sudo apt-get install -y gcovr ninja-build valgrind
 
       - name: Install meson
+        # Meson 1.8.0 breaks build
+        # https://github.com/apache/arrow-nanoarrow/issues/753
         run: |
           python3 -m pip install "meson<1.8.0"
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -126,8 +126,7 @@ jobs:
           name: nanoarrow-memcheck
           path: build/Testing/Temporary/MemoryChecker.*.log
 
-  verify-meson:
-    name: meson-build
+  meson-build:
     # Workaround until https://github.com/apache/arrow-nanoarrow/issues/663 is solved
     # (after which we can use ubuntu-latest)
     runs-on: ubuntu-22.04
@@ -143,7 +142,7 @@ jobs:
 
       - name: Install meson
         run: |
-          python3 -m pip install meson
+          python3 -m pip install "meson<1.8.0"
 
       - name: Cache Arrow C++ Build
         id: cache-arrow-build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -127,9 +127,7 @@ jobs:
           path: build/Testing/Temporary/MemoryChecker.*.log
 
   meson-build:
-    # Workaround until https://github.com/apache/arrow-nanoarrow/issues/663 is solved
-    # (after which we can use ubuntu-latest)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/src/nanoarrow/hpp/view.hpp
+++ b/src/nanoarrow/hpp/view.hpp
@@ -32,11 +32,11 @@ struct Nothing {};
 template <typename T>
 class Maybe {
  public:
-  Maybe() : nothing_(Nothing()), is_something_(false) {}
+  Maybe() : is_something_(false) {}
   Maybe(Nothing) : Maybe() {}
 
   Maybe(T something)  // NOLINT(google-explicit-constructor)
-      : something_(something), is_something_(true) {}
+      : is_something_(true), something_(something) {}
 
   explicit constexpr operator bool() const { return is_something_; }
 
@@ -60,11 +60,8 @@ class Maybe {
   // is_trivially_copyable<T>::value
   static_assert(std::is_trivially_destructible<T>::value, "");
 
-  union {
-    Nothing nothing_;
-    T something_;
-  };
-  bool is_something_;
+  bool is_something_{};
+  T something_{};
 };
 
 template <typename Get>

--- a/src/nanoarrow/hpp/view.hpp
+++ b/src/nanoarrow/hpp/view.hpp
@@ -43,8 +43,13 @@ class Maybe {
   const T& operator*() const { return something_; }
 
   friend inline bool operator==(Maybe l, Maybe r) {
-    if (l.is_something_ != r.is_something_) return false;
-    return l.is_something_ ? l.something_ == r.something_ : true;
+    if (l.is_something_) {
+      return r.is_something_ && l.something_ == r.something_;
+    } else if (r.is_something_) {
+      return l.is_something_ && l.something_ == r.something_;
+    } else {
+      return l.is_something_ == r.is_something_;
+    }
   }
   friend inline bool operator!=(Maybe l, Maybe r) { return !(l == r); }
 


### PR DESCRIPTION
I'm not sure that anything was actually wrong here, but writing it differently helped valgrind understand what's going on. I also added a pin for meson since the latest version results in failing CI when running valgrind (and opened #753 to track removing the pin).

Closes #749.