### PR TITLE
ci: authenticate Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -37,6 +37,9 @@ jobs:
   coverage:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v7
@@ -56,4 +59,6 @@ jobs:
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v7
         with:
+          fail_ci_if_error: true
           files: '_coverage/coverage.info,_coverage/r_coverage.json,_coverage/python_coverage.xml'
+          use_oidc: true


### PR DESCRIPTION
The coverage workflow on `main` currently completes successfully even though Codecov rejects its upload with `Token required because branch is protected`. This leaves the repository coverage baseline stale and causes PR patch reports to compare against an old commit.

Configure the Codecov action to use GitHub OIDC, grant the required permissions, and fail the job when an upload is rejected. Fork pull requests continue to use Codecov tokenless uploads because the action detects fork events and skips OIDC for them.

The failed protected-branch upload is visible in https://github.com/apache/arrow-nanoarrow/actions/runs/32611406823.