### PR TITLE
fix(python): Remove incorrect last byte zeroing in Python buffer construction

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -139,7 +139,7 @@ jobs:
               platform: "ubuntu",
               arch: "amd64",
               extra_label: "-memcheck",
-              compose_args: "-e TEST_WITH_MEMCHECK=1  -e TEST_C_BUNDLED=0"
+              compose_args: "-e TEST_WITH_MEMCHECK=1 -e TEST_C_BUNDLED=0"
             }
           - {
               platform: "ubuntu",


### PR DESCRIPTION
There was some code that zeroed out the last byte of a validity buffer in the Python buffer construction from an iterable; however, we already zero out the last byte when reserving/allocating an ArrowBitmap.

Checked locally with:

```shell
export NANOARROW_PLATFORM=ubuntu 
export NANOARROW_ARCH=arm64
docker compose run --rm -e TEST_WITH_MEMCHECK=1 -e TEST_DEFAULT=0 -e TEST_PYTHON=1 verify
```

Closes #821.