### PR TITLE
chore(python): Update minimum Python version to 3.9

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
           pytest python/tests -v -s
 
       - name: Check type stubs
-        if: success() && matrix.python-version == '3.12'
+        if: success() && matrix.python-version == '3.13'
         run: |
           pip install mypy
           cd src/nanoarrow
@@ -72,7 +72,7 @@ jobs:
           done
 
       - name: Run doctests
-        if: success() && matrix.python-version == '3.12'
+        if: success() && matrix.python-version == '3.13'
         run: |
           pytest --pyargs nanoarrow --doctest-modules
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -21,7 +21,7 @@
 # - cmake >= 3.14
 # - R >= 3.5.0
 # - Arrow C++ >= 9.0.0
-# - Python >= 3.8
+# - Python >= 3.9
 #
 # Environment Variables
 # - CMAKE_BIN: Command to use for cmake (e.g., cmake3 on Centos7)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ description = "Python bindings to the nanoarrow C library"
 authors = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
 maintainers = [{name = "Apache Arrow Developers", email = "dev@arrow.apache.org"}]
 license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 test = ["pyarrow", "python-dateutil", "pytest", "numpy"]


### PR DESCRIPTION
An attempt to fix the latest wheel builds, which are failing on Python 3.8 with a missing symbol.