### PR TITLE
fix: Ensure metal device's align buffers exports aligned buffer pointers correctly

### DIFF
--- a/.github/workflows/r-check.yaml
+++ b/.github/workflows/r-check.yaml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.config.os != 'windows-latest'
         env:
           PKG_CPPFLAGS: "-DNANOARROW_DEBUG"
-          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion -Wno-cast-function-type -Wno-misleading-indentation -Wno-conversion -Wno-unused-const-variable"
+          PKG_CFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wconversion -Wno-unused-parameter -Wno-sign-conversion -Wno-cast-function-type -Wno-misleading-indentation -Wno-conversion -Wno-unused-const-variable -Wno-c23-extensions"
         run: |
           R CMD INSTALL r --preclean
         shell: bash

--- a/src/nanoarrow/device/metal.cc
+++ b/src/nanoarrow/device/metal.cc
@@ -127,8 +127,7 @@ ArrowErrorCode ArrowDeviceMetalAlignArrayBuffers(struct ArrowArray* array) {
     NANOARROW_RETURN_NOT_OK(ArrowDeviceMetalInitBuffer(&new_buffer));
     NANOARROW_RETURN_NOT_OK(
         ArrowBufferAppend(&new_buffer, buffer->data, buffer->size_bytes));
-    ArrowBufferReset(buffer);
-    ArrowBufferMove(&new_buffer, buffer);
+    NANOARROW_RETURN_NOT_OK(ArrowArraySetBuffer(array, i, &new_buffer));
   }
 
   for (int64_t i = 0; i < array->n_children; i++) {

--- a/src/nanoarrow/device/metal_test.cc
+++ b/src/nanoarrow/device/metal_test.cc
@@ -206,7 +206,7 @@ TEST(NanoarrowDeviceMetal, DeviceCpuArrayBuffers) {
       ArrowArrayFinishBuilding(array.get(), NANOARROW_VALIDATION_LEVEL_FULL, nullptr),
       NANOARROW_OK);
 
-  // Make sure that ArrowDeviceMetalInitArrayBuffers() copies existing content
+  // Make sure that ArrowDeviceMetalAlignArrayBuffers() copies existing content
   ASSERT_EQ(ArrowDeviceMetalAlignArrayBuffers(array.get()), NANOARROW_OK);
 
   auto data_ptr = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);


### PR DESCRIPTION
The existing implementation of `ArrowDeviceMetalAlignArrayBuffers()` did not properly flush the buffer pointer in the `ArrowArray`, so the `array->buffers[i]` pointer pointed to potentially freed data. This is not a commonly (if ever) used function.