### PR TITLE
ci: Remove Meson default_option to set buildtype of release

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -184,6 +184,7 @@ jobs:
       - name: Run meson
         run: |
           meson setup builddir `
+              -Dbuildtype=release `
               --vsenv `
               -Dwerror=true `
               -Dipc=enabled `

--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -61,7 +61,10 @@ function main() {
     mkdir "${SANDBOX_DIR}"
 
     show_header "Compile project with meson"
-    meson setup "${SANDBOX_DIR}" --pkg-config-path $PKG_CONFIG_PATH -Dwerror=true
+    meson setup "${SANDBOX_DIR}" \
+          --pkg-config-path $PKG_CONFIG_PATH \
+          -Dwerror=true \
+          -Dbuildtype=release
 
     pushd "${SANDBOX_DIR}"
 

--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,7 @@ project(
     version: '0.7.0-SNAPSHOT',
     license: 'Apache 2.0',
     meson_version: '>=1.3.0',
-    default_options: [
-        'buildtype=release',
-        'c_std=c99',
-        'warning_level=2',
-        'cpp_std=c++17',
-    ],
+    default_options: ['c_std=c99', 'warning_level=2', 'cpp_std=c++17'],
 )
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
I have a suspicion this is why the wrapdb Windows build is failing. When developing locally, I think Meson will propogate this setting to subprojects, but when nanoarrow is itself a subproject, I don't believe this propogates to any other subprojects, and I _think_ that's why we are getting mixed build types in the Windows CI