### PR TITLE
fix(python): Ensure source distribution builds with Cython 3.1.0

### DIFF
--- a/python/src/nanoarrow/_types.pyx
+++ b/python/src/nanoarrow/_types.pyx
@@ -24,6 +24,11 @@ from struct import calcsize
 from sys import byteorder as sys_byteorder
 
 
+# The default changed in Cython 3.1.0 such that the member of an
+# enum are no longer automatically copied to the parent module.
+globals().update(getattr(CArrowType, '__members__'))
+
+
 cdef equal(int type_id1, int type_id2):
     """Check if two type identifiers are equal
 


### PR DESCRIPTION
In Cython 3.1.0, cpdef enums are no longer copied to the parent module. We're using the types module a bit like an enum and kind of want this behaviour, so this PR implements the workaround suggested in the Cython docs: https://cython.readthedocs.io/en/stable/src/userguide/language_basics.html

Closes #756, superceeds #757 as long as Will is OK with this!