### PR TITLE
fix(ci): Fix runner specification for c-device

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -50,7 +50,7 @@ jobs:
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          # - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
     steps:
       - uses: actions/checkout@v4
@@ -158,3 +158,5 @@ jobs:
         run: |
           cd python
           python3 -m pytest -vv
+
+

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -50,7 +50,7 @@ jobs:
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -155,5 +155,3 @@ jobs:
         run: |
           cd python
           python3 -m pytest -vv
-
-

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -60,6 +60,13 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y valgrind
 
+      - name: Set up Python
+        if: matrix.config.label == 'with-cuda'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: 'pip'
+
       # The self-hosted runner for CUDA needs a number of packages installed that
       # are already installed on the GitHub runner
       - name: Install build dependencies
@@ -67,6 +74,10 @@ jobs:
         run: |
           sudo apt-get update && \
             sudo apt-get install -y cmake build-essential cuda-toolkit tzdata
+
+          # Install newer cmake for building Arrow C++
+          pip install cmake
+
           # Debug install location of cuda toolkit
           ldconfig -p | grep libcuda
 
@@ -82,7 +93,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 19.0.0 arrow
 
       - name: Build
         run: |
@@ -133,13 +144,6 @@ jobs:
         with:
           name: nanoarrow-device-memcheck
           path: build/Testing/Temporary/MemoryChecker.*.log
-
-      - name: Set up Python
-        if: matrix.config.label == 'with-cuda'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: 'pip'
 
       - name: Build Python bindings with CUDA
         if: matrix.config.label == 'with-cuda'

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -50,7 +50,7 @@ jobs:
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {runner: ubuntu-latest, label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -48,9 +48,9 @@ jobs:
           - {runner: ubuntu-latest, label: default-build}
           - {runner: ubuntu-latest, label: namespaced-build, cmake_args: "-DNANOARROW_NAMESPACE=SomeUserNamespace"}
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
-          - {label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
+          - {runner: ubuntu-latest, label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          # - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          - {runner: cuda, label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
     steps:
       - uses: actions/checkout@v4
@@ -76,16 +76,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          # The self-hosted runner needs its own Arrow build since it is running
-          # a much older linux distribution. When the Arrow C++ requirement for tests is
-          # dropped, we don't have to use this at all as part of the CI configuration.
-          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-2
+          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-3
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 18.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -93,7 +93,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 19.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,6 +748,9 @@ if(NANOARROW_BUILD_TESTS)
                             nanoarrow
                             gtest_main
                             nanoarrow_coverage_config)
+      target_include_directories(nanoarrow_device_metal_test
+                                 PRIVATE ${NANOARROW_DEVICE_INCLUDE_METAL})
+
       if(Arrow_FOUND)
         target_compile_definitions(nanoarrow_device_metal_test
                                    PRIVATE -DNANOARROW_BUILD_TESTS_WITH_ARROW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,8 +744,8 @@ if(NANOARROW_BUILD_TESTS)
     if(NANOARROW_DEVICE_WITH_METAL)
       add_executable(nanoarrow_device_metal_test src/nanoarrow/device/metal_test.cc)
       target_link_libraries(nanoarrow_device_metal_test
-                            nanoarrow_device
-                            nanoarrow
+                            ${NANOARROW_TEST_DEVICE_LIB}
+                            ${NANOARROW_TEST_LIB}
                             gtest_main
                             nanoarrow_coverage_config)
       target_include_directories(nanoarrow_device_metal_test
@@ -761,8 +761,8 @@ if(NANOARROW_BUILD_TESTS)
     if(NANOARROW_DEVICE_WITH_CUDA)
       add_executable(nanoarrow_device_cuda_test src/nanoarrow/device/cuda_test.cc)
       target_link_libraries(nanoarrow_device_cuda_test
-                            nanoarrow_device
-                            nanoarrow
+                            ${NANOARROW_TEST_DEVICE_LIB}
+                            ${NANOARROW_TEST_LIB}
                             CUDA::cuda_driver
                             gtest_main
                             nanoarrow_coverage_config)


### PR DESCRIPTION
This is currently failing with:

```
Error when evaluating 'runs-on' for job 'test-c-device'. .github/workflows/build-and-test-device.yaml (Line: 40, Col: 14): Unexpected value ''
```

...because we'd been relying on the "empty string means ubuntu-latest" that was removed from GitHub actions at some point. There are a few updates here as well to fix the device build since that job hadn't been running for some time.