### PR TITLE
Correct invocation of R_MakeExternalPtr with R NULL

### DIFF
--- a/r/src/buffer.c
+++ b/r/src/buffer.c
@@ -186,7 +186,7 @@ SEXP nanoarrow_c_buffer_info(SEXP buffer_xptr) {
                          "type", "data_type",  "element_size_bits",
                          ""};
   SEXP info = PROTECT(Rf_mkNamed(VECSXP, names));
-  SET_VECTOR_ELT(info, 0, R_MakeExternalPtr(buffer->data, NULL, buffer_xptr));
+  SET_VECTOR_ELT(info, 0, R_MakeExternalPtr(buffer->data, R_NilValue, buffer_xptr));
   SET_VECTOR_ELT(info, 1, Rf_ScalarReal((double)buffer->size_bytes));
   SET_VECTOR_ELT(info, 2, Rf_ScalarReal((double)buffer->capacity_bytes));
   SET_VECTOR_ELT(info, 3, buffer_type_sexp);


### PR DESCRIPTION
We recently found some bad code using `R_MakeExternalPtr(p, nullptr, nullptr)` (C++ "equivalent" of `NULL`) which could trigger a segfault _via_ `object.size()` of an object including the incorrectly-initialized externalptr.

https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#External-pointers-and-weak-references-1

`tag` is an `SEXP`, so the R `NULL` is better than the C `NULL`.

cc @randy3k