### PR TITLE
fix: Fix ENODATA undefined on FreeBSD and OpenBSD

### DIFF
--- a/src/nanoarrow/ipc/decoder.c
+++ b/src/nanoarrow/ipc/decoder.c
@@ -25,8 +25,9 @@
 #include "nanoarrow/nanoarrow.h"
 #include "nanoarrow/nanoarrow_ipc.h"
 
-// R 3.6 / Windows builds on a very old toolchain that does not define ENODATA
-#if defined(_WIN32) && !defined(_MSC_VER) && !defined(ENODATA)
+// ENODATA is an XSI extension and is not defined by all libcs (e.g., older
+// Windows/MinGW toolchains used by R 3.6, FreeBSD, and OpenBSD).
+#if !defined(ENODATA)
 #define ENODATA 120
 #endif
 

--- a/src/nanoarrow/ipc/reader.c
+++ b/src/nanoarrow/ipc/reader.c
@@ -23,8 +23,9 @@
 #include "nanoarrow/nanoarrow.h"
 #include "nanoarrow/nanoarrow_ipc.h"
 
-// R 3.6 / Windows builds on a very old toolchain that does not define ENODATA
-#if defined(_WIN32) && !defined(_MSC_VER) && !defined(ENODATA)
+// ENODATA is an XSI extension and is not defined by all libcs (e.g., older
+// Windows/MinGW toolchains used by R 3.6, FreeBSD, and OpenBSD).
+#if !defined(ENODATA)
 #define ENODATA 120
 #endif
 


### PR DESCRIPTION
ENODATA is an XSI/SVID extension, not part of the POSIX base specification, so <errno.h> is not required to define it. FreeBSD and OpenBSD do not define it, which currently breaks the build of nanoarrow_ipc on those platforms. (NetBSD already defines ENODATA itself and is unaffected.)

The existing fallback only kicked in for old Windows/MinGW toolchains (R 3.6). Widen the guard to apply on any platform that does not define ENODATA, so FreeBSD, OpenBSD, and other such systems also get the fallback definition.

The value 120 matches the existing Windows/MinGW fallback and does not collide with any errno value defined by FreeBSD (ELAST == 97 as of FreeBSD 16-CURRENT) or OpenBSD (ELAST == 95).