### PR TITLE
chore(dev/release): Update release instructions for 0.7.0

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -481,10 +481,8 @@ The Apache Arrow Community
 ### Remove old artifacts from SVN
 
 These artifacts include any release candidates that were uploaded to
-<https://dist.apache.org/repos/dist/dev/arrow/> and old releases that
-were upload to
-<https://dist.apache.org/repos/dist/release/arrow/>. You can remove
-them using:
+<https://dist.apache.org/repos/dist/dev/arrow/>. You can remove them
+using:
 
 ```
 # Once

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -113,7 +113,7 @@ to verify the C library; R and Rtools can be installed using the
 
 ```bash
 # Pass location of R to the verification script
-export NANOARROW_CMAKE_OPTIONS="-Dgtest_force_shared_crt=ON -DNANOARROW_ARROW_STATIC=ON"
+export NANOARROW_CMAKE_OPTIONS="-Dgtest_force_shared_crt=ON"
 export R_HOME="/c/Program Files/R/R-4.5.0"
 ```
 
@@ -136,7 +136,7 @@ On recent Fedora (e.g., `docker run --rm -it fedora:latest`), you can install al
 using `dnf`:
 
 ```bash
-dnf install -y git cmake R gnupg curl python3-devel python3-virtualenv
+dnf install -y git cmake R gnupg curl python3-devel python3-virtualenv awk
 ```
 
 ### Arch Linux
@@ -150,8 +150,7 @@ pacman -Sy git gcc make cmake r-base gnupg curl python
 
 ### Alpine Linux
 
-On Alpine Linux (e.g., `docker run --rm -it alpine:latest`), all prerequisites are available using `apk add` except for Arrow C++ which requires enabling the
-community repository.
+On Alpine Linux (e.g., `docker run --rm -it alpine:latest`), all prerequisites are available using `apk add`.
 
 ```bash
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -117,7 +117,7 @@ export NANOARROW_CMAKE_OPTIONS="-Dgtest_force_shared_crt=ON"
 export R_HOME="/c/Program Files/R/R-4.5.0"
 ```
 
-Unfortunately verifying Python via the release verification script on Windows is not currently possible, thus successful verification requites `TEST_PYTHON=0 ./verify-release-candidate.sh`.
+Unfortunately verifying Python via the release verification script on Windows may not work in some shells, thus successful verification may require `TEST_PYTHON=0 ./verify-release-candidate.sh`.
 
 ### Debian/Ubuntu
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -117,6 +117,8 @@ export NANOARROW_CMAKE_OPTIONS="-Dgtest_force_shared_crt=ON"
 export R_HOME="/c/Program Files/R/R-4.5.0"
 ```
 
+Unfortunately verifying Python via the release verification script on Windows is not currently possible, thus successful verification requites `TEST_PYTHON=0 ./verify-release-candidate.sh`.
+
 ### Debian/Ubuntu
 
 On Debian/Ubuntu (e.g., `docker run --rm -it ubuntu:latest`) you can install prerequisites using `apt`.

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -25,12 +25,12 @@ Release candidates for nanoarrow are uploaded to https://dist.apache.org/repos/d
 prior to a release vote being called on the
 [Apache Arrow developer mailing list](https://lists.apache.org/list.html?dev@arrow.apache.org).
 A script (`verify-release-candidate.sh`) is provided to verify such a release candidate.
-For example, to verify nanoarrow 0.6.0-rc0, one could run:
+For example, to verify nanoarrow 0.7.0-rc0, one could run:
 
 ```bash
 git clone https://github.com/apache/arrow-nanoarrow.git arrow-nanoarrow
 cd arrow-nanoarrow/dev/release
-./verify-release-candidate.sh 0.6.0 0
+./verify-release-candidate.sh 0.7.0 0
 ```
 
 Full verification requires [CMake](https://cmake.org/download/) to build and run the test
@@ -56,19 +56,19 @@ manager except on Windows (see below).
 To run only C library verification (requires CMake and Arrow C++ but not R or Python):
 
 ```bash
-TEST_DEFAULT=0 TEST_C=1 TEST_C_BUNDLED=1 ./verify-release-candidate.sh 0.6.0 0
+TEST_DEFAULT=0 TEST_C=1 TEST_C_BUNDLED=1 ./verify-release-candidate.sh 0.7.0 0
 ```
 
 To run only R package verification (requires R but not CMake or Arrow C++):
 
 ```bash
-TEST_DEFAULT=0 TEST_R=1 ./verify-release-candidate.sh 0.6.0 0
+TEST_DEFAULT=0 TEST_R=1 ./verify-release-candidate.sh 0.7.0 0
 ```
 
 To run only Python verification (requires Python but not CMake or Arrow C++):
 
 ```bash
-TEST_DEFAULT=0 TEST_PYTHON=1 ./verify-release-candidate.sh 0.6.0 0
+TEST_DEFAULT=0 TEST_PYTHON=1 ./verify-release-candidate.sh 0.7.0 0
 ```
 
 ### MacOS
@@ -229,7 +229,7 @@ One can verify a nanoarrow release candidate on big endian by setting
 ## Creating a release candidate
 
 The first step to creating a nanoarrow release is to create a `maint-VERSION` branch
-(e.g., `usethis::pr_init("maint-0.6.0")`) and push the branch to `upstream`. This is
+(e.g., `usethis::pr_init("maint-0.7.0")`) and push the branch to `upstream`. This is
 a good opportunity to run though the above instructions to make sure the verification
 script and instructions are up-to-date.
 targeting the maint-XX branch that was just pushed.
@@ -249,11 +249,11 @@ When these steps are complete, run
 ```bash
 # from the repository root
 # 01-prepare.sh <nanoarrow-dir> <prev_veresion> <version> <next_version> <rc-num>
-dev/release/01-prepare.sh . 0.5.0 0.6.0 0.7.0 0
+dev/release/01-prepare.sh . 0.6.0 0.7.0 0.8.0 0
 ```
 
 This will update version numbers, the changelong, and create the git tag
-`apache-arrow-nanoarrow-0.6.0-rc0`. Check to make sure that the changelog
+`apache-arrow-nanoarrow-0.7.0-rc0`. Check to make sure that the changelog
 and versions are what you expect them to be before pushing the tag (you
 may wish to do this by opening a dummy PR to run CI and look at the diff
 from the main branch).
@@ -277,7 +277,7 @@ file to exist setting the appropriate `GPG_KEY_ID` environment variable.
 
 ```bash
 # 02-sign.sh <version> <rc-num>
-dev/release/02-sign.sh 0.6.0 0
+dev/release/02-sign.sh 0.7.0 0
 ```
 
 Finally, run
@@ -289,7 +289,7 @@ file to exist setting the appropriate `APACHE_USERNAME` environment variable.
 
 ```
 # 03-source.sh $0 <version> <rc-num>
-dev/release/03-source.sh 0.6.0 0
+dev/release/03-source.sh 0.7.0 0
 ```
 
 You should check that the release verification runs locally and/or
@@ -299,11 +299,11 @@ start a
 At this point the release candidate is suitable for a vote on the Apache Arrow developer mailing list.
 
 ```
-[VOTE] Release nanoarrow 0.6.0
+[VOTE] Release nanoarrow 0.7.0
 
 Hello,
 
-I would like to propose the following release candidate (rc0) of Apache Arrow nanoarrow [0] version 0.6.0. This is an initial release consisting of 44 resolved GitHub issues from 5 contributors [1].
+I would like to propose the following release candidate (rc0) of Apache Arrow nanoarrow [0] version 0.7.0. This is an initial release consisting of 44 resolved GitHub issues from 5 contributors [1].
 
 This release candidate is based on commit: {rc_commit} [2]
 
@@ -314,15 +314,15 @@ Please download, verify checksums and signatures, run the unit tests, and vote o
 
 The vote will be open for at least 72 hours.
 
-[ ] +1 Release this as Apache Arrow nanoarrow 0.6.0
+[ ] +1 Release this as Apache Arrow nanoarrow 0.7.0
 [ ] +0
-[ ] -1 Do not release this as Apache Arrow nanoarrow 0.6.0 because...
+[ ] -1 Do not release this as Apache Arrow nanoarrow 0.7.0 because...
 
 [0] https://github.com/apache/arrow-nanoarrow
 [1] https://github.com/apache/arrow-nanoarrow/milestone/4?closed=1
-[2] https://github.com/apache/arrow-nanoarrow/tree/apache-arrow-nanoarrow-0.6.0-rc0
-[3] https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-nanoarrow-0.6.0-rc0/
-[4] https://github.com/apache/arrow-nanoarrow/blob/apache-arrow-nanoarrow-0.6.0-rc0/CHANGELOG.md
+[2] https://github.com/apache/arrow-nanoarrow/tree/apache-arrow-nanoarrow-0.7.0-rc0
+[3] https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-nanoarrow-0.7.0-rc0/
+[4] https://github.com/apache/arrow-nanoarrow/blob/apache-arrow-nanoarrow-0.7.0-rc0/CHANGELOG.md
 [5] https://github.com/apache/arrow-nanoarrow/blob/main/dev/release/README.md
 ```
 
@@ -356,7 +356,7 @@ and mark it as closed.
 The reporter system for Arrow can be found at
 <https://reporter.apache.org/addrelease.html?arrow>. To add a release, a
 PMC member must log in with their Apache username/password. The release
-names are in the form `NANOARROW-0.6.0`.
+names are in the form `NANOARROW-0.7.0`.
 
 ### Upload artifacts to Subversion / Create GitHub Release
 
@@ -366,7 +366,7 @@ This script must be run by a PMC member whose `APACHE_USERNAME` environment vari
 has been set in `.env`.
 
 ```bash
-dev/release/post-01-upload.sh 0.6.0 0
+dev/release/post-01-upload.sh 0.7.0 0
 ```
 
 ### Submit R package to CRAN
@@ -378,8 +378,8 @@ Before a release candidate is created, the first section of
 `usethis::use_release_issue()` should all be completed (i.e., any changes
 after release should be minor tweaks). The steps are:
 
-- Ensure you are on the release branch (i.e., `git switch maint-0.6.0`)
-- Run `usethis::pr_init("r-cran-maint-0.6.0")` and push the branch to your
+- Ensure you are on the release branch (i.e., `git switch maint-0.7.0`)
+- Run `usethis::pr_init("r-cran-maint-0.7.0")` and push the branch to your
   fork.
 - Ensure `cran_comments.md` is up-to-date.
 - Run `devtools::check()` locally and verify that the package version is correct
@@ -391,12 +391,12 @@ after release should be minor tweaks). The steps are:
 Any changes required at this stage should be made as a PR into `main` and
 cherry-picked into the `r-cran-maint-XXX` packaging branch. (i.e.,
 `git cherry-pick 01234abcdef`). If any changes
-to the source are required, bump the "tweak" version (e.g., `Version: 0.6.0.1`
+to the source are required, bump the "tweak" version (e.g., `Version: 0.7.0.1`
 in `DESCRIPTION`).
 
 ### Submit Python package to PyPI
 
-The Python package source distribution and wheels are built using the [Build Python Wheels](https://github.com/apache/arrow-nanoarrow/actions/workflows/python-wheels.yaml) action on the `maint-0.6.0` branch after cutting the release candidate.
+The Python package source distribution and wheels are built using the [Build Python Wheels](https://github.com/apache/arrow-nanoarrow/actions/workflows/python-wheels.yaml) action on the `maint-0.7.0` branch after cutting the release candidate.
 
 To submit these to PyPI, download all assets from the run into a folder (e.g., `python/dist`) and run:
 
@@ -426,18 +426,18 @@ git clone -b asf-site --single-branch https://github.com/apache/arrow-nanoarrow.
 cd arrow-nanoarrow
 ```
 
-Download the [0.6.0 documentation](https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.6.0/docs.tgz):
+Download the [0.7.0 documentation](https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.7.0/docs.tgz):
 
 ```shell
-curl -L https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.6.0/docs.tgz \
+curl -L https://github.com/apache/arrow-nanoarrow/releases/download/apache-arrow-nanoarrow-0.7.0/docs.tgz \
   -o docs.tgz
 ```
 
-Extract the documentation and rename the directory to `0.6.0`:
+Extract the documentation and rename the directory to `0.7.0`:
 
 ```shell
 tar -xvzf docs.tgz
-mv nanoarrow-docs 0.6.0
+mv nanoarrow-docs 0.7.0
 ```
 
 Then remove the existing `latest` directory and run the extraction again, renaming to `latest` instead:
@@ -448,7 +448,7 @@ tar -xvzf docs.tgz
 mv nanoarrow-docs latest
 ```
 
-Finally, update `switcher.json` with entries pointing `/latest/` and `/0.6.0/` to `"version": "0.6.0"`:
+Finally, update `switcher.json` with entries pointing `/latest/` and `/0.7.0/` to `"version": "0.7.0"`:
 
 ```json
 [
@@ -457,16 +457,16 @@ Finally, update `switcher.json` with entries pointing `/latest/` and `/0.6.0/` t
         "url": "https://arrow.apache.org/nanoarrow/main/"
     },
     {
-        "version": "0.6.0",
+        "version": "0.7.0",
         "url": "https://arrow.apache.org/nanoarrow/latest/"
+    },
+    {
+        "version": "0.7.0",
+        "url": "https://arrow.apache.org/nanoarrow/0.7.0/"
     },
     {
         "version": "0.6.0",
         "url": "https://arrow.apache.org/nanoarrow/0.6.0/"
-    },
-    {
-        "version": "0.5.0",
-        "url": "https://arrow.apache.org/nanoarrow/0.5.0/"
     },
     ...
 ]
@@ -488,9 +488,9 @@ the `mail-relay.apache.org` outgoing server.
 Email template:
 
 ```
-[ANNOUNCE] Apache Arrow nanoarrow 0.6.0 Released
+[ANNOUNCE] Apache Arrow nanoarrow 0.7.0 Released
 
-The Apache Arrow community is pleased to announce the 0.6.0 release of
+The Apache Arrow community is pleased to announce the 0.7.0 release of
 Apache Arrow nanoarrow. This initial release covers 79 resolved issues
 from 9 contributors[1].
 
@@ -526,10 +526,10 @@ Please report any feedback to the mailing lists ([6], [7]).
 Regards,
 The Apache Arrow Community
 
-[1] https://github.com/apache/arrow-nanoarrow/issues?q=milestone%3A%22nanoarrow+0.6.0%22+is%3Aclosed
-[2] https://www.apache.org/dyn/closer.cgi/arrow/apache-arrow-nanoarrow-0.6.0
-[3] https://github.com/apache/arrow-nanoarrow/blob/apache-arrow-nanoarrow-0.6.0/CHANGELOG.md
-[4] https://arrow.apache.org/blog/2024/05/27/nanoarrow-0.6.0-release/
+[1] https://github.com/apache/arrow-nanoarrow/issues?q=milestone%3A%22nanoarrow+0.7.0%22+is%3Aclosed
+[2] https://www.apache.org/dyn/closer.cgi/arrow/apache-arrow-nanoarrow-0.7.0
+[3] https://github.com/apache/arrow-nanoarrow/blob/apache-arrow-nanoarrow-0.7.0/CHANGELOG.md
+[4] https://arrow.apache.org/blog/2024/05/27/nanoarrow-0.7.0-release/
 [5] https://arrow.apache.org/nanoarrow/
 [6] https://lists.apache.org/list.html?user@arrow.apache.org
 [7] https://lists.apache.org/list.html?dev@arrow.apache.org
@@ -544,7 +544,10 @@ were upload to
 them using:
 
 ```
-dev/release/post-02-remove-old-artifacts.sh
+# Once
+export APACHE_USERNAME=xxx
+# Once for every release candidate
+svn rm --username=$APACHE_USERNAME -m "Clean up svn artifacts" https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-nanoarrow-0.7.0-rc0/
 ```
 
 ### Bumped versions on main
@@ -553,5 +556,5 @@ This is handled by
 [post-03-bump-versions.sh](https://github.com/apache/arrow-nanoarrow/blob/main/dev/release/post-03-bump-versions.sh). Create a branch and then run:
 
 ```bash
-dev/release/post-03-bump-versions.sh . 0.6.0 0.7.0
+dev/release/post-03-bump-versions.sh . 0.7.0 0.8.0
 ```

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -79,29 +79,6 @@ On MacOS you can install all requirements except R using [Homebrew](https://brew
 brew install cmake gnupg apache-arrow
 ```
 
-For older MacOS or MacOS without Homebrew, you will have to install the XCode
-Command Line Tools (i.e., `xcode-select --install`),
-[install GnuPG](https://gnupg.org/download/),
-[install CMake](https://cmake.org/download/), and build Arrow C++ from source.
-
-```bash
-# Download + build Arrow C++
-curl https://github.com/apache/arrow/archive/refs/tags/apache-arrow-14.0.2.tar.gz | \
-  tar -zxf -
-mkdir arrow-build && cd arrow-build
-cmake ../apache-arrow-14.0.2/cpp \
-    -DARROW_JEMALLOC=OFF -DARROW_SIMD_LEVEL=NONE \
-    # Required for Arrow on old MacOS
-    -DCMAKE_CXX_FLAGS="-D_LIBCPP_DISABLE_AVAILABILITY" \
-    -DCMAKE_INSTALL_PREFIX=../arrow
-cmake --build .
-cmake --install . --prefix=../arrow
-cd ..
-
-# Pass location of install to the release verification script
-export NANOARROW_CMAKE_OPTIONS="-DArrow_DIR=$(pwd)/arrow/lib/cmake/Arrow -DCMAKE_CXX_FLAGS=-D_LIBCPP_DISABLE_AVAILABILITY"
-```
-
 You can install R using the instructions provided on the
 [R Project Download page](https://cloud.r-project.org/bin/macosx/).
 
@@ -129,10 +106,6 @@ conda install -c conda-forge r-testthat r-hms r-blob r-pkgbuild r-bit64
 Note that using conda-provided R when there is also a system install of R
 on MacOS is unlikely to work.
 
-Linux users that have built and installed a custom build of Arrow C++ may
-have to `export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib` before running the
-verification script.
-
 ### Windows
 
 On Windows, prerequisites can be installed using officially provided
@@ -148,10 +121,10 @@ the verification script.
 
 ```bash
 # Build Arrow C++ from source
-curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz | \
+curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-20.0.0.tar.gz | \
   tar -zxf -
 mkdir arrow-build && cd arrow-build
-cmake ../apache-arrow-17.0.0/cpp -DCMAKE_INSTALL_PREFIX=../arrow-minimal
+cmake ../apache-arrow-20.0.0/cpp -DCMAKE_INSTALL_PREFIX=../arrow-minimal
 cmake --build .
 cmake --install . --prefix=../arrow-minimal --config=Debug
 cd ..

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -178,6 +178,7 @@ This is a good time to run other final checks such as:
 - Manually dispatch the [Verification workflow](https://github.com/apache/arrow-nanoarrow/actions/workflows/verify.yaml).
 - Manually dispatch the [Python wheels workflow](https://github.com/apache/arrow-nanoarrow/actions/workflows/python-wheels.yaml).
 - Create a draft [PR into WrapDB](#update-the-wrapdb-entry) to make sure tests pass in their CI
+- Create a draft [PR into vcpkg](#update-the-vcpkg-entry) to make sure tests pass in their CI
 - Draft a release blog post and make a draft PR into [arrow-site](https://github.com/apache/arrow-site).
 - Review [nanoarrow dev documentation](https://arrow.apache.org/nanoarrow/main/) for obvious holes/typos.
 
@@ -354,6 +355,10 @@ The [conda-forge feedstock](https://github.com/conda-forge/nanoarrow-feedstock) 
 ### Update the WrapDB Entry
 
 The nanoarrow C library is available for users of the [Meson build system](https://mesonbuild.com/) via [WrapDB](https://mesonbuild.com/Wrapdb-projects.html). When a new release is added, PR into the [WrapDB repository](https://github.com/mesonbuild/wrapdb) is required to make the new version available to users. See https://github.com/mesonbuild/wrapdb/pull/1536 for a template PR. It is also a good idea to do this step before the release candidate is cut to catch packaging issues before finalizing the content of the version.
+
+### Update the vcpkg Entry
+
+The nanoarrow C library is available on [vcpkg](https://github.com/microsoft/vcpkg). When a new release is added, PR into the vcpkg repository to make the new version available to users. See https://github.com/microsoft/vcpkg/pull/46029 for a template PR. It is a good idea to do this step before merging a release to catch packaging issues before finalizing the content of the version.
 
 ### Update release documentation
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -20,8 +20,9 @@
 # Requirements
 # - cmake >= 3.14
 # - R >= 3.5.0
-# - Arrow C++ >= 9.0.0
-# - Python >= 3.9
+# - Python >= 3.8
+# - gpg (for key verification)
+# - shasum or sha512sum
 #
 # Environment Variables
 # - CMAKE_BIN: Command to use for cmake (e.g., cmake3 on Centos7)


### PR DESCRIPTION
Just working through these instructions to make sure everything still works!

- Remove Arrow C++ directions since it is no longer necessary for verification (Updates from https://github.com/apache/arrow-nanoarrow/pull/695/ that I'd forgotten to merge)
- Update version numbers for easier command copy/pasting
- Tweaks to dependencies required on various platforms