### PR TITLE
chore(ci): Update integration dockerfile for updated image setup

### DIFF
--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -18,7 +18,6 @@
 FROM apache/arrow-dev:amd64-conda-integration
 
 ENV ARROW_USE_CCACHE=OFF \
-    ARROW_CPP_EXE_PATH=/build/cpp/debug \
     ARROW_NANOARROW_PATH=/build/nanoarrow \
     ARROW_RUST_EXE_PATH=/build/rust/debug \
     BUILD_DOCS_CPP=OFF \

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -60,14 +60,6 @@ RUN git clone https://github.com/apache/arrow-js.git /arrow-integration/js --dep
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs.git /arrow-integration/rust --depth 1
 
-# Install missing conda packages that the base image expects but no longer includes.
-# The conda environment sets CC, GOROOT, CFLAGS etc. but the packages that provide
-# these tools were removed from the base image. Must install into the "arrow" environment.
-RUN conda install -n arrow -y compilers go
-
-# Tell zstd-sys to use system libzstd via pkg-config instead of compiling from source
-ENV ZSTD_SYS_USE_PKG_CONFIG=1
-
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 # Activate conda environment directly instead of using conda run, which has issues with
 # environment variables being inherited from base instead of the target environment.

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -60,6 +60,10 @@ RUN git clone https://github.com/apache/arrow-js.git /arrow-integration/js --dep
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs.git /arrow-integration/rust --depth 1
 
+# Tell zstd-sys to use system libzstd via pkg-config instead of compiling from source
+# (the conda C compiler referenced by $CC doesn't exist in this image)
+ENV ZSTD_SYS_USE_PKG_CONFIG=1
+
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
     conda run --no-capture-output \

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -60,16 +60,21 @@ RUN git clone https://github.com/apache/arrow-js.git /arrow-integration/js --dep
 # Clone the arrow-rs repo
 RUN git clone https://github.com/apache/arrow-rs.git /arrow-integration/rust --depth 1
 
+# Install missing conda packages that the base image expects but no longer includes.
+# The conda environment sets CC, GOROOT, CFLAGS etc. but the packages that provide
+# these tools were removed from the base image. Must install into the "arrow" environment.
+RUN conda install -n arrow -y compilers go
+
 # Tell zstd-sys to use system libzstd via pkg-config instead of compiling from source
-# (the conda C compiler referenced by $CC doesn't exist in this image)
 ENV ZSTD_SYS_USE_PKG_CONFIG=1
 
-# Install Go (the base image sets GOROOT=/opt/conda/go but doesn't install it)
-RUN conda install -y go
-
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
-RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
-    conda run --no-capture-output \
-    /arrow-integration/ci/scripts/integration_arrow_build.sh \
-    /arrow-integration \
-    /build
+# Activate conda environment directly instead of using conda run, which has issues with
+# environment variables being inherited from base instead of the target environment.
+# Also add cargo/bin back to PATH since conda activation may not include it.
+SHELL ["/bin/bash", "-c"]
+RUN source /opt/conda/etc/profile.d/conda.sh && \
+    conda activate arrow && \
+    export PATH="/root/.cargo/bin:$PATH" && \
+    ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
+    /arrow-integration/ci/scripts/integration_arrow_build.sh /arrow-integration /build

--- a/ci/docker/integration.dockerfile
+++ b/ci/docker/integration.dockerfile
@@ -64,6 +64,9 @@ RUN git clone https://github.com/apache/arrow-rs.git /arrow-integration/rust --d
 # (the conda C compiler referenced by $CC doesn't exist in this image)
 ENV ZSTD_SYS_USE_PKG_CONFIG=1
 
+# Install Go (the base image sets GOROOT=/opt/conda/go but doesn't install it)
+RUN conda install -y go
+
 # Build all the integrations except nanoarrow (since we'll do that ourselves on each run)
 RUN ARCHERY_INTEGRATION_WITH_NANOARROW="0" \
     conda run --no-capture-output \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,10 +56,16 @@ services:
     environment:
       ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS: "nanoarrow"
       ARCHERY_INTEGRATION_WITH_RUST: "1"
+    # Activate conda environment directly instead of using conda run, which has issues with
+    # environment variables being inherited from base instead of the target environment.
+    # Also add cargo/bin back to PATH since conda activation may not include it.
     command:
-      ["echo '::group::Build nanoarrow' &&
-        conda run --no-capture-output /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&
+      ["/bin/bash", "-c",
+        "source /opt/conda/etc/profile.d/conda.sh && conda activate arrow &&
+        echo '::group::Build nanoarrow' &&
+        /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&
         echo '::endgroup::' &&
         echo '::group::Run integration tests' &&
-        conda run --no-capture-output /arrow-integration/ci/scripts/integration_arrow.sh /arrow-integration /build &&
-        echo '::endgroup::'"]
+        /arrow-integration/ci/scripts/integration_arrow.sh /arrow-integration /build &&
+        echo '::endgroup::'"
+      ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,13 +59,13 @@ services:
     # Activate conda environment directly instead of using conda run, which has issues with
     # environment variables being inherited from base instead of the target environment.
     # Also add cargo/bin back to PATH since conda activation may not include it.
+    entrypoint: ["/bin/bash", "-c"]
     command:
-      ["/bin/bash", "-c",
-        "source /opt/conda/etc/profile.d/conda.sh && conda activate arrow &&
+      - |
+        source /opt/conda/etc/profile.d/conda.sh && conda activate arrow && export PATH=/root/.cargo/bin:$$PATH &&
         echo '::group::Build nanoarrow' &&
         /arrow-integration/ci/scripts/nanoarrow_build.sh /arrow-integration /build &&
         echo '::endgroup::' &&
         echo '::group::Run integration tests' &&
         /arrow-integration/ci/scripts/integration_arrow.sh /arrow-integration /build &&
-        echo '::endgroup::'"
-      ]
+        echo '::endgroup::'


### PR DESCRIPTION
The image (from Arrow) seems to use a non-base environment and `conda run` was not setting the correct environment for compilers. The location of Arrow C++ also seems to have changed to being installed in the image.

Fixes #859.