### PR TITLE
chore: Use better debug detection in Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ add_project_arguments(
     language: 'cpp',
 )
 
-if get_option('buildtype') in ['debug', 'debugoptimized']
+if get_option('debug')
     add_project_arguments('-DNANOARROW_DEBUG', language: 'c')
     add_project_arguments('-DNANOARROW_DEBUG', language: 'cpp')
 endif

--- a/python/src/nanoarrow/meson.build
+++ b/python/src/nanoarrow/meson.build
@@ -66,7 +66,7 @@ cython_args = [
     '--include-dir',
     meson.current_build_dir(),
 ]
-if get_option('buildtype') in ['debug', 'debugoptimized']
+if get_option('debug')
     cython_args += ['--gdb']
 endif
 


### PR DESCRIPTION
This is a minor update per the suggestion in https://github.com/mesonbuild/wrapdb/issues/2208#issuecomment-2989884271