### PR TITLE
fix(r): Ensure that `python` is used on Windows when running bootstrap.R

### DIFF
--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -43,7 +43,8 @@ run_bundler <- function() {
     "--with-flatcc"
   )
   command <- sprintf(
-    "python3 ../ci/scripts/bundle.py  %s",
+    "%s ../ci/scripts/bundle.py  %s",
+    python(),
     paste(args, collapse = " ")
   )
 


### PR DESCRIPTION
Uncovered whilst attempting verification on Windows!