### PR TITLE
fix: Don't use the value of `__GNUC__` unless defined

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -148,7 +148,7 @@
 #define NANOARROW_DLL __declspec(dllimport)
 #endif  // defined(NANOARROW_EXPORT_DLL)
 #elif !defined(NANOARROW_DLL)
-#if __GNUC__ >= 4
+#if defined(__GNUC__) && __GNUC__ >= 4
 #define NANOARROW_DLL __attribute__((visibility("default")))
 #else
 #define NANOARROW_DLL


### PR DESCRIPTION
Fixes a warning on MSVC:

```
(ClCompile target) -> 
         D:\a\arrow-adbc\arrow-adbc\adbc\c\vendor\nanoarrow\nanoarrow.h(1239,5): warning C4668: '__GNUC__' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif' [D:\a\arrow-adbc\arrow-adbc\adbc\build\driver\common\adbc_driver_common.vcxproj]

```

From https://github.com/apache/arrow-adbc/pull/2930