### PR TITLE
chore: Help clang-tidy avoid errors when calling AppendBitmapInt8

### DIFF
--- a/src/nanoarrow/common/inline_buffer.h
+++ b/src/nanoarrow/common/inline_buffer.h
@@ -624,6 +624,9 @@ static inline void ArrowBitmapAppendInt8Unsafe(struct ArrowBitmap* bitmap,
     return;
   }
 
+  NANOARROW_DCHECK(bitmap->buffer.data != NULL);
+  NANOARROW_DCHECK(values != NULL);
+
   const int8_t* values_cursor = values;
   int64_t n_remaining = n_values;
   int64_t out_i_cursor = bitmap->size_bits;
@@ -670,6 +673,9 @@ static inline void ArrowBitmapAppendInt32Unsafe(struct ArrowBitmap* bitmap,
   if (n_values == 0) {
     return;
   }
+
+  NANOARROW_DCHECK(bitmap->buffer.data != NULL);
+  NANOARROW_DCHECK(values != NULL);
 
   const int32_t* values_cursor = values;
   int64_t n_remaining = n_values;

--- a/src/nanoarrow/ipc/reader_test.cc
+++ b/src/nanoarrow/ipc/reader_test.cc
@@ -103,7 +103,7 @@ TEST(NanoarrowIpcReader, InputStreamBuffer) {
 // if an assertion fails
 struct FileCloser {
   FileCloser(FILE* file) : file_(file) {}
-  ~FileCloser() { fclose(file_); }
+  ~FileCloser() { if (file_) fclose(file_); }
   FILE* file_{};
 };
 
@@ -122,7 +122,9 @@ TEST(NanoarrowIpcReader, InputStreamFile) {
   uint8_t output_data[] = {0xff, 0xff, 0xff, 0xff, 0xff};
   int64_t size_read_bytes;
 
-  ASSERT_EQ(ArrowIpcInputStreamInitFile(&stream, file_ptr, 0), NANOARROW_OK);
+  ASSERT_EQ(ArrowIpcInputStreamInitFile(&stream, file_ptr, /*close_on_release=*/1),
+            NANOARROW_OK);
+  closer.file_ = nullptr;
 
   EXPECT_EQ(stream.read(&stream, output_data, 2, &size_read_bytes, nullptr),
             NANOARROW_OK);

--- a/src/nanoarrow/ipc/reader_test.cc
+++ b/src/nanoarrow/ipc/reader_test.cc
@@ -103,7 +103,9 @@ TEST(NanoarrowIpcReader, InputStreamBuffer) {
 // if an assertion fails
 struct FileCloser {
   FileCloser(FILE* file) : file_(file) {}
-  ~FileCloser() { if (file_) fclose(file_); }
+  ~FileCloser() {
+    if (file_) fclose(file_);
+  }
   FILE* file_{};
 };
 

--- a/src/nanoarrow/ipc/writer_test.cc
+++ b/src/nanoarrow/ipc/writer_test.cc
@@ -55,7 +55,9 @@ TEST(NanoarrowIpcWriter, OutputStreamBuffer) {
 // if an assertion fails
 struct FileCloser {
   FileCloser(FILE* file) : file_(file) {}
-  ~FileCloser() { fclose(file_); }
+  ~FileCloser() {
+    if (file_) fclose(file_);
+  }
   FILE* file_{};
 };
 
@@ -74,6 +76,7 @@ TEST(NanoarrowIpcWriter, OutputStreamFile) {
   nanoarrow::ipc::UniqueOutputStream stream;
   ASSERT_EQ(ArrowIpcOutputStreamInitFile(stream.get(), file_ptr, /*close_on_release=*/1),
             NANOARROW_OK);
+  closer.file_ = nullptr;
 
   struct ArrowError error;
 
@@ -111,6 +114,7 @@ TEST(NanoarrowIpcWriter, OutputStreamFileError) {
   ASSERT_EQ(file_ptr, nullptr);
   EXPECT_EQ(ArrowIpcOutputStreamInitFile(stream.get(), file_ptr, /*close_on_release=*/1),
             ENOENT);
+  closer.file_ = nullptr;
 }
 
 struct ArrowIpcWriterPrivate {


### PR DESCRIPTION
I tried to add a test that would trigger the sanitizer error based on https://github.com/vyasr/nanoarrow_clang_tidy_error ; however, I think clang-tidy is too smart when it's all integrated in the same project and I don't see the error appear.

Closes #662.