### PR TITLE
chore(ci/docker): Add libuv to fedora image

### DIFF
--- a/ci/docker/fedora.dockerfile
+++ b/ci/docker/fedora.dockerfile
@@ -20,7 +20,7 @@ ARG NANOARROW_ARCH
 FROM --platform=linux/${NANOARROW_ARCH} fedora:latest
 
 RUN dnf install -y git cmake R gnupg curl libarrow-devel glibc-langpack-en \
-   python3-devel python3-virtualenv awk
+   python3-devel python3-virtualenv awk libuv-devel
 
 # For Python
 RUN python3 -m venv --upgrade-deps /venv


### PR DESCRIPTION
Thanks to amoeba the verification run works again!

Like Alpine, Fedora R needs libuv to install testthat and the verification run is failing ( https://github.com/apache/arrow-nanoarrow/actions/runs/24016985124/job/70038174555#step:4:3458 ).