### PR TITLE
fix(ci): Set endianness of decoder in dictionary batch decode test

### DIFF
--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -699,7 +699,7 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDictionaryEncodingsUniqueIds) {
   ArrowIpcDictionaryEncodingsReset(&dictionary_encodings);
 }
 
-TEST(NanoarrowIpcTest, NanoarrowIpcDecodeDictionaryBatchDecode) {
+TEST(NanoarrowIpcTest, NanoarrowIpcDecodeDictionaryBatch) {
   using namespace nanoarrow::literals;
 
   struct ArrowIpcDictionaryEncodings dictionary_encodings;
@@ -734,6 +734,14 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeDictionaryBatchDecode) {
   // Check that we can't decode a dictionary batch if we haven't read a dictionary batch
   // message
   ASSERT_EQ(ArrowIpcDecoderInit(&decoder), NANOARROW_OK);
+#ifdef __BIG_ENDIAN__
+  ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_LITTLE),
+            NANOARROW_OK);
+#else
+  ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_BIG),
+            NANOARROW_OK);
+#endif
+
   struct ArrowBufferView body;
   body.data.data = nullptr;
   body.size_bytes = 0;

--- a/src/nanoarrow/ipc/decoder_test.cc
+++ b/src/nanoarrow/ipc/decoder_test.cc
@@ -734,13 +734,8 @@ TEST(NanoarrowIpcTest, NanoarrowIpcDecodeDictionaryBatch) {
   // Check that we can't decode a dictionary batch if we haven't read a dictionary batch
   // message
   ASSERT_EQ(ArrowIpcDecoderInit(&decoder), NANOARROW_OK);
-#ifdef __BIG_ENDIAN__
   ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_LITTLE),
             NANOARROW_OK);
-#else
-  ASSERT_EQ(ArrowIpcDecoderSetEndianness(&decoder, NANOARROW_IPC_ENDIANNESS_BIG),
-            NANOARROW_OK);
-#endif
 
   struct ArrowBufferView body;
   body.data.data = nullptr;


### PR DESCRIPTION
The dictionary batch decode was failing on big endian CI because we need to explicitly set the endianness of the decoder to ensure it byte swaps buffers correctly.