### PR TITLE
chore(ci): Trust the gemfury client when brewing

### DIFF
--- a/.github/workflows/python-wheels.yaml
+++ b/.github/workflows/python-wheels.yaml
@@ -173,6 +173,7 @@ jobs:
       - name: Install gemfury client
         run: |
           brew tap gemfury/tap
+          brew trust gemfury/tap
           brew install fury-cli
           fury --version
 


### PR DESCRIPTION
Fixes a CI error on main when uploading wheels

```
==> Tapping gemfury/tap
Cloning into '/opt/homebrew/Library/Taps/gemfury/homebrew-tap'...
Tapped 2 formulae (15 files, 34.3KB).
Error: Refusing to load formula gemfury/tap/fury-cli from untrusted tap gemfury/tap.
Run `brew trust --formula gemfury/tap/fury-cli` or `brew trust gemfury/tap` to trust it.
Error: Process completed with exit code 1.
```

https://github.com/apache/arrow-nanoarrow/actions/runs/28251153309/job/83705731758#step:3:7