### PR TITLE
chore(ci): Improve compatibility between nanoarrow and arrow Meson builds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -187,8 +187,7 @@ jobs:
               -Dbuildtype=release \
               -Dwerror=true \
               -Dipc=enabled \
-              -Dtests=enabled \
-              --wrap-mode=nodownload
+              -Dtests=enabled
           meson compile -C builddir
           meson test -C builddir --print-errorlogs
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -166,6 +166,31 @@ jobs:
         run: |
           PKG_CONFIG_PATH="$(pwd)/arrow/lib/pkgconfig" ci/scripts/build-with-meson.sh
 
+  meson-build-no-arrow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      # Meson 1.8.0 breaks build
+      # https://github.com/apache/arrow-nanoarrow/issues/753
+      - name: Install build dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "meson<1.8.0" ninja
+
+      - name: Run meson (no Arrow)
+        run: |
+          meson setup builddir \
+              -Dbuildtype=release \
+              -Dwerror=true \
+              -Dipc=enabled \
+              -Dtests=enabled
+          meson compile -C builddir
+          meson test -C builddir --print-errorlogs
+
   meson-build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -187,7 +187,8 @@ jobs:
               -Dbuildtype=release \
               -Dwerror=true \
               -Dipc=enabled \
-              -Dtests=enabled
+              -Dtests=enabled \
+              --wrap-mode=nodownload
           meson compile -C builddir
           meson test -C builddir --print-errorlogs
 

--- a/ci/scripts/build-with-meson.sh
+++ b/ci/scripts/build-with-meson.sh
@@ -64,7 +64,8 @@ function main() {
     meson setup "${SANDBOX_DIR}" \
           --pkg-config-path $PKG_CONFIG_PATH \
           -Dwerror=true \
-          -Dbuildtype=release
+          -Dbuildtype=release \
+          -Dtests_with_arrow=enabled
 
     pushd "${SANDBOX_DIR}"
 

--- a/meson.build
+++ b/meson.build
@@ -266,15 +266,11 @@ if get_option('tests').enabled()
     if get_option('tests_with_arrow').enabled()
         # When tests_with_arrow is enabled, Arrow is required. Use pkg-config first,
         # then fall back to building from the wrapdb subproject if not found.
-        arrow_dep = dependency(
-            'arrow',
-            include_type: 'system',
-            fallback: ['arrow-cpp', 'arrow_dep'],
-        )
+        arrow_dep = dependency('arrow')
         test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
     else
         # When tests_with_arrow is disabled, Arrow is optional (for roundtrip tests)
-        arrow_dep = dependency('arrow', include_type: 'system', required: false)
+        arrow_dep = dependency('arrow', required: false)
     endif
 
     gtest_dep = dependency('gtest_main')

--- a/meson.build
+++ b/meson.build
@@ -263,13 +263,18 @@ if get_option('tests').enabled()
     # Similarly code coverage has a built in option users should use instead
     # https://mesonbuild.com/Unit-tests.html#coverage
 
-    arrow_dep = dependency('arrow', include_type: 'system', required: false)
     if get_option('tests_with_arrow').enabled()
-        if arrow_dep.found()
-            test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
-        else
-            warning('tests_with_arrow option enabled but could not find Arrow')
-        endif
+        # When tests_with_arrow is enabled, Arrow is required. Use pkg-config first,
+        # then fall back to building from the wrapdb subproject if not found.
+        arrow_dep = dependency(
+            'arrow',
+            include_type: 'system',
+            fallback: ['arrow-cpp', 'arrow_dep'],
+        )
+        test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
+    else
+        # When tests_with_arrow is disabled, Arrow is optional (for roundtrip tests)
+        arrow_dep = dependency('arrow', include_type: 'system', required: false)
     endif
 
     gtest_dep = dependency('gtest_main')

--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,8 @@ project(
     'cpp',
     version: '0.9.0-SNAPSHOT',
     license: 'Apache-2.0',
-    meson_version: '>=0.58.0',
-    default_options: ['c_std=c99', 'warning_level=2', 'cpp_std=c++17'],
+    meson_version: '>=1.3.0',
+    default_options: ['c_std=c99', 'warning_level=2', 'cpp_std=c++20,c++17'],
 )
 
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -266,7 +266,7 @@ if get_option('tests').enabled()
     if get_option('tests_with_arrow').enabled()
         # When tests_with_arrow is enabled, Arrow is required. Use pkg-config first,
         # then fall back to building from the wrapdb subproject if not found.
-        arrow_dep = dependency('arrow')
+        arrow_dep = dependency('arrow', include_type: 'system')
         test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
     else
         # When tests_with_arrow is disabled, Arrow is optional (for roundtrip tests)

--- a/meson.build
+++ b/meson.build
@@ -270,7 +270,7 @@ if get_option('tests').enabled()
         test_cpp_args += ['-DNANOARROW_BUILD_TESTS_WITH_ARROW']
     else
         # When tests_with_arrow is disabled, Arrow is optional (for roundtrip tests)
-        arrow_dep = dependency('arrow', required: false)
+        arrow_dep = dependency('arrow', include_type: 'system', required: false)
     endif
 
     gtest_dep = dependency('gtest_main')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 option('tests', type: 'feature', description: 'Build tests')
-option('tests_with_arrow', type: 'feature', description: 'Build tests with Arrow')
+option('tests_with_arrow', type: 'feature', value: 'disabled', description: 'Build tests with Arrow')
 option('benchmarks', type: 'feature', description: 'Build benchmarks')
 option('apps', type: 'feature', description: 'Build utility applications')
 option('ipc', type: 'feature', description: 'Build IPC libraries')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 option('tests', type: 'feature', description: 'Build tests')
-option('tests_with_arrow', type: 'feature', value: 'disabled', description: 'Build tests with Arrow')
+option('tests_with_arrow', type: 'feature', description: 'Build tests with Arrow')
 option('benchmarks', type: 'feature', description: 'Build benchmarks')
 option('apps', type: 'feature', description: 'Build utility applications')
 option('ipc', type: 'feature', description: 'Build IPC libraries')

--- a/subprojects/arrow-cpp.wrap
+++ b/subprojects/arrow-cpp.wrap
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = apache-arrow-21.0.0
+source_url = https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-21.0.0/apache-arrow-21.0.0.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/arrow-cpp_21.0.0-1/apache-arrow-21.0.0.tar.gz
+source_filename = apache-arrow-21.0.0.tar.gz
+source_hash = 5d3f8db7e72fb9f65f4785b7a1634522e8d8e9657a445af53d4a34a3849857b5
+patch_filename = arrow-cpp_21.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/arrow-cpp_21.0.0-1/get_patch
+patch_hash = b25196ce575954384f158575bf3c54fc72745ec793a7b7d1c270089f1639bbbf
+wrapdb_version = 21.0.0-1
+
+[provide]
+arrow = arrow_dep
+arrow-compute = arrow_compute_dep


### PR DESCRIPTION
This hopefully resolves building nanoarrow against arrow from the WrapDB (with apologies if I've misunderstood some of these concepts or the issue).

Closes #902