### PR TITLE
docs: fix issues in ArrowBasicArrayStreamSetArray docstring

### DIFF
--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1251,8 +1251,8 @@ NANOARROW_DLL ArrowErrorCode ArrowBasicArrayStreamInit(
 /// \brief Set the ith ArrowArray in this ArrowArrayStream.
 ///
 /// array_stream must have been initialized with ArrowBasicArrayStreamInit().
-/// This function move the ownership of array to the array_stream. i must
-/// be greater than zero and less than the value of n_arrays passed in
+/// This function moves the ownership of array to the array_stream. i must
+/// be greater than or equal to zero and less than the value of n_arrays passed in
 /// ArrowBasicArrayStreamInit(). Callers are not required to fill all
 /// n_arrays members (i.e., n_arrays is a maximum bound).
 NANOARROW_DLL void ArrowBasicArrayStreamSetArray(struct ArrowArrayStream* array_stream,


### PR DESCRIPTION
This fixes two issues with the docstring for ArrowBasicArrayStreamSetArray:

1. Corrects a statement about the  range of the `i` parameter. The correct range for `i` is `[0, n_arrays)`. I believe this was just a mistake as tests (and my code) uses 0 just fine.
2. Fixes a minor grammar issue in "move" vs. "moves"