### PR TITLE
chore: add libuv-dev to alpine-s390x dockerfile

### DIFF
--- a/ci/docker/alpine.dockerfile
+++ b/ci/docker/alpine.dockerfile
@@ -20,7 +20,7 @@ ARG NANOARROW_ARCH
 FROM --platform=linux/${NANOARROW_ARCH} alpine:latest
 
 RUN apk add bash linux-headers git cmake R R-dev g++ gfortran gnupg \
-    curl py3-virtualenv python3-dev lz4-dev
+    curl py3-virtualenv python3-dev lz4-dev libuv-dev
 
 # For Arrow C++
 COPY ci/scripts/build-arrow-cpp-minimal.sh /


### PR DESCRIPTION
fs >= 2.0.0 now prefers system libuv and you appear to have to opt into
building with the bundled version. Adding libuv-dev to the Dockefile
seems like the best fix.
