### PR TITLE
chore(ci): Temporarily disable missing CUDA runner

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -50,7 +50,9 @@ jobs:
           - {runner: ubuntu-latest, label: bundled-build, cmake_args: "-DNANOARROW_DEVICE_BUNDLE=ON"}
           - {runner: ubuntu-latest, label: shared-test-linkage, cmake_args: "-DNANOARROW_TEST_LINKAGE_SHARED=ON"}
           - {runner: macOS-latest, label: with-metal, cmake_args: "-DNANOARROW_DEVICE_WITH_METAL=ON"}
-          - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
+          # This runner is currently not available
+          # https://github.com/apache/arrow-nanoarrow/issues/814
+          # - {runner: ["self-hosted", "cuda"], label: with-cuda, cmake_args: "-DNANOARROW_DEVICE_WITH_CUDA=ON"}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We're working on a solution for this (https://github.com/apache/arrow-nanoarrow/issues/814), but in the meantime a perpetually hanging CI job isn't helping!