### PR TITLE
docs: Fix typo in Python docs

### DIFF
--- a/python/src/nanoarrow/__init__.py
+++ b/python/src/nanoarrow/__init__.py
@@ -17,7 +17,7 @@
 
 """Python bindings to the nanoarrow C library
 
-EXPERIMNETAL
+EXPERIMENTAL
 
 The nanoarrow Python package provides bindings to the nanoarrow C library. Like
 the nanoarrow C library, it provides tools to facilitate the use of the


### PR DESCRIPTION
Hi, thanks for creating Nanoarrow! This fixes a typo in the [Python API reference](https://arrow.apache.org/nanoarrow/latest/reference/python/index.html).