### PR TITLE
chore(python): Add free-threaded Python wheel and update gemfury CLI client

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -133,7 +133,7 @@ jobs:
           arch: x86
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.0.0
+        run: python -m pip install cibuildwheel==2.23.3
 
       - name: Set nanoarrow Python dev version
         if: github.ref == 'refs/heads/main'
@@ -148,7 +148,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           CIBW_PLATFORM: ${{ matrix.config.platform }}
           CIBW_ARCHS: ${{ matrix.config.arch }}
-          CIBW_ENABLE: "cpython-freethreading"
+          CIBW_ENABLE: cpython-freethreading
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -133,7 +133,7 @@ jobs:
           arch: x86
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.1
+        run: python -m pip install cibuildwheel==3.0.0
 
       - name: Set nanoarrow Python dev version
         if: github.ref == 'refs/heads/main'
@@ -148,7 +148,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           CIBW_PLATFORM: ${{ matrix.config.platform }}
           CIBW_ARCHS: ${{ matrix.config.arch }}
-          CIBW_ENABLE: cpython-freethreading
+          CIBW_ENABLE: "cpython-freethreading"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -159,8 +159,7 @@ jobs:
   upload_nightly:
     needs: ["sdist", "wheels"]
     name: Upload nightly packages
-    runs-on: "ubuntu-latest"
-    if: github.repository == 'apache/arrow-nanoarrow' && github.ref == 'refs/heads/main'
+    runs-on: "macos-latest"
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -168,16 +167,14 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "ruby"
-
       - name: Install gemfury client
         run: |
-          gem install gemfury
+          brew tap gemfury/tap
+          brew install fury-cli
+          fury --version
 
       - name: Upload packages to Gemfury
+        if: github.repository == 'apache/arrow-nanoarrow' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           fury push \

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -54,11 +54,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
-
-    - name: Check that cmake is installed
-      run: |
-        cmake --version
+        python-version: '3.x'
 
     - name: Install packaging tools
       run: |
@@ -152,6 +148,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {package}/tests -vv
           CIBW_PLATFORM: ${{ matrix.config.platform }}
           CIBW_ARCHS: ${{ matrix.config.arch }}
+          CIBW_ENABLE: cpython-freethreading
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The last time we tried this Cython wasn't ready for it but now it is!

This updates cibuildwheel to just before 3.0.0, which was released an hour ago. 3.0 includes some updates to the default manylinux and at least for this release I think we maybe can keep the old defaults (and update to 3.0 shortly after to get Python 3.14 support).

Also (possibly) fixes the gemfury nightly upload since the previous CLI is apparently deprecated.