### PR TITLE
chore: Remove unnecessary use of `__COUNTER__`

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -40,7 +40,6 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: '4.1'}
           - {os: windows-latest, r: '4.2'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -142,6 +142,13 @@ struct ArrowArrayStream {
     if (NAME) return NAME;                        \
   } while (0)
 
+// __COUNTER__ is not guaranteed to be available and some compiler warnings may occur
+// if we use it (-Wc2y-extensions). We don't strictly need it because of the
+// do { ... } while(0) scoping and because we never need the return value to live
+// outside the temporary scope. Here we define a suffix that is unlikely to collide
+// with anything in EXPR.
+#define _NANOARROW_UNIQUE_SUFFIX _nanoarrow_unique_suffix
+
 #define _NANOARROW_CHECK_RANGE(x_, min_, max_) \
   NANOARROW_RETURN_NOT_OK((x_ >= min_ && x_ <= max_) ? NANOARROW_OK : EINVAL)
 
@@ -266,7 +273,8 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// \brief Check the result of an expression and return it if not NANOARROW_OK
 /// \ingroup nanoarrow-errors
 #define NANOARROW_RETURN_NOT_OK(EXPR) \
-  _NANOARROW_RETURN_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR)
+  _NANOARROW_RETURN_NOT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR)
 
 /// \brief Check the result of an expression and return it if not NANOARROW_OK,
 /// adding an auto-generated message to an ArrowError.
@@ -275,9 +283,10 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// This macro is used to ensure that functions that accept an ArrowError
 /// as input always set its message when returning an error code (e.g., when calling
 /// a nanoarrow function that does *not* accept ArrowError).
-#define NANOARROW_RETURN_NOT_OK_WITH_ERROR(EXPR, ERROR_EXPR) \
-  _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(                  \
-      _NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, ERROR_EXPR, #EXPR)
+#define NANOARROW_RETURN_NOT_OK_WITH_ERROR(EXPR, ERROR_EXPR)                           \
+  _NANOARROW_RETURN_NOT_OK_WITH_ERROR_IMPL(                                            \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, ERROR_EXPR, \
+      #EXPR)
 
 #if defined(NANOARROW_DEBUG) && !defined(NANOARROW_PRINT_AND_DIE)
 #define NANOARROW_PRINT_AND_DIE(VALUE, EXPR_STR)                                 \
@@ -304,7 +313,8 @@ static inline void ArrowErrorSetString(struct ArrowError* error, const char* src
 /// be defining the NANOARROW_PRINT_AND_DIE macro before including nanoarrow.h
 /// This macro is provided as a convenience for users and is not used internally.
 #define NANOARROW_ASSERT_OK(EXPR) \
-  _NANOARROW_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, #EXPR)
+  _NANOARROW_ASSERT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, #EXPR)
 
 #define _NANOARROW_DCHECK_IMPL(EXPR, EXPR_STR)          \
   do {                                                  \

--- a/src/nanoarrow/device/cuda.c
+++ b/src/nanoarrow/device/cuda.c
@@ -53,9 +53,9 @@ static inline void ArrowDeviceCudaSetError(CUresult err, const char* op,
     }                                                             \
   } while (0)
 
-#define NANOARROW_CUDA_RETURN_NOT_OK(EXPR, OP, ERROR)                                    \
-  _NANOARROW_CUDA_RETURN_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(cuda_err_, __COUNTER__), EXPR, \
-                                     OP, ERROR)
+#define NANOARROW_CUDA_RETURN_NOT_OK(EXPR, OP, ERROR) \
+  _NANOARROW_CUDA_RETURN_NOT_OK_IMPL(                 \
+      _NANOARROW_MAKE_NAME(cuda_err_, _NANOARROW_UNIQUE_SUFFIX), EXPR, OP, ERROR)
 
 #if defined(NANOARROW_DEBUG)
 #define _NANOARROW_CUDA_ASSERT_OK_IMPL(NAME, EXPR, EXPR_STR)           \
@@ -63,9 +63,9 @@ static inline void ArrowDeviceCudaSetError(CUresult err, const char* op,
     const CUresult NAME = (EXPR);                                      \
     if (NAME != CUDA_SUCCESS) NANOARROW_PRINT_AND_DIE(NAME, EXPR_STR); \
   } while (0)
-#define NANOARROW_CUDA_ASSERT_OK(EXPR)                                                   \
-  _NANOARROW_CUDA_ASSERT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, \
-                                 #EXPR)
+#define NANOARROW_CUDA_ASSERT_OK(EXPR) \
+  _NANOARROW_CUDA_ASSERT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, #EXPR)
 #else
 #define NANOARROW_CUDA_ASSERT_OK(EXPR) (void)(EXPR)
 #endif

--- a/src/nanoarrow/hpp/exception.hpp
+++ b/src/nanoarrow/hpp/exception.hpp
@@ -68,9 +68,9 @@ class Exception : public std::exception {
   } while (0)
 #endif
 
-#define NANOARROW_THROW_NOT_OK(EXPR)                                                   \
-  _NANOARROW_THROW_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR, \
-                               #EXPR)
+#define NANOARROW_THROW_NOT_OK(EXPR) \
+  _NANOARROW_THROW_NOT_OK_IMPL(      \
+      _NANOARROW_MAKE_NAME(errno_status_, _NANOARROW_UNIQUE_SUFFIX), EXPR, #EXPR)
 
 /// @}
 


### PR DESCRIPTION
In https://github.com/apache/arrow-adbc/pull/4044, ADBC has to work around a clang warning that declares `__COUNTER__` an extension. We don't strictly need it here so I just removed the usage. Claude Opus seems to think this is safe because of the `do { ... } while(0);` scoping but alternative opinions are welcome!