### PR TITLE
chore(ci): Add valgrind suppressions for Arrow C++ dynamic library initialization

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -170,5 +170,17 @@ jobs:
 
         run: |
           cd src
+          mkdir -p ../nanoarrow-verify-tmp
           echo "::group::Docker Pull"
-          docker compose run -e GITHUB_ACTIONS ${{ matrix.config.compose_args }} verify
+          docker compose run \
+            -e GITHUB_ACTIONS \
+            -e NANOARROW_TMPDIR=/nanoarrow-verify-tmp \
+            -v "$(pwd)/../nanoarrow-verify-tmp:/nanoarrow-verify-tmp" \
+            ${{ matrix.config.compose_args }} verify
+
+      - name: Upload temp directory
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          path: nanoarrow-verify-tmp
+          name: nanoarrow-verify-tmp-${{ matrix.config.platform }}-${{ matrix.config.arch }}${{ matrix.config.extra_label }}

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -19,7 +19,7 @@
    <Arrow C++>:Library initialization
    Memcheck:Cond
    ...
-   obj:*libarrow*
+   obj:*arrow*
    ...
    fun:call_init*
    fun:_dl_init

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -16,6 +16,16 @@
 # under the License.
 
 {
+   <Arrow C++>:Library initialization
+   Memcheck:Cond
+   ...
+   obj:*libarrow*
+   ...
+   fun:call_init*
+   fun:_dl_init
+}
+
+{
     <jemalloc>:Thread locals don't appear to be freed
     Memcheck:Leak
     ...


### PR DESCRIPTION
This CI adds valgrind suppressions for the Arrow C++ shared object initialization, which apparently has an uninitialized conditional valgrind note. The prefix is `mi_` so I am guessing mimalloc but I'm not sure.

I also added a slight modification to upload the verification directory in case of failure (to more easily debug these in the future).