### PR TITLE
chore(ci): Update arrow C++ version and force new builds

### DIFF
--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -104,7 +104,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-device.yaml
+++ b/.github/workflows/build-and-test-device.yaml
@@ -98,13 +98,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-3
+          key: arrow-device-${{ runner.os }}-${{ runner.arch }}-${{ matrix.config.label }}-4
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -73,13 +73,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-5
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-6
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test-ipc.yaml
+++ b/.github/workflows/build-and-test-ipc.yaml
@@ -79,7 +79,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Build
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -71,7 +71,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Build nanoarrow
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -160,7 +160,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Run meson testing script
         run: |

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -65,13 +65,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-2
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-3
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Build nanoarrow
         run: |
@@ -154,13 +154,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-3
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-4
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Run meson testing script
         run: |

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -48,13 +48,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-3
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-4
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Build nanoarrow
         run: |

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -54,7 +54,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Build nanoarrow
         run: |

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -96,7 +96,7 @@ jobs:
         if: steps.cache-arrow-build.outputs.cache-hit != 'true' && matrix.config.label != 'windows-win32'
         shell: bash
         run: |
-          src/ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
+          src/ci/scripts/build-arrow-cpp-minimal.sh 24.0.0 arrow
 
       - name: Set CMake options
         shell: bash

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -90,13 +90,13 @@ jobs:
         with:
           path: arrow
           # Bump the number at the end of this line to force a new Arrow C++ build
-          key: arrow-${{ runner.os }}-${{ runner.arch }}-3
+          key: arrow-${{ runner.os }}-${{ runner.arch }}-4
 
       - name: Build Arrow C++
         if: steps.cache-arrow-build.outputs.cache-hit != 'true' && matrix.config.label != 'windows-win32'
         shell: bash
         run: |
-          src/ci/scripts/build-arrow-cpp-minimal.sh 21.0.0 arrow
+          src/ci/scripts/build-arrow-cpp-minimal.sh 25.0.0 arrow
 
       - name: Set CMake options
         shell: bash

--- a/ci/docker/alpine.dockerfile
+++ b/ci/docker/alpine.dockerfile
@@ -24,7 +24,7 @@ RUN apk add bash linux-headers git cmake R R-dev g++ gfortran gnupg \
 
 # For Arrow C++
 COPY ci/scripts/build-arrow-cpp-minimal.sh /
-RUN /build-arrow-cpp-minimal.sh 21.0.0 /arrow
+RUN /build-arrow-cpp-minimal.sh 25.0.0 /arrow
 
 # There's a missing define that numpy's build needs on s390x and there is no wheel
 RUN (grep -e "S390" /usr/include/bits/hwcap.h && echo "#define HWCAP_S390_VX HWCAP_S390_VXRS" >> /usr/include/bits/hwcap.h) || true

--- a/ci/docker/alpine.dockerfile
+++ b/ci/docker/alpine.dockerfile
@@ -24,7 +24,7 @@ RUN apk add bash linux-headers git cmake R R-dev g++ gfortran gnupg \
 
 # For Arrow C++
 COPY ci/scripts/build-arrow-cpp-minimal.sh /
-RUN /build-arrow-cpp-minimal.sh 25.0.0 /arrow
+RUN /build-arrow-cpp-minimal.sh 24.0.0 /arrow
 
 # There's a missing define that numpy's build needs on s390x and there is no wheel
 RUN (grep -e "S390" /usr/include/bits/hwcap.h && echo "#define HWCAP_S390_VX HWCAP_S390_VXRS" >> /usr/include/bits/hwcap.h) || true

--- a/ci/docker/centos.dockerfile
+++ b/ci/docker/centos.dockerfile
@@ -32,7 +32,7 @@ RUN ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
 
 # For Arrow C++
 COPY ci/scripts/build-arrow-cpp-minimal.sh /
-RUN /build-arrow-cpp-minimal.sh 25.0.0 /arrow
+RUN /build-arrow-cpp-minimal.sh 24.0.0 /arrow
 
 RUN python3 -m venv /venv
 RUN source /venv/bin/activate && \

--- a/ci/docker/centos.dockerfile
+++ b/ci/docker/centos.dockerfile
@@ -32,7 +32,7 @@ RUN ln -s /opt/R/${R_VERSION}/bin/R /usr/local/bin/R && \
 
 # For Arrow C++
 COPY ci/scripts/build-arrow-cpp-minimal.sh /
-RUN /build-arrow-cpp-minimal.sh 21.0.0 /arrow
+RUN /build-arrow-cpp-minimal.sh 25.0.0 /arrow
 
 RUN python3 -m venv /venv
 RUN source /venv/bin/activate && \


### PR DESCRIPTION
This PR updates Arrow C++ to 24 in the places we build it. Arrow 21 was failing to build on the MacOS verify job, so hopefully Arrow 24 fixes the issue.

We can't use Arrow 25 because it won't build with a SMID level of NONE ( https://github.com/apache/arrow/issues/50542 ). I believe I build with a level of none for Alpine but we also don't use any compute functionality to run the tests.