### PR TITLE
chore: Fix CMake linking to static-only nanoarrow install with BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -830,6 +830,13 @@ endif()
 # Generate package files for the build and install trees.
 include(CMakePackageConfigHelpers)
 
+# Capture BUILD_SHARED_LIBS at configure time for use in the config file
+if(BUILD_SHARED_LIBS)
+  set(NANOARROW_BUILD_SHARED_LIBS "ON")
+else()
+  set(NANOARROW_BUILD_SHARED_LIBS "OFF")
+endif()
+
 foreach(tree_type BUILD INSTALL)
   if(tree_type STREQUAL "BUILD")
     set(install_location ".")

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/nanoarrow-config-version.cmake" REQUIRED)
 
 foreach(target nanoarrow nanoarrow_ipc nanoarrow_device nanoarrow_testing)
   if(TARGET nanoarrow::${target}_static)
-    if(BUILD_SHARED_LIBS)
+    if(@NANOARROW_BUILD_SHARED_LIBS@)
       add_library(nanoarrow::${target} ALIAS nanoarrow::${target}_shared)
     else()
       add_library(nanoarrow::${target} ALIAS nanoarrow::${target}_static)

--- a/examples/cmake-scenarios/build.sh
+++ b/examples/cmake-scenarios/build.sh
@@ -54,3 +54,23 @@ for nanoarrow_build_type in static shared auto; do
         -DTEST_BUILD_TYPE=${nanoarrow_build_type}
     cmake --build scratch/build_against_fetched_${nanoarrow_build_type}/
 done
+
+# Test that the nanoarrow::nanoarrow alias uses BUILD_SHARED_LIBS from nanoarrow's
+# build time, not the consumer's. Build nanoarrow as static-only, then configure
+# the consumer with BUILD_SHARED_LIBS=ON. The alias should resolve to static.
+# See: https://github.com/apache/arrow-nanoarrow/issues/875
+cmake -S ../.. -B scratch/nanoarrow_build_static_only/ \
+    -DCMAKE_INSTALL_PREFIX=scratch/nanoarrow_install_static_only/ \
+    -DNANOARROW_IPC=ON -DNANOARROW_DEVICE=ON -DNANOARROW_TESTING=ON \
+    -DBUILD_SHARED_LIBS=OFF \
+    $EXTRA_CMAKE_CONFIGURE
+cmake --build scratch/nanoarrow_build_static_only/
+cmake --install scratch/nanoarrow_build_static_only/ $EXTRA_CMAKE_INSTALL
+
+# Consumer uses BUILD_SHARED_LIBS=ON but nanoarrow only has static libs.
+# With the fix, this should work because nanoarrow::nanoarrow aliases to _static.
+cmake -S . -B scratch/build_mismatched_shared_libs/ \
+    -Dnanoarrow_ROOT=scratch/nanoarrow_install_static_only \
+    -DTEST_BUILD_TYPE=auto \
+    -DBUILD_SHARED_LIBS=ON
+cmake --build scratch/build_mismatched_shared_libs/

--- a/examples/cmake-scenarios/run.sh
+++ b/examples/cmake-scenarios/run.sh
@@ -24,6 +24,7 @@ WIN_DLL_NANOARROW_FETCHED="$(pwd)/scratch/build_against_fetched_shared/_deps/nan
 WIN_DLL_NANOARROW_BUILT="$(pwd)/scratch/nanoarrow_build/Debug"
 WIN_DLL_NANOARROW_INSTALLED="$(pwd)/scratch/nanoarrow_install/bin"
 
+# The mismatched_shared_libs test is static-only, so no DLL path needed
 for dir in scratch/build*; do
     # Special cases where we have to set PATH on Windows
     if [ "${dir}" = "scratch/build_against_fetched_shared" ] && [ "${OSTYPE}" = "msys" ]; then


### PR DESCRIPTION
Closes #875.