### PR TITLE
fix: Ensure the array view can be used to inspect map offsets

### DIFF
--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -1746,6 +1746,14 @@ TEST(ArrayTest, ArrayTestAppendToMapArray) {
   array.children[0]->length = array.children[0]->length + 1;
   EXPECT_EQ(ArrowArrayFinishBuildingDefault(&array, &error), NANOARROW_OK);
 
+  // Check values with an array view
+  struct ArrowArrayView array_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&array_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&array_view, &array, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewListChildOffset(&array_view, 0), 0);
+  ASSERT_EQ(ArrowArrayViewListChildOffset(&array_view, 1), 1);
+  ArrowArrayViewReset(&array_view);
+
 #if defined(NANOARROW_BUILD_TESTS_WITH_ARROW)
   auto maybe_arrow_array = ImportArray(&array, &schema);
   ARROW_EXPECT_OK(maybe_arrow_array);

--- a/src/nanoarrow/common/inline_array.h
+++ b/src/nanoarrow/common/inline_array.h
@@ -1094,6 +1094,7 @@ static inline int64_t ArrowArrayViewListChildOffset(
     const struct ArrowArrayView* array_view, int64_t i) {
   switch (array_view->storage_type) {
     case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_LIST_VIEW:
       return array_view->buffer_views[1].data.as_int32[i];
     case NANOARROW_TYPE_LARGE_LIST:


### PR DESCRIPTION
Closes #798.