### PR TITLE
fix!: Ensure ArrowTypeString never returns NULL

### DIFF
--- a/python/src/nanoarrow/_array.pyx
+++ b/python/src/nanoarrow/_array.pyx
@@ -143,8 +143,7 @@ cdef class CArrayView:
     @property
     def storage_type(self):
         cdef const char* type_str = ArrowTypeString(self._ptr.storage_type)
-        if type_str != NULL:
-            return type_str.decode('UTF-8')
+        return type_str.decode('UTF-8')
 
     @property
     def layout(self):

--- a/python/src/nanoarrow/_schema.pyx
+++ b/python/src/nanoarrow/_schema.pyx
@@ -594,18 +594,12 @@ cdef class CSchemaView:
     @property
     def type(self) -> str:
         cdef const char* type_str = ArrowTypeString(self._schema_view.type)
-        if type_str != NULL:
-            return type_str.decode()
-        else:
-            raise ValueError("ArrowTypeString() returned NULL")
+        return type_str.decode()
 
     @property
     def storage_type(self) -> str:
         cdef const char* type_str = ArrowTypeString(self._schema_view.storage_type)
-        if type_str != NULL:
-            return type_str.decode()
-        else:
-            raise ValueError("ArrowTypeString() returned NULL")
+        return type_str.decode()
 
     @property
     def dictionary_ordered(self) -> Union[bool, None]:

--- a/src/nanoarrow/common/inline_types.h
+++ b/src/nanoarrow/common/inline_types.h
@@ -473,7 +473,7 @@ enum ArrowType {
 /// \brief Get a string value of an enum ArrowType value
 /// \ingroup nanoarrow-utils
 ///
-/// Returns NULL for invalid values for type
+/// Returns "<unknown type identifier>" for invalid values for type
 static inline const char* ArrowTypeString(enum ArrowType type);
 
 static inline const char* ArrowTypeString(enum ArrowType type) {
@@ -569,7 +569,7 @@ static inline const char* ArrowTypeString(enum ArrowType type) {
     case NANOARROW_TYPE_LARGE_LIST_VIEW:
       return "large_list_view";
     default:
-      return NULL;
+      return "<unknown type identifier>";
   }
 }
 


### PR DESCRIPTION
Previously an unknown type identifier would have resulted in a NULL; now a conspicuous-looking possibly helpful string is shown.

Almost all internal usage of ArrowTypeString is use in Printf strings, for which gcc now displays a warning if the value could be NULL.

This is a breaking change if anybody was relying on the null output here to detect an invalid type identifier.

Closes #884.