### PR TITLE
chore(ci): Update python-wheels CI job

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -100,8 +100,9 @@ jobs:
         config:
           - {os: "ubuntu-latest", label: "pyodide", platform: "pyodide", arch: "auto"}
           - {os: "ubuntu-latest", label: "linux", platform: "auto", arch: "auto"}
-          - {os: "windows-2019", label: "windows-x86", platform: "auto", arch: "x86"}
-          - {os: "windows-2019", label: "windows-amd64", platform: "auto", arch: "AMD64"}
+          - {os: "windows-latest", label: "windows-x86", platform: "auto", arch: "x86"}
+          - {os: "windows-latest", label: "windows-amd64", platform: "auto", arch: "AMD64"}
+          - {os: "windows-latest", label: "windows-arm64", platform: "auto", arch: "ARM64"}
           - {os: "macOS-13", label: "macOS", platform: "auto", arch: "auto"}
           - {os: "macOS-14", label: "macOS-arm64", platform: "auto", arch: "auto"}
           - {os: "ubuntu-24.04-arm", label: "linux-arm64", platform: "auto", arch: "auto"}


### PR DESCRIPTION
This PR updates the python-wheels job to not use windows-2019 (which is going away soon), and adds arm64 Windows wheels (maybe).