### PR TITLE
chore(ci): Update Arrow C++ in CI to use 21.0.0

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -93,7 +93,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -79,7 +79,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,7 +71,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Build nanoarrow
         run: |
@@ -160,7 +160,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Run meson testing script
         run: |

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -54,7 +54,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Build nanoarrow
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -96,7 +96,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true' && matrix.config.label != 'windows-win32'
         shell: bash
         run: |
-          src/ci/scripts/build-arrow-cpp-minimal.sh 20.0.0 arrow
+          src/ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
 
       - name: Set CMake options
         shell: bash


### PR DESCRIPTION
This will hopefully fix documentation errors that are causing the Metal device build to fail.