### PR TITLE
fix(r): Ensure C23 version check works for clang20 (current GitHub Actions)

### DIFF
--- a/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
+++ b/thirdparty/flatcc/include/flatcc/portable/pstdalign.h
@@ -140,6 +140,8 @@ extern "C" {
 
 #endif /* __STDC__ */
 
+#error "C standard version __STDC_VERSION__ = " __STDC_VERSION__
+
 // For C23, alignas/alignof are keywords and will warn (-Wkeyword-macro) when #defined here
 #if !(defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
 


### PR DESCRIPTION
This was fixed in https://github.com/apache/arrow-nanoarrow/pull/742 but given the current R CI failure may not have correctly identified whatever flags are being used to compile on the current macos-latest GitHub actions.