### PR TITLE
chore(dev/release): Update release workflow instructions for undocumented release tasks

### DIFF
--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -192,6 +192,11 @@ When these steps are complete, run
 dev/release/01-prepare.sh . 0.6.0 0.7.0 0.8.0 0
 ```
 
+A currently not automated part of this workflow is updating the R NEWS.md
+from the changelog: any changelog items for the `r/...` component can
+be copied to the R NEWS.md file. This is not essential (i.e., it does not
+affect the ability to release the R package).
+
 This will update version numbers, the changelong, and create the git tag
 `apache-arrow-nanoarrow-0.7.0-rc0`. Check to make sure that the changelog
 and versions are what you expect them to be before pushing the tag (you
@@ -511,6 +516,10 @@ This is handled by
 ```bash
 dev/release/post-03-bump-versions.sh . 0.7.0 0.8.0
 ```
+
+A currently not automated part of this workflow is also porting the R NEWS.md
+updates that occurred when updating the changelog. This is not essential but
+makes the next R NEWS.md update for the next release make a bit more sense.
 
 After this PR is merged, create the dev tag that is used to generate the changelog:
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -511,3 +511,10 @@ This is handled by
 ```bash
 dev/release/post-03-bump-versions.sh . 0.7.0 0.8.0
 ```
+
+After this PR is merged, create the dev tag that is used to generate the changelog:
+
+```shell
+git tag -a apache-arrow-nanoarrow-0.8.0.dev -m "tag dev 0.8.0"
+git push upstream apache-arrow-nanoarrow-0.8.0.dev
+```

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -338,16 +338,26 @@ in `DESCRIPTION`).
 
 The Python package source distribution and wheels are built using the [Build Python Wheels](https://github.com/apache/arrow-nanoarrow/actions/workflows/python-wheels.yaml) action on the `maint-0.7.0` branch after cutting the release candidate.
 
-To submit these to PyPI, download all assets from the run into a folder (e.g., `python/dist`) and run:
+To submit these to PyPI, download all assets from the run into a folder (e.g., `python/dist`) and run `twine upload`:
 
 ```shell
 # pip install twine
-twine upload python/dist/*.tar.gz python/dist/*.whl
+
+# Clear the dist directory
+rm -rf python/dist
+mkdir python/dist
+
+# Download assets from the lastest `maint-x.x.x` branch run,
+# remove the pyodide wheels (which will be rejected by PyPI)
+pushd python/dist
+gh run download 15963020465
+rm -rf release-wheels-pyodide
+popd
+
+twine upload python/dist/**/*.tar.gz python/dist/**/*.whl
 ```
 
 You will need to enter a token with "upload packages" permissions for the [nanoarrow PyPI project](https://pypi.org/project/nanoarrow/).
-
-This can/should be automated for future releases using one or more GitHub API calls.
 
 ### Update Python package on conda-forge
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -494,14 +494,13 @@ The Apache Arrow Community
 ### Remove old artifacts from SVN
 
 These artifacts include any release candidates that were uploaded to
-<https://dist.apache.org/repos/dist/dev/arrow/>. You can remove them
-using:
+<https://dist.apache.org/repos/dist/dev/arrow/> and old releases that
+were upload to
+<https://dist.apache.org/repos/dist/release/arrow/>. You can remove
+them using:
 
 ```
-# Once
-export APACHE_USERNAME=xxx
-# Once for every release candidate
-svn rm --username=$APACHE_USERNAME -m "Clean up svn artifacts" https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-nanoarrow-0.7.0-rc0/
+dev/release/post-02-remove-old-artifacts.sh
 ```
 
 ### Bumped versions on main

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -438,7 +438,8 @@ the release candidate.
 
 This email should be sent to `announce@apache.org` and `dev@arrow.apache.org`. It
 **must** be sent from your Apache email address and **must** be sent through
-the `mail-relay.apache.org` outgoing server.
+the `mail-relay.apache.org` outgoing server. It also must be in plain text
+or it will be rejected by the announce mailing list.
 
 Email template:
 

--- a/dev/release/README.md
+++ b/dev/release/README.md
@@ -311,28 +311,29 @@ dev/release/post-01-upload.sh 0.7.0 0
 
 ### Submit R package to CRAN
 
-The R package submission occurs from a separate branch to facilitate including
-any small changes requested by a member of the CRAN team; however, these
-updates are usually automatic and do not require additional changes.
-Before a release candidate is created, the first section of
-`usethis::use_release_issue()` should all be completed (i.e., any changes
-after release should be minor tweaks). The steps are:
+The R package can be updated directly from the release branch if no updates
+are required to pass CRAN checks. Because most updates are just updates of
+the underlying C library, most updates should not required special updates
+just to submit to CRAN. It is usually a good idea to check the package URLs
+and run a [WinBuilder](https://win-builder.r-project.org/) check before
+submitting, just to be sure. These can be run with:
 
-- Ensure you are on the release branch (i.e., `git switch maint-0.7.0`)
-- Run `usethis::pr_init("r-cran-maint-0.7.0")` and push the branch to your
-  fork.
-- Ensure `cran_comments.md` is up-to-date.
-- Run `devtools::check()` locally and verify that the package version is correct
-- Run `urlchecker::url_check()`
-- Run `devtools::check_win_devel()` and wait for the response
-- Run `devtools::submit_cran()`
-- Confirm submission email
+```r
+urlchecker::url_check()
+devtools::check_win_devel()
+```
 
-Any changes required at this stage should be made as a PR into `main` and
-cherry-picked into the `r-cran-maint-XXX` packaging branch. (i.e.,
-`git cherry-pick 01234abcdef`). If any changes
-to the source are required, bump the "tweak" version (e.g., `Version: 0.7.0.1`
-in `DESCRIPTION`).
+If there are no NOTEs, WARNINGs, or ERRORs on the winbuilder results
+(emailed to the package maintainer), the package can be submitted to CRAN with:
+
+```r
+devtools::submit_cran()
+```
+
+If changes *are* required, create a branch called `r-cran-maint-0.7.-0`,
+make any changes required, and resubmit to CRAN after bumping the "tweak"
+version (e.g., `Version: 0.7.0.1` in the `DESCRIPTION`). Ensure those changes
+are also reflected in the main branch after submission is successful.
 
 ### Submit Python package to PyPI
 

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -58,30 +58,3 @@ update_versions() {
   git add _static_version.py
   popd
 }
-
-set_resolved_issues() {
-    # TODO: this needs to work with open milestones
-    local -r version="${1}"
-    local -r milestone_info=$(gh api \
-                                 /repos/apache/arrow-nanoarrow/milestones \
-                                 -X GET \
-                                 -F state=all \
-                                 --jq ".[] | select(.title | test(\"nanoarrow ${version}\$\"))")
-    local -r milestone_number=$(echo "${milestone_info}" | jq -r '.number')
-
-    local -r graphql_query="query {
-    repository(owner: \"apache\", name: \"arrow-nanoarrow\") {
-        milestone(number: ${milestone_number}) {
-            issues(states: CLOSED) {
-                totalCount
-            }
-        }
-    }
-}
-"
-
-    export MILESTONE_URL=$(echo "${milestone_info}" | jq -r '.html_url')
-    export RESOLVED_ISSUES=$(gh api graphql \
-                            -f query="${graphql_query}" \
-                            --jq '.data.repository.milestone.issues.totalCount')
-}

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -42,7 +42,7 @@ update_versions() {
   sed -i.bak -E "s/set\(NANOARROW_VERSION \".+\"\)/set(NANOARROW_VERSION \"${version}\")/g" CMakeLists.txt
   rm CMakeLists.txt.bak
   git add CMakeLists.txt
-  sed -i.bak -E "s/version: '.+'/version: '${version}')/g" meson.build
+  sed -i.bak -E "s/ version: '.+'/ version: '${version}'/g" meson.build
   rm meson.build.bak
   git add meson.build
   popd


### PR DESCRIPTION
Closes #660.

This doesn't do any more automations but at least documents all the pieces for the next time!