### PR TITLE
macos-13 is deprecated

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -99,7 +99,7 @@ jobs:
           - {os: "windows-latest", label: "windows-x86", platform: "auto", arch: "x86"}
           - {os: "windows-latest", label: "windows-amd64", platform: "auto", arch: "AMD64"}
           - {os: "windows-latest", label: "windows-arm64", platform: "auto", arch: "ARM64"}
-          - {os: "macOS-13", label: "macOS", platform: "auto", arch: "auto"}
+          - {os: "macos-latest", label: "macOS", platform: "auto", arch: "auto"}
           - {os: "macOS-14", label: "macOS-arm64", platform: "auto", arch: "auto"}
           - {os: "ubuntu-24.04-arm", label: "linux-arm64", platform: "auto", arch: "auto"}
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -99,7 +99,7 @@ jobs:
           - {os: "windows-latest", label: "windows-x86", platform: "auto", arch: "x86"}
           - {os: "windows-latest", label: "windows-amd64", platform: "auto", arch: "AMD64"}
           - {os: "windows-latest", label: "windows-arm64", platform: "auto", arch: "ARM64"}
-          - {os: "macos-latest", label: "macOS", platform: "auto", arch: "auto"}
+          - {os: "macos-latest", label: "macOS", platform: "auto", arch: "x86_64"}
           - {os: "macOS-14", label: "macOS-arm64", platform: "auto", arch: "auto"}
           - {os: "ubuntu-24.04-arm", label: "linux-arm64", platform: "auto", arch: "auto"}
 

--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -99,7 +99,7 @@ jobs:
           - {os: "windows-latest", label: "windows-x86", platform: "auto", arch: "x86"}
           - {os: "windows-latest", label: "windows-amd64", platform: "auto", arch: "AMD64"}
           - {os: "windows-latest", label: "windows-arm64", platform: "auto", arch: "ARM64"}
-          - {os: "macos-latest", label: "macOS", platform: "auto", arch: "x86_64"}
+          - {os: "macos-15-intel", label: "macOS", platform: "auto", arch: "x86_64"}
           - {os: "macOS-14", label: "macOS-arm64", platform: "auto", arch: "auto"}
           - {os: "ubuntu-24.04-arm", label: "linux-arm64", platform: "auto", arch: "auto"}
 


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

replacing with `macos-15-intel` based on
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
