### PR TITLE
feat: append array views to arrays

### DIFF
--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -436,7 +436,7 @@ static ArrowErrorCode ArrowArrayAppendValidityFromArrayView(
 
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapReserve(dst_validity, src->length),
                                      error);
-  int8_t validity[1024];
+  int8_t validity[1024] = {0};
   for (int64_t offset = 0; offset < src->length;) {
     int64_t remaining = src->length - offset;
     int64_t chunk_size =

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -186,6 +186,14 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)dst->private_data;
   enum ArrowType dst_type = private_data->storage_type;
+
+  if (src->storage_type == NANOARROW_TYPE_DENSE_UNION ||
+      src->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
+    ArrowErrorSet(error, "Appending array views is not supported for %s",
+                  ArrowTypeString(src->storage_type));
+    return ENOTSUP;
+  }
+
   if (!ArrowArrayCanAppendStorageType(dst_type, src->storage_type)) {
     ArrowErrorSet(error, "Can't append %s storage to an array with %s storage",
                   ArrowTypeString(src->storage_type), ArrowTypeString(dst_type));
@@ -299,25 +307,6 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendInterval(dst, &interval), error);
       return NANOARROW_OK;
     }
-    case NANOARROW_TYPE_DECIMAL32:
-    case NANOARROW_TYPE_DECIMAL64:
-    case NANOARROW_TYPE_DECIMAL128:
-    case NANOARROW_TYPE_DECIMAL256: {
-      int32_t bitwidth = 32;
-      if (src->storage_type == NANOARROW_TYPE_DECIMAL64) {
-        bitwidth = 64;
-      } else if (src->storage_type == NANOARROW_TYPE_DECIMAL128) {
-        bitwidth = 128;
-      } else if (src->storage_type == NANOARROW_TYPE_DECIMAL256) {
-        bitwidth = 256;
-      }
-
-      struct ArrowDecimal decimal;
-      ArrowDecimalInit(&decimal, bitwidth, /*precision=*/0, /*scale=*/0);
-      ArrowArrayViewGetDecimalUnsafe(src, i, &decimal);
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendDecimal(dst, &decimal), error);
-      return NANOARROW_OK;
-    }
     case NANOARROW_TYPE_STRUCT:
       for (int64_t child_i = 0; child_i < src->n_children; child_i++) {
         NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
@@ -357,45 +346,12 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
     }
+    case NANOARROW_TYPE_DECIMAL32:
+    case NANOARROW_TYPE_DECIMAL64:
+    case NANOARROW_TYPE_DECIMAL128:
+    case NANOARROW_TYPE_DECIMAL256:
     case NANOARROW_TYPE_DENSE_UNION:
-    case NANOARROW_TYPE_SPARSE_UNION: {
-      int8_t type_id = ArrowArrayViewUnionTypeId(src, i);
-      int8_t child_index = ArrowArrayViewUnionChildIndex(src, i);
-      int64_t child_offset = ArrowArrayViewUnionChildOffset(src, i);
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
-          dst->children[child_index], src->children[child_index], child_offset, error));
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          ArrowBufferAppend(ArrowArrayBuffer(dst, 0), &type_id, sizeof(type_id)), error);
-      if (src->storage_type == NANOARROW_TYPE_DENSE_UNION) {
-        int64_t dst_child_offset = dst->children[child_index]->length - 1;
-        if (dst_child_offset < 0 || dst_child_offset > INT32_MAX) {
-          ArrowErrorSet(error,
-                        "Expected dense union child offset to fit in int32 but "
-                        "found %" PRId64,
-                        dst_child_offset);
-          return EOVERFLOW;
-        }
-        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-            ArrowBufferAppendInt32(ArrowArrayBuffer(dst, 1), (int32_t)dst_child_offset),
-            error);
-      } else {
-        for (int64_t child_i = 0; child_i < dst->n_children; child_i++) {
-          if (child_i != child_index && dst->children[child_i]->length == dst->length) {
-            NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-                ArrowArrayAppendEmpty(dst->children[child_i], 1), error);
-          }
-          if (dst->children[child_i]->length != dst->length + 1) {
-            ArrowErrorSet(error,
-                          "Expected sparse union child length of %" PRId64
-                          " but found %" PRId64,
-                          dst->length + 1, dst->children[child_i]->length);
-            return EINVAL;
-          }
-        }
-      }
-      dst->length++;
-      return NANOARROW_OK;
-    }
+    case NANOARROW_TYPE_SPARSE_UNION:
     case NANOARROW_TYPE_RUN_END_ENCODED:
     case NANOARROW_TYPE_UNINITIALIZED:
     default:
@@ -409,7 +365,8 @@ static int ArrowArrayCanAppendFixedWidthStorage(struct ArrowArray* dst,
                                                 const struct ArrowArrayView* src) {
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)dst->private_data;
-  return private_data->storage_type == src->storage_type && src->n_children == 0 &&
+  return private_data->storage_type == src->storage_type && dst->n_buffers == 2 &&
+         src->n_children == 0 &&
          src->layout.buffer_type[1] == NANOARROW_BUFFER_TYPE_DATA &&
          src->layout.element_size_bits[1] > 0 &&
          src->layout.element_size_bits[1] % 8 == 0;

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -169,6 +169,14 @@ static int ArrowArrayCanAppendStorageType(enum ArrowType dst_type,
 
 static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
     struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
+  if (src->offset < 0 || src->length < 0 || src->offset > INT64_MAX - src->length) {
+    ArrowErrorSet(error,
+                  "Expected source offset and length to describe a valid int64 "
+                  "range but found %" PRId64 " and %" PRId64,
+                  src->offset, src->length);
+    return EINVAL;
+  }
+
   if (!ArrowArrayIsInternal(dst)) {
     ArrowErrorSet(error, "Expected destination to be an internal ArrowArray");
     return EINVAL;
@@ -404,6 +412,95 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
   }
 }
 
+static int ArrowArrayCanAppendFixedWidthStorage(struct ArrowArray* dst,
+                                                const struct ArrowArrayView* src) {
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)dst->private_data;
+  return private_data->storage_type == src->storage_type && src->n_children == 0 &&
+         src->layout.buffer_type[1] == NANOARROW_BUFFER_TYPE_DATA &&
+         src->layout.element_size_bits[1] > 0 &&
+         src->layout.element_size_bits[1] % 8 == 0;
+}
+
+static ArrowErrorCode ArrowArrayAppendValidityFromArrayView(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
+  struct ArrowBitmap* dst_validity = ArrowArrayValidityBitmap(dst);
+  const uint8_t* src_validity = src->buffer_views[0].data.as_uint8;
+  if (src_validity == NULL && dst_validity->buffer.data == NULL) {
+    return NANOARROW_OK;
+  }
+
+  if (dst_validity->buffer.data == NULL) {
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapAppend(dst_validity, 1, dst->length),
+                                       error);
+  }
+
+  if (src_validity == NULL) {
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapAppend(dst_validity, 1, src->length),
+                                       error);
+    return NANOARROW_OK;
+  }
+
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowBitmapReserve(dst_validity, src->length),
+                                     error);
+  int8_t validity[1024];
+  for (int64_t offset = 0; offset < src->length;) {
+    int64_t remaining = src->length - offset;
+    int64_t chunk_size =
+        remaining < (int64_t)sizeof(validity) ? remaining : (int64_t)sizeof(validity);
+    ArrowBitsUnpackInt8(src_validity, src->offset + offset, chunk_size, validity);
+    ArrowBitmapAppendInt8Unsafe(dst_validity, validity, chunk_size);
+    offset += chunk_size;
+  }
+
+  return NANOARROW_OK;
+}
+
+static ArrowErrorCode ArrowArrayAppendFixedWidthStorageFromArrayView(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
+  if (src->length == 0) {
+    return NANOARROW_OK;
+  }
+
+  int64_t element_size_bytes = src->layout.element_size_bits[1] / 8;
+  if (src->offset > INT64_MAX / element_size_bytes ||
+      src->length > INT64_MAX / element_size_bytes) {
+    ArrowErrorSet(error,
+                  "Expected fixed-width append size to fit in int64 but found "
+                  "element size %" PRId64 ", offset %" PRId64 ", and length %" PRId64,
+                  element_size_bytes, src->offset, src->length);
+    return EOVERFLOW;
+  }
+
+  int64_t src_offset_bytes = src->offset * element_size_bytes;
+  int64_t src_size_bytes = src->length * element_size_bytes;
+  if (src->buffer_views[1].data.as_uint8 == NULL ||
+      src_offset_bytes > src->buffer_views[1].size_bytes ||
+      src_size_bytes > src->buffer_views[1].size_bytes - src_offset_bytes) {
+    ArrowErrorSet(error,
+                  "Expected fixed-width source buffer to contain %" PRId64
+                  " bytes at offset %" PRId64 " but its size is %" PRId64,
+                  src_size_bytes, src_offset_bytes, src->buffer_views[1].size_bytes);
+    return EINVAL;
+  }
+
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowArrayAppendValidityFromArrayView(dst, src, error), error);
+
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowBufferAppend(ArrowArrayBuffer(dst, 1),
+                        src->buffer_views[1].data.as_uint8 + src_offset_bytes,
+                        src_size_bytes),
+      error);
+
+  if (src->buffer_views[0].data.as_uint8 != NULL) {
+    dst->null_count += src->length - ArrowBitCountSet(src->buffer_views[0].data.as_uint8,
+                                                      src->offset, src->length);
+  }
+  dst->length += src->length;
+  return NANOARROW_OK;
+}
+
 static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
                                         int64_t logical_offset) {
   if (run_ends->length <= 1) {
@@ -437,6 +534,10 @@ ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
                                                     struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(
       ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error), error);
+
+  if (ArrowArrayCanAppendFixedWidthStorage(dst, src)) {
+    return ArrowArrayAppendFixedWidthStorageFromArrayView(dst, src, error);
+  }
 
   if (src->storage_type == NANOARROW_TYPE_RUN_END_ENCODED) {
     if (src->length == 0) {

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -77,17 +77,8 @@ int ArrowArrayIsInternal(struct ArrowArray* array) {
   return array->release == &ArrowArrayReleaseInternal;
 }
 
-static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
-                                                       const struct ArrowArrayView* src,
-                                                       int64_t i,
-                                                       struct ArrowError* error) {
-  if (ArrowArrayViewIsNull(src, i)) {
-    return ArrowArrayAppendNull(dst, 1);
-  }
-
-  switch (src->storage_type) {
-    case NANOARROW_TYPE_NA:
-      return ArrowArrayAppendNull(dst, 1);
+static int ArrowTypeIsSignedInteger(enum ArrowType type) {
+  switch (type) {
     case NANOARROW_TYPE_BOOL:
     case NANOARROW_TYPE_INT8:
     case NANOARROW_TYPE_INT16:
@@ -99,16 +90,31 @@ static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
     case NANOARROW_TYPE_TIME32:
     case NANOARROW_TYPE_TIME64:
     case NANOARROW_TYPE_DURATION:
-      return ArrowArrayAppendInt(dst, ArrowArrayViewGetIntUnsafe(src, i));
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+static int ArrowTypeIsUnsignedInteger(enum ArrowType type) {
+  switch (type) {
     case NANOARROW_TYPE_UINT8:
     case NANOARROW_TYPE_UINT16:
     case NANOARROW_TYPE_UINT32:
     case NANOARROW_TYPE_UINT64:
-      return ArrowArrayAppendUInt(dst, ArrowArrayViewGetUIntUnsafe(src, i));
-    case NANOARROW_TYPE_HALF_FLOAT:
-    case NANOARROW_TYPE_FLOAT:
-    case NANOARROW_TYPE_DOUBLE:
-      return ArrowArrayAppendDouble(dst, ArrowArrayViewGetDoubleUnsafe(src, i));
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+static int ArrowTypeIsFloatingPoint(enum ArrowType type) {
+  return type == NANOARROW_TYPE_HALF_FLOAT || type == NANOARROW_TYPE_FLOAT ||
+         type == NANOARROW_TYPE_DOUBLE;
+}
+
+static int ArrowTypeIsBinaryLike(enum ArrowType type) {
+  switch (type) {
     case NANOARROW_TYPE_STRING:
     case NANOARROW_TYPE_BINARY:
     case NANOARROW_TYPE_FIXED_SIZE_BINARY:
@@ -116,14 +122,172 @@ static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
     case NANOARROW_TYPE_LARGE_BINARY:
     case NANOARROW_TYPE_BINARY_VIEW:
     case NANOARROW_TYPE_STRING_VIEW:
-      return ArrowArrayAppendBytes(dst, ArrowArrayViewGetBytesUnsafe(src, i));
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+static int ArrowTypeIsListLike(enum ArrowType type) {
+  switch (type) {
+    case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_MAP:
+    case NANOARROW_TYPE_LIST_VIEW:
+    case NANOARROW_TYPE_LARGE_LIST_VIEW:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+static int ArrowArrayCanAppendStorageType(enum ArrowType dst_type,
+                                          enum ArrowType src_type) {
+  if (src_type == NANOARROW_TYPE_NA) {
+    return 1;
+  }
+
+  if (ArrowTypeIsSignedInteger(src_type) || ArrowTypeIsUnsignedInteger(src_type)) {
+    return ArrowTypeIsSignedInteger(dst_type) || ArrowTypeIsUnsignedInteger(dst_type) ||
+           ArrowTypeIsFloatingPoint(dst_type);
+  }
+
+  if (ArrowTypeIsFloatingPoint(src_type)) {
+    return ArrowTypeIsFloatingPoint(dst_type);
+  }
+
+  if (ArrowTypeIsBinaryLike(src_type)) {
+    return ArrowTypeIsBinaryLike(dst_type);
+  }
+
+  if (ArrowTypeIsListLike(src_type)) {
+    return ArrowTypeIsListLike(dst_type);
+  }
+
+  return dst_type == src_type;
+}
+
+static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
+  if (!ArrowArrayIsInternal(dst)) {
+    ArrowErrorSet(error, "Expected destination to be an internal ArrowArray");
+    return EINVAL;
+  }
+
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)dst->private_data;
+  enum ArrowType dst_type = private_data->storage_type;
+  if (!ArrowArrayCanAppendStorageType(dst_type, src->storage_type)) {
+    ArrowErrorSet(error, "Can't append %s storage to an array with %s storage",
+                  ArrowTypeString(src->storage_type), ArrowTypeString(dst_type));
+    return EINVAL;
+  }
+
+  if ((src->dictionary == NULL) != (dst->dictionary == NULL)) {
+    ArrowErrorSet(error,
+                  "Can't append storage when exactly one of source and destination "
+                  "is dictionary-encoded");
+    return EINVAL;
+  }
+
+  if (src->storage_type == NANOARROW_TYPE_NA) {
+    return NANOARROW_OK;
+  }
+
+  if (src->n_children != dst->n_children) {
+    ArrowErrorSet(error,
+                  "Expected source and destination to have the same number of "
+                  "children but found %" PRId64 " and %" PRId64,
+                  src->n_children, dst->n_children);
+    return EINVAL;
+  }
+
+  if (src->storage_type == NANOARROW_TYPE_FIXED_SIZE_LIST &&
+      src->layout.child_size_elements != private_data->layout.child_size_elements) {
+    ArrowErrorSet(error,
+                  "Expected source and destination fixed-size list child sizes to "
+                  "match but found %" PRId64 " and %" PRId64,
+                  src->layout.child_size_elements,
+                  private_data->layout.child_size_elements);
+    return EINVAL;
+  }
+
+  if (src->storage_type == NANOARROW_TYPE_FIXED_SIZE_BINARY &&
+      src->layout.element_size_bits[1] != private_data->layout.element_size_bits[1]) {
+    ArrowErrorSet(error,
+                  "Expected source and destination fixed-size binary widths to "
+                  "match but found %" PRId64 " and %" PRId64 " bits",
+                  src->layout.element_size_bits[1],
+                  private_data->layout.element_size_bits[1]);
+    return EINVAL;
+  }
+
+  for (int64_t i = 0; i < src->n_children; i++) {
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayCheckCanAppendStorageFromArrayView(
+                                           dst->children[i], src->children[i], error),
+                                       error);
+  }
+
+  return NANOARROW_OK;
+}
+
+static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, int64_t i,
+    struct ArrowError* error) {
+  if (ArrowArrayViewIsNull(src, i)) {
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendNull(dst, 1), error);
+    return NANOARROW_OK;
+  }
+
+  switch (src->storage_type) {
+    case NANOARROW_TYPE_NA:
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendNull(dst, 1), error);
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_BOOL:
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_INT16:
+    case NANOARROW_TYPE_INT32:
+    case NANOARROW_TYPE_INT64:
+    case NANOARROW_TYPE_DATE32:
+    case NANOARROW_TYPE_DATE64:
+    case NANOARROW_TYPE_TIMESTAMP:
+    case NANOARROW_TYPE_TIME32:
+    case NANOARROW_TYPE_TIME64:
+    case NANOARROW_TYPE_DURATION:
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendInt(dst, ArrowArrayViewGetIntUnsafe(src, i)), error);
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_UINT8:
+    case NANOARROW_TYPE_UINT16:
+    case NANOARROW_TYPE_UINT32:
+    case NANOARROW_TYPE_UINT64:
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendUInt(dst, ArrowArrayViewGetUIntUnsafe(src, i)), error);
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_HALF_FLOAT:
+    case NANOARROW_TYPE_FLOAT:
+    case NANOARROW_TYPE_DOUBLE:
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendDouble(dst, ArrowArrayViewGetDoubleUnsafe(src, i)), error);
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_STRING:
+    case NANOARROW_TYPE_BINARY:
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+    case NANOARROW_TYPE_LARGE_STRING:
+    case NANOARROW_TYPE_LARGE_BINARY:
+    case NANOARROW_TYPE_BINARY_VIEW:
+    case NANOARROW_TYPE_STRING_VIEW:
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendBytes(dst, ArrowArrayViewGetBytesUnsafe(src, i)), error);
+      return NANOARROW_OK;
     case NANOARROW_TYPE_INTERVAL_MONTHS:
     case NANOARROW_TYPE_INTERVAL_DAY_TIME:
     case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO: {
       struct ArrowInterval interval;
       ArrowIntervalInit(&interval, src->storage_type);
       ArrowArrayViewGetIntervalUnsafe(src, i, &interval);
-      return ArrowArrayAppendInterval(dst, &interval);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendInterval(dst, &interval), error);
+      return NANOARROW_OK;
     }
     case NANOARROW_TYPE_DECIMAL32:
     case NANOARROW_TYPE_DECIMAL64:
@@ -141,14 +305,18 @@ static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
       struct ArrowDecimal decimal;
       ArrowDecimalInit(&decimal, bitwidth, /*precision=*/0, /*scale=*/0);
       ArrowArrayViewGetDecimalUnsafe(src, i, &decimal);
-      return ArrowArrayAppendDecimal(dst, &decimal);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayAppendDecimal(dst, &decimal), error);
+      return NANOARROW_OK;
     }
     case NANOARROW_TYPE_STRUCT:
       for (int64_t child_i = 0; child_i < src->n_children; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
-            dst->children[child_i], src->children[child_i], src->offset + i, error));
+        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+            ArrowArrayAppendStorageFromArrayViewElement(
+                dst->children[child_i], src->children[child_i], src->offset + i, error),
+            error);
       }
-      return ArrowArrayFinishElement(dst);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
+      return NANOARROW_OK;
     case NANOARROW_TYPE_LIST:
     case NANOARROW_TYPE_LARGE_LIST:
     case NANOARROW_TYPE_MAP:
@@ -166,36 +334,54 @@ static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
       }
 
       for (int64_t child_i = 0; child_i < child_length; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
-            dst->children[0], src->children[0], child_offset + child_i, error));
+        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+            ArrowArrayAppendStorageFromArrayViewElement(
+                dst->children[0], src->children[0], child_offset + child_i, error),
+            error);
       }
-      return ArrowArrayFinishElement(dst);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
+      return NANOARROW_OK;
     }
     case NANOARROW_TYPE_FIXED_SIZE_LIST: {
       int64_t child_offset = (src->offset + i) * src->layout.child_size_elements;
       for (int64_t child_i = 0; child_i < src->layout.child_size_elements; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
-            dst->children[0], src->children[0], child_offset + child_i, error));
+        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+            ArrowArrayAppendStorageFromArrayViewElement(
+                dst->children[0], src->children[0], child_offset + child_i, error),
+            error);
       }
-      return ArrowArrayFinishElement(dst);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
+      return NANOARROW_OK;
     }
     case NANOARROW_TYPE_DENSE_UNION:
     case NANOARROW_TYPE_SPARSE_UNION: {
       int8_t type_id = ArrowArrayViewUnionTypeId(src, i);
       int8_t child_index = ArrowArrayViewUnionChildIndex(src, i);
       int64_t child_offset = ArrowArrayViewUnionChildOffset(src, i);
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
-          dst->children[child_index], src->children[child_index], child_offset, error));
-      NANOARROW_RETURN_NOT_OK(
-          ArrowBufferAppend(ArrowArrayBuffer(dst, 0), &type_id, sizeof(type_id)));
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendStorageFromArrayViewElement(dst->children[child_index],
+                                                      src->children[child_index],
+                                                      child_offset, error),
+          error);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowBufferAppend(ArrowArrayBuffer(dst, 0), &type_id, sizeof(type_id)), error);
       if (src->storage_type == NANOARROW_TYPE_DENSE_UNION) {
-        _NANOARROW_CHECK_RANGE(dst->children[child_index]->length - 1, 0, INT32_MAX);
-        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt32(
-            ArrowArrayBuffer(dst, 1), (int32_t)dst->children[child_index]->length - 1));
+        int64_t dst_child_offset = dst->children[child_index]->length - 1;
+        if (dst_child_offset < 0 || dst_child_offset > INT32_MAX) {
+          ArrowErrorSet(error,
+                        "Expected dense union child offset to fit in int32 but "
+                        "found %" PRId64,
+                        dst_child_offset);
+          return EOVERFLOW;
+        }
+        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+            ArrowBufferAppendInt32(ArrowArrayBuffer(dst, 1), (int32_t)dst_child_offset),
+            error);
       } else {
         for (int64_t child_i = 0; child_i < dst->n_children; child_i++) {
           if (child_i != child_index && dst->children[child_i]->length == dst->length) {
-            NANOARROW_RETURN_NOT_OK(ArrowArrayAppendEmpty(dst->children[child_i], 1));
+            NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+                ArrowArrayAppendEmpty(dst->children[child_i], 1), error);
           }
           if (dst->children[child_i]->length != dst->length + 1) {
             ArrowErrorSet(error,
@@ -218,29 +404,77 @@ static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
   }
 }
 
-ArrowErrorCode ArrowArrayAppendArrayView(struct ArrowArray* dst,
-                                         const struct ArrowArrayView* src,
-                                         struct ArrowError* error) {
+static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
+                                        int64_t logical_offset) {
+  if (run_ends->length <= 1) {
+    return 0;
+  }
+
+  switch (run_ends->storage_type) {
+    case NANOARROW_TYPE_INT32:
+      return ArrowResolveChunk32(
+          (int32_t)(logical_offset + 1),
+          run_ends->buffer_views[1].data.as_int32 + run_ends->offset, 0,
+          (int32_t)run_ends->length);
+    case NANOARROW_TYPE_INT64:
+      return ArrowResolveChunk64(
+          logical_offset + 1, run_ends->buffer_views[1].data.as_int64 + run_ends->offset,
+          0, run_ends->length);
+    case NANOARROW_TYPE_INT16:
+    default: {
+      int64_t run = 0;
+      while (run + 1 < run_ends->length &&
+             ArrowArrayViewGetIntUnsafe(run_ends, run) <= logical_offset) {
+        run++;
+      }
+      return run;
+    }
+  }
+}
+
+ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
+                                                    const struct ArrowArrayView* src,
+                                                    struct ArrowError* error) {
+  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+      ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error), error);
+
   if (src->storage_type == NANOARROW_TYPE_RUN_END_ENCODED) {
-    if (src->offset != 0) {
-      ArrowErrorSet(error, "Can't append a sliced run-end encoded array view");
-      return ENOTSUP;
+    if (src->length == 0) {
+      return NANOARROW_OK;
     }
 
+    const struct ArrowArrayView* run_ends = src->children[0];
+    if (run_ends->length == 0) {
+      ArrowErrorSet(error,
+                    "Expected a non-empty run ends array for a non-empty "
+                    "run-end encoded array");
+      return EINVAL;
+    }
+
+    int64_t first_run = ArrowArrayViewResolveRun(run_ends, src->offset);
+    int64_t slice_end = src->offset + src->length;
     int64_t run_end_offset = dst->length;
-    for (int64_t i = 0; i < src->children[0]->length; i++) {
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(
-          dst->children[0],
-          run_end_offset + ArrowArrayViewGetIntUnsafe(src->children[0], i)));
-      NANOARROW_RETURN_NOT_OK(
-          ArrowArrayAppendArrayViewElement(dst->children[1], src->children[1], i, error));
+    for (int64_t i = first_run; i < run_ends->length; i++) {
+      int64_t src_run_end = ArrowArrayViewGetIntUnsafe(run_ends, i);
+      int64_t clipped_run_end = src_run_end < slice_end ? src_run_end : slice_end;
+      int64_t dst_run_end = run_end_offset + clipped_run_end - src->offset;
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendInt(dst->children[0], dst_run_end), error);
+      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+          ArrowArrayAppendStorageFromArrayViewElement(dst->children[1], src->children[1],
+                                                      i, error),
+          error);
+      if (src_run_end >= slice_end) {
+        break;
+      }
     }
     dst->length += src->length;
     return NANOARROW_OK;
   }
 
   for (int64_t i = 0; i < src->length; i++) {
-    NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(dst, src, i, error));
+    NANOARROW_RETURN_NOT_OK_WITH_ERROR(
+        ArrowArrayAppendStorageFromArrayViewElement(dst, src, i, error), error);
   }
   return NANOARROW_OK;
 }

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -77,6 +77,174 @@ int ArrowArrayIsInternal(struct ArrowArray* array) {
   return array->release == &ArrowArrayReleaseInternal;
 }
 
+static ArrowErrorCode ArrowArrayAppendArrayViewElement(struct ArrowArray* dst,
+                                                       const struct ArrowArrayView* src,
+                                                       int64_t i,
+                                                       struct ArrowError* error) {
+  if (ArrowArrayViewIsNull(src, i)) {
+    return ArrowArrayAppendNull(dst, 1);
+  }
+
+  switch (src->storage_type) {
+    case NANOARROW_TYPE_NA:
+      return ArrowArrayAppendNull(dst, 1);
+    case NANOARROW_TYPE_BOOL:
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_INT16:
+    case NANOARROW_TYPE_INT32:
+    case NANOARROW_TYPE_INT64:
+    case NANOARROW_TYPE_DATE32:
+    case NANOARROW_TYPE_DATE64:
+    case NANOARROW_TYPE_TIMESTAMP:
+    case NANOARROW_TYPE_TIME32:
+    case NANOARROW_TYPE_TIME64:
+    case NANOARROW_TYPE_DURATION:
+      return ArrowArrayAppendInt(dst, ArrowArrayViewGetIntUnsafe(src, i));
+    case NANOARROW_TYPE_UINT8:
+    case NANOARROW_TYPE_UINT16:
+    case NANOARROW_TYPE_UINT32:
+    case NANOARROW_TYPE_UINT64:
+      return ArrowArrayAppendUInt(dst, ArrowArrayViewGetUIntUnsafe(src, i));
+    case NANOARROW_TYPE_HALF_FLOAT:
+    case NANOARROW_TYPE_FLOAT:
+    case NANOARROW_TYPE_DOUBLE:
+      return ArrowArrayAppendDouble(dst, ArrowArrayViewGetDoubleUnsafe(src, i));
+    case NANOARROW_TYPE_STRING:
+    case NANOARROW_TYPE_BINARY:
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+    case NANOARROW_TYPE_LARGE_STRING:
+    case NANOARROW_TYPE_LARGE_BINARY:
+    case NANOARROW_TYPE_BINARY_VIEW:
+    case NANOARROW_TYPE_STRING_VIEW:
+      return ArrowArrayAppendBytes(dst, ArrowArrayViewGetBytesUnsafe(src, i));
+    case NANOARROW_TYPE_INTERVAL_MONTHS:
+    case NANOARROW_TYPE_INTERVAL_DAY_TIME:
+    case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO: {
+      struct ArrowInterval interval;
+      ArrowIntervalInit(&interval, src->storage_type);
+      ArrowArrayViewGetIntervalUnsafe(src, i, &interval);
+      return ArrowArrayAppendInterval(dst, &interval);
+    }
+    case NANOARROW_TYPE_DECIMAL32:
+    case NANOARROW_TYPE_DECIMAL64:
+    case NANOARROW_TYPE_DECIMAL128:
+    case NANOARROW_TYPE_DECIMAL256: {
+      int32_t bitwidth = 32;
+      if (src->storage_type == NANOARROW_TYPE_DECIMAL64) {
+        bitwidth = 64;
+      } else if (src->storage_type == NANOARROW_TYPE_DECIMAL128) {
+        bitwidth = 128;
+      } else if (src->storage_type == NANOARROW_TYPE_DECIMAL256) {
+        bitwidth = 256;
+      }
+
+      struct ArrowDecimal decimal;
+      ArrowDecimalInit(&decimal, bitwidth, /*precision=*/0, /*scale=*/0);
+      ArrowArrayViewGetDecimalUnsafe(src, i, &decimal);
+      return ArrowArrayAppendDecimal(dst, &decimal);
+    }
+    case NANOARROW_TYPE_STRUCT:
+      for (int64_t child_i = 0; child_i < src->n_children; child_i++) {
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
+            dst->children[child_i], src->children[child_i], src->offset + i, error));
+      }
+      return ArrowArrayFinishElement(dst);
+    case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_MAP:
+    case NANOARROW_TYPE_LIST_VIEW:
+    case NANOARROW_TYPE_LARGE_LIST_VIEW: {
+      int64_t logical_i = src->offset + i;
+      int64_t child_offset = ArrowArrayViewListChildOffset(src, logical_i);
+      int64_t child_length;
+      if (src->storage_type == NANOARROW_TYPE_LIST_VIEW) {
+        child_length = src->buffer_views[2].data.as_int32[logical_i];
+      } else if (src->storage_type == NANOARROW_TYPE_LARGE_LIST_VIEW) {
+        child_length = src->buffer_views[2].data.as_int64[logical_i];
+      } else {
+        child_length = ArrowArrayViewListChildOffset(src, logical_i + 1) - child_offset;
+      }
+
+      for (int64_t child_i = 0; child_i < child_length; child_i++) {
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
+            dst->children[0], src->children[0], child_offset + child_i, error));
+      }
+      return ArrowArrayFinishElement(dst);
+    }
+    case NANOARROW_TYPE_FIXED_SIZE_LIST: {
+      int64_t child_offset = (src->offset + i) * src->layout.child_size_elements;
+      for (int64_t child_i = 0; child_i < src->layout.child_size_elements; child_i++) {
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
+            dst->children[0], src->children[0], child_offset + child_i, error));
+      }
+      return ArrowArrayFinishElement(dst);
+    }
+    case NANOARROW_TYPE_DENSE_UNION:
+    case NANOARROW_TYPE_SPARSE_UNION: {
+      int8_t type_id = ArrowArrayViewUnionTypeId(src, i);
+      int8_t child_index = ArrowArrayViewUnionChildIndex(src, i);
+      int64_t child_offset = ArrowArrayViewUnionChildOffset(src, i);
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(
+          dst->children[child_index], src->children[child_index], child_offset, error));
+      NANOARROW_RETURN_NOT_OK(
+          ArrowBufferAppend(ArrowArrayBuffer(dst, 0), &type_id, sizeof(type_id)));
+      if (src->storage_type == NANOARROW_TYPE_DENSE_UNION) {
+        _NANOARROW_CHECK_RANGE(dst->children[child_index]->length - 1, 0, INT32_MAX);
+        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt32(
+            ArrowArrayBuffer(dst, 1), (int32_t)dst->children[child_index]->length - 1));
+      } else {
+        for (int64_t child_i = 0; child_i < dst->n_children; child_i++) {
+          if (child_i != child_index && dst->children[child_i]->length == dst->length) {
+            NANOARROW_RETURN_NOT_OK(ArrowArrayAppendEmpty(dst->children[child_i], 1));
+          }
+          if (dst->children[child_i]->length != dst->length + 1) {
+            ArrowErrorSet(error,
+                          "Expected sparse union child length of %" PRId64
+                          " but found %" PRId64,
+                          dst->length + 1, dst->children[child_i]->length);
+            return EINVAL;
+          }
+        }
+      }
+      dst->length++;
+      return NANOARROW_OK;
+    }
+    case NANOARROW_TYPE_RUN_END_ENCODED:
+    case NANOARROW_TYPE_UNINITIALIZED:
+    default:
+      ArrowErrorSet(error, "Appending array views is not supported for %s",
+                    ArrowTypeString(src->storage_type));
+      return ENOTSUP;
+  }
+}
+
+ArrowErrorCode ArrowArrayAppendArrayView(struct ArrowArray* dst,
+                                         const struct ArrowArrayView* src,
+                                         struct ArrowError* error) {
+  if (src->storage_type == NANOARROW_TYPE_RUN_END_ENCODED) {
+    if (src->offset != 0) {
+      ArrowErrorSet(error, "Can't append a sliced run-end encoded array view");
+      return ENOTSUP;
+    }
+
+    int64_t run_end_offset = dst->length;
+    for (int64_t i = 0; i < src->children[0]->length; i++) {
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendInt(
+          dst->children[0],
+          run_end_offset + ArrowArrayViewGetIntUnsafe(src->children[0], i)));
+      NANOARROW_RETURN_NOT_OK(
+          ArrowArrayAppendArrayViewElement(dst->children[1], src->children[1], i, error));
+    }
+    dst->length += src->length;
+    return NANOARROW_OK;
+  }
+
+  for (int64_t i = 0; i < src->length; i++) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayViewElement(dst, src, i, error));
+  }
+  return NANOARROW_OK;
+}
+
 static ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,
                                                enum ArrowType storage_type) {
   switch (storage_type) {

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -231,9 +231,8 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   }
 
   for (int64_t i = 0; i < src->n_children; i++) {
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayCheckCanAppendStorageFromArrayView(
-                                           dst->children[i], src->children[i], error),
-                                       error);
+    NANOARROW_RETURN_NOT_OK(ArrowArrayCheckCanAppendStorageFromArrayView(
+        dst->children[i], src->children[i], error));
   }
 
   return NANOARROW_OK;
@@ -318,10 +317,8 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
     }
     case NANOARROW_TYPE_STRUCT:
       for (int64_t child_i = 0; child_i < src->n_children; child_i++) {
-        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-            ArrowArrayAppendStorageFromArrayViewElement(
-                dst->children[child_i], src->children[child_i], src->offset + i, error),
-            error);
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
+            dst->children[child_i], src->children[child_i], src->offset + i, error));
       }
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
@@ -342,10 +339,8 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
       }
 
       for (int64_t child_i = 0; child_i < child_length; child_i++) {
-        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-            ArrowArrayAppendStorageFromArrayViewElement(
-                dst->children[0], src->children[0], child_offset + child_i, error),
-            error);
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
+            dst->children[0], src->children[0], child_offset + child_i, error));
       }
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
@@ -353,10 +348,8 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
     case NANOARROW_TYPE_FIXED_SIZE_LIST: {
       int64_t child_offset = (src->offset + i) * src->layout.child_size_elements;
       for (int64_t child_i = 0; child_i < src->layout.child_size_elements; child_i++) {
-        NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-            ArrowArrayAppendStorageFromArrayViewElement(
-                dst->children[0], src->children[0], child_offset + child_i, error),
-            error);
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
+            dst->children[0], src->children[0], child_offset + child_i, error));
       }
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
@@ -366,11 +359,8 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
       int8_t type_id = ArrowArrayViewUnionTypeId(src, i);
       int8_t child_index = ArrowArrayViewUnionChildIndex(src, i);
       int64_t child_offset = ArrowArrayViewUnionChildOffset(src, i);
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          ArrowArrayAppendStorageFromArrayViewElement(dst->children[child_index],
-                                                      src->children[child_index],
-                                                      child_offset, error),
-          error);
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
+          dst->children[child_index], src->children[child_index], child_offset, error));
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowBufferAppend(ArrowArrayBuffer(dst, 0), &type_id, sizeof(type_id)), error);
       if (src->storage_type == NANOARROW_TYPE_DENSE_UNION) {
@@ -484,8 +474,7 @@ static ArrowErrorCode ArrowArrayAppendFixedWidthStorageFromArrayView(
     return EINVAL;
   }
 
-  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-      ArrowArrayAppendValidityFromArrayView(dst, src, error), error);
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendValidityFromArrayView(dst, src, error));
 
   NANOARROW_RETURN_NOT_OK_WITH_ERROR(
       ArrowBufferAppend(ArrowArrayBuffer(dst, 1),
@@ -532,8 +521,7 @@ static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
 ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
                                                     const struct ArrowArrayView* src,
                                                     struct ArrowError* error) {
-  NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-      ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error), error);
+  NANOARROW_RETURN_NOT_OK(ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error));
 
   if (ArrowArrayCanAppendFixedWidthStorage(dst, src)) {
     return ArrowArrayAppendFixedWidthStorageFromArrayView(dst, src, error);
@@ -561,10 +549,8 @@ ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
       int64_t dst_run_end = run_end_offset + clipped_run_end - src->offset;
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowArrayAppendInt(dst->children[0], dst_run_end), error);
-      NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-          ArrowArrayAppendStorageFromArrayViewElement(dst->children[1], src->children[1],
-                                                      i, error),
-          error);
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
+          dst->children[1], src->children[1], i, error));
       if (src_run_end >= slice_end) {
         break;
       }
@@ -574,8 +560,8 @@ ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
   }
 
   for (int64_t i = 0; i < src->length; i++) {
-    NANOARROW_RETURN_NOT_OK_WITH_ERROR(
-        ArrowArrayAppendStorageFromArrayViewElement(dst, src, i, error), error);
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayAppendStorageFromArrayViewElement(dst, src, i, error));
   }
   return NANOARROW_OK;
 }

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -135,6 +135,7 @@ static int ArrowTypeIsListLike(enum ArrowType type) {
     case NANOARROW_TYPE_MAP:
     case NANOARROW_TYPE_LIST_VIEW:
     case NANOARROW_TYPE_LARGE_LIST_VIEW:
+    case NANOARROW_TYPE_FIXED_SIZE_LIST:
       return 1;
     default:
       return 0;
@@ -211,6 +212,7 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   }
 
   if (src->storage_type == NANOARROW_TYPE_FIXED_SIZE_LIST &&
+      dst_type == NANOARROW_TYPE_FIXED_SIZE_LIST &&
       src->layout.child_size_elements != private_data->layout.child_size_elements) {
     ArrowErrorSet(error,
                   "Expected source and destination fixed-size list child sizes to "
@@ -221,6 +223,7 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   }
 
   if (src->storage_type == NANOARROW_TYPE_FIXED_SIZE_BINARY &&
+      dst_type == NANOARROW_TYPE_FIXED_SIZE_BINARY &&
       src->layout.element_size_bits[1] != private_data->layout.element_size_bits[1]) {
     ArrowErrorSet(error,
                   "Expected source and destination fixed-size binary widths to "

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -187,6 +187,14 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
       (struct ArrowArrayPrivateData*)dst->private_data;
   enum ArrowType dst_type = private_data->storage_type;
 
+  if (src->storage_type == NANOARROW_TYPE_NA &&
+      dst_type == NANOARROW_TYPE_RUN_END_ENCODED) {
+    ArrowErrorSet(error,
+                  "Can't append null storage to an array with run-end encoded "
+                  "storage");
+    return EINVAL;
+  }
+
   if (src->storage_type == NANOARROW_TYPE_DENSE_UNION ||
       src->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
     ArrowErrorSet(error, "Appending array views is not supported for %s",
@@ -249,6 +257,10 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   return NANOARROW_OK;
 }
 
+static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewRange(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, int64_t offset,
+    int64_t length, struct ArrowError* error);
+
 static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
     struct ArrowArray* dst, const struct ArrowArrayView* src, int64_t i,
     struct ArrowError* error) {
@@ -309,8 +321,8 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
     }
     case NANOARROW_TYPE_STRUCT:
       for (int64_t child_i = 0; child_i < src->n_children; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
-            dst->children[child_i], src->children[child_i], src->offset + i, error));
+        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewRange(
+            dst->children[child_i], src->children[child_i], src->offset + i, 1, error));
       }
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
@@ -330,19 +342,16 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewElement(
         child_length = ArrowArrayViewListChildOffset(src, logical_i + 1) - child_offset;
       }
 
-      for (int64_t child_i = 0; child_i < child_length; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
-            dst->children[0], src->children[0], child_offset + child_i, error));
-      }
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewRange(
+          dst->children[0], src->children[0], child_offset, child_length, error));
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
     }
     case NANOARROW_TYPE_FIXED_SIZE_LIST: {
       int64_t child_offset = (src->offset + i) * src->layout.child_size_elements;
-      for (int64_t child_i = 0; child_i < src->layout.child_size_elements; child_i++) {
-        NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
-            dst->children[0], src->children[0], child_offset + child_i, error));
-      }
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewRange(
+          dst->children[0], src->children[0], child_offset,
+          src->layout.child_size_elements, error));
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(ArrowArrayFinishElement(dst), error);
       return NANOARROW_OK;
     }
@@ -478,9 +487,22 @@ static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
   }
 }
 
-ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
-                                                    const struct ArrowArrayView* src,
-                                                    struct ArrowError* error) {
+static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewRange(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, int64_t offset,
+    int64_t length, struct ArrowError* error) {
+  struct ArrowArrayView src_slice = *src;
+  if (offset < 0 || src->offset < 0 || offset > INT64_MAX - src->offset) {
+    ArrowErrorSet(error,
+                  "Expected source offset and range offset to describe a valid "
+                  "int64 offset but found %" PRId64 " and %" PRId64,
+                  src->offset, offset);
+    return EINVAL;
+  }
+
+  src_slice.offset = src->offset + offset;
+  src_slice.length = length;
+  src = &src_slice;
+
   NANOARROW_RETURN_NOT_OK(ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error));
 
   if (ArrowArrayCanAppendFixedWidthStorage(dst, src)) {
@@ -509,8 +531,8 @@ ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
       int64_t dst_run_end = run_end_offset + clipped_run_end - src->offset;
       NANOARROW_RETURN_NOT_OK_WITH_ERROR(
           ArrowArrayAppendInt(dst->children[0], dst_run_end), error);
-      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewElement(
-          dst->children[1], src->children[1], i, error));
+      NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewRange(
+          dst->children[1], src->children[1], i, 1, error));
       if (src_run_end >= slice_end) {
         break;
       }
@@ -524,6 +546,12 @@ ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
         ArrowArrayAppendStorageFromArrayViewElement(dst, src, i, error));
   }
   return NANOARROW_OK;
+}
+
+ArrowErrorCode ArrowArrayAppendStorageFromArrayView(struct ArrowArray* dst,
+                                                    const struct ArrowArrayView* src,
+                                                    struct ArrowError* error) {
+  return ArrowArrayAppendStorageFromArrayViewRange(dst, src, 0, src->length, error);
 }
 
 static ArrowErrorCode ArrowArraySetStorageType(struct ArrowArray* array,

--- a/src/nanoarrow/common/array.c
+++ b/src/nanoarrow/common/array.c
@@ -168,6 +168,49 @@ static int ArrowArrayCanAppendStorageType(enum ArrowType dst_type,
   return dst_type == src_type;
 }
 
+static int ArrowArrayAppendNullMayReachRunEndEncoded(struct ArrowArray* dst) {
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)dst->private_data;
+
+  switch (private_data->storage_type) {
+    case NANOARROW_TYPE_RUN_END_ENCODED:
+      return 1;
+    case NANOARROW_TYPE_FIXED_SIZE_LIST:
+      return private_data->layout.child_size_elements > 0 &&
+             ArrowArrayAppendNullMayReachRunEndEncoded(dst->children[0]);
+    case NANOARROW_TYPE_STRUCT:
+    case NANOARROW_TYPE_SPARSE_UNION:
+      for (int64_t i = 0; i < dst->n_children; i++) {
+        if (ArrowArrayAppendNullMayReachRunEndEncoded(dst->children[i])) {
+          return 1;
+        }
+      }
+      return 0;
+    case NANOARROW_TYPE_DENSE_UNION:
+      return ArrowArrayAppendNullMayReachRunEndEncoded(dst->children[0]);
+    default:
+      return 0;
+  }
+}
+
+static int ArrowArrayViewHasNulls(const struct ArrowArrayView* src) {
+  if (src->length == 0) {
+    return 0;
+  }
+
+  if (src->storage_type == NANOARROW_TYPE_NA) {
+    return 1;
+  }
+
+  if (src->layout.buffer_type[0] != NANOARROW_BUFFER_TYPE_VALIDITY) {
+    return 0;
+  }
+
+  const uint8_t* validity = src->buffer_views[0].data.as_uint8;
+  return validity != NULL &&
+         ArrowBitCountSet(validity, src->offset, src->length) != src->length;
+}
+
 static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
     struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
   if (src->offset < 0 || src->length < 0 || src->offset > INT64_MAX - src->length) {
@@ -186,14 +229,6 @@ static ArrowErrorCode ArrowArrayCheckCanAppendStorageFromArrayView(
   struct ArrowArrayPrivateData* private_data =
       (struct ArrowArrayPrivateData*)dst->private_data;
   enum ArrowType dst_type = private_data->storage_type;
-
-  if (src->storage_type == NANOARROW_TYPE_NA &&
-      dst_type == NANOARROW_TYPE_RUN_END_ENCODED) {
-    ArrowErrorSet(error,
-                  "Can't append null storage to an array with run-end encoded "
-                  "storage");
-    return EINVAL;
-  }
 
   if (src->storage_type == NANOARROW_TYPE_DENSE_UNION ||
       src->storage_type == NANOARROW_TYPE_SPARSE_UNION) {
@@ -381,6 +416,14 @@ static int ArrowArrayCanAppendFixedWidthStorage(struct ArrowArray* dst,
          src->layout.element_size_bits[1] % 8 == 0;
 }
 
+static int ArrowArrayCanAppendStructStorage(struct ArrowArray* dst,
+                                            const struct ArrowArrayView* src) {
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)dst->private_data;
+  return private_data->storage_type == NANOARROW_TYPE_STRUCT &&
+         src->storage_type == NANOARROW_TYPE_STRUCT;
+}
+
 static ArrowErrorCode ArrowArrayAppendValidityFromArrayView(
     struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
   struct ArrowBitmap* dst_validity = ArrowArrayValidityBitmap(dst);
@@ -459,6 +502,22 @@ static ArrowErrorCode ArrowArrayAppendFixedWidthStorageFromArrayView(
   return NANOARROW_OK;
 }
 
+static ArrowErrorCode ArrowArrayAppendStructStorageFromArrayView(
+    struct ArrowArray* dst, const struct ArrowArrayView* src, struct ArrowError* error) {
+  for (int64_t i = 0; i < src->n_children; i++) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayViewRange(
+        dst->children[i], src->children[i], src->offset, src->length, error));
+  }
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendValidityFromArrayView(dst, src, error));
+  if (src->buffer_views[0].data.as_uint8 != NULL) {
+    dst->null_count += src->length - ArrowBitCountSet(src->buffer_views[0].data.as_uint8,
+                                                      src->offset, src->length);
+  }
+  dst->length += src->length;
+  return NANOARROW_OK;
+}
+
 static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
                                         int64_t logical_offset) {
   if (run_ends->length <= 1) {
@@ -476,20 +535,20 @@ static int64_t ArrowArrayViewResolveRun(const struct ArrowArrayView* run_ends,
           logical_offset + 1, run_ends->buffer_views[1].data.as_int64 + run_ends->offset,
           0, run_ends->length);
     case NANOARROW_TYPE_INT16:
-    default: {
-      int64_t run = 0;
-      while (run + 1 < run_ends->length &&
-             ArrowArrayViewGetIntUnsafe(run_ends, run) <= logical_offset) {
-        run++;
-      }
-      return run;
-    }
+      return ArrowResolveChunk16(
+          (int16_t)(logical_offset + 1),
+          run_ends->buffer_views[1].data.as_int16 + run_ends->offset, 0,
+          (int16_t)run_ends->length);
+    default:
+      return 0;
   }
 }
 
 static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewRange(
     struct ArrowArray* dst, const struct ArrowArrayView* src, int64_t offset,
     int64_t length, struct ArrowError* error) {
+  // Note: src_slice must not be freed; it is a convenience to avoid repeatedly
+  // composing offset and length on top of src in internal calls.
   struct ArrowArrayView src_slice = *src;
   if (offset < 0 || src->offset < 0 || offset > INT64_MAX - src->offset) {
     ArrowErrorSet(error,
@@ -505,8 +564,26 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewRange(
 
   NANOARROW_RETURN_NOT_OK(ArrowArrayCheckCanAppendStorageFromArrayView(dst, src, error));
 
+  struct ArrowArrayPrivateData* private_data =
+      (struct ArrowArrayPrivateData*)dst->private_data;
+  // Exact struct-to-struct appends copy child storage in bulk, including storage
+  // beneath null parent slots. Other null appends use ArrowArrayAppendNull(), whose
+  // empty child values cannot represent run-end encoded storage.
+  if (!(src->storage_type == NANOARROW_TYPE_STRUCT &&
+        private_data->storage_type == NANOARROW_TYPE_STRUCT) &&
+      ArrowArrayAppendNullMayReachRunEndEncoded(dst) && ArrowArrayViewHasNulls(src)) {
+    ArrowErrorSet(error,
+                  "Can't append null storage to an array whose null representation "
+                  "requires appending to run-end encoded storage");
+    return EINVAL;
+  }
+
   if (ArrowArrayCanAppendFixedWidthStorage(dst, src)) {
     return ArrowArrayAppendFixedWidthStorageFromArrayView(dst, src, error);
+  }
+
+  if (ArrowArrayCanAppendStructStorage(dst, src)) {
+    return ArrowArrayAppendStructStorageFromArrayView(dst, src, error);
   }
 
   if (src->storage_type == NANOARROW_TYPE_RUN_END_ENCODED) {
@@ -520,6 +597,14 @@ static ArrowErrorCode ArrowArrayAppendStorageFromArrayViewRange(
                     "Expected a non-empty run ends array for a non-empty "
                     "run-end encoded array");
       return EINVAL;
+    }
+
+    if (dst->length > INT64_MAX - src->length) {
+      ArrowErrorSet(error,
+                    "Expected run-end encoded destination length plus source length "
+                    "to fit in int64 but found %" PRId64 " and %" PRId64,
+                    dst->length, src->length);
+      return EOVERFLOW;
     }
 
     int64_t first_run = ArrowArrayViewResolveRun(run_ends, src->offset);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5093,7 +5093,7 @@ static ArrowErrorCode AppendArrayViewForTest(const struct ArrowArrayView* src,
                                              struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromArrayView(dst, src, error));
   NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(dst));
-  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayView(dst, src, error));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayView(dst, src, error));
   return ArrowArrayFinishBuildingDefault(dst, error);
 }
 
@@ -5294,8 +5294,8 @@ TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
   struct ArrowArray dst;
   ASSERT_EQ(ArrowArrayInitFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
   EXPECT_EQ(dst.length, 6);
 
@@ -5307,8 +5307,11 @@ TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
 
   src_view.offset = 1;
   src_view.length = 1;
-  EXPECT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), ENOTSUP);
-  EXPECT_STREQ(error.message, "Can't append a sliced run-end encoded array view");
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
+      << error.message;
+  EXPECT_EQ(dst.length, 7);
+  EXPECT_EQ(dst.children[0]->length, 5);
+  EXPECT_EQ(dst.children[1]->length, 5);
 
   ArrowArrayViewReset(&dst_view);
   ArrowArrayRelease(&dst);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5087,3 +5087,232 @@ TEST(ArrayMoveSharedTest, ArrayWithNullBuffers) {
 
   ArrowArrayRelease(&shared);
 }
+
+static ArrowErrorCode AppendArrayViewForTest(const struct ArrowArrayView* src,
+                                             struct ArrowArray* dst,
+                                             struct ArrowError* error) {
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromArrayView(dst, src, error));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(dst));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayAppendArrayView(dst, src, error));
+  return ArrowArrayFinishBuildingDefault(dst, error);
+}
+
+static void ExpectPrimitiveArrayViewAppendIdentical(struct ArrowArray* src,
+                                                    enum ArrowType type) {
+  struct ArrowError error;
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, type);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, src, &error), NANOARROW_OK)
+      << error.message;
+
+  struct ArrowArray dst;
+  ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+  struct ArrowArrayView dst_view;
+  ArrowArrayViewInitFromType(&dst_view, type);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+
+  int identical = 0;
+  ASSERT_EQ(ArrowArrayViewCompare(&src_view, &dst_view, NANOARROW_COMPARE_IDENTICAL,
+                                  &identical, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(identical, 1) << error.message;
+
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+}
+
+TEST(ArrayTest, ArrayAppendArrayViewPrimitiveTypes) {
+  struct ArrowArray array;
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&array, -42), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_INT64);
+  ArrowArrayRelease(&array);
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_UINT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendUInt(&array, UINT64_MAX), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_UINT64);
+  ArrowArrayRelease(&array);
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_DOUBLE), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendDouble(&array, 1.25), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_DOUBLE);
+  ArrowArrayRelease(&array);
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(&array, "some value"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_STRING);
+  ArrowArrayRelease(&array);
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INTERVAL_MONTHS), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  struct ArrowInterval interval;
+  ArrowIntervalInit(&interval, NANOARROW_TYPE_INTERVAL_MONTHS);
+  interval.months = 42;
+  ASSERT_EQ(ArrowArrayAppendInterval(&array, &interval), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_INTERVAL_MONTHS);
+  ArrowArrayRelease(&array);
+
+  ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_DECIMAL128), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
+  struct ArrowDecimal decimal;
+  ArrowDecimalInit(&decimal, 128, 10, 2);
+  ArrowDecimalSetInt(&decimal, 1234);
+  ASSERT_EQ(ArrowArrayAppendDecimal(&array, &decimal), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
+  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_DECIMAL128);
+  ArrowArrayRelease(&array);
+}
+
+TEST(ArrayTest, ArrayAppendArrayViewNestedAndSliced) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema, 2), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_LIST), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0]->children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0]->children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0]->children[0], 2), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(src.children[0]), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "first"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(src.children[0]), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "third"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK) << error.message;
+
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+  src_view.offset = 1;
+  src_view.length = 2;
+  src_view.null_count = 1;
+
+  struct ArrowArray dst;
+  ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+  EXPECT_EQ(dst.length, 2);
+  EXPECT_EQ(dst.children[0]->length, 2);
+  EXPECT_EQ(dst.children[0]->children[0]->length, 0);
+  EXPECT_EQ(dst.children[1]->length, 2);
+
+  struct ArrowArrayView dst_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 0));
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(dst_view.children[1], 1), "third"_asv);
+
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}
+
+TEST(ArrayTest, ArrayAppendArrayViewUnions) {
+  for (enum ArrowType union_type :
+       {NANOARROW_TYPE_DENSE_UNION, NANOARROW_TYPE_SPARSE_UNION}) {
+    struct ArrowError error;
+    struct ArrowSchema schema;
+    ArrowSchemaInit(&schema);
+    ASSERT_EQ(ArrowSchemaSetTypeUnion(&schema, union_type, 2), NANOARROW_OK);
+    ASSERT_EQ(ArrowSchemaSetType(schema.children[0], NANOARROW_TYPE_INT32), NANOARROW_OK);
+    ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING),
+              NANOARROW_OK);
+
+    struct ArrowArray src;
+    ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 42), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayFinishUnionElement(&src, 0), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendString(src.children[1], "value"_asv), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayFinishUnionElement(&src, 1), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+
+    struct ArrowArrayView src_view;
+    ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+    struct ArrowArray dst;
+    ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+        << error.message;
+    EXPECT_EQ(dst.length, 2);
+
+    struct ArrowArrayView dst_view;
+    ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+    EXPECT_EQ(ArrowArrayViewUnionTypeId(&dst_view, 0), 0);
+    EXPECT_EQ(ArrowArrayViewUnionTypeId(&dst_view, 1), 1);
+
+    ArrowArrayViewReset(&dst_view);
+    ArrowArrayRelease(&dst);
+    ArrowArrayViewReset(&src_view);
+    ArrowArrayRelease(&src);
+    ArrowSchemaRelease(&schema);
+  }
+}
+
+TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 2), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 3), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "a"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "b"_asv), NANOARROW_OK);
+  src.length = 3;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
+  EXPECT_EQ(dst.length, 6);
+
+  struct ArrowArrayView dst_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 2), 5);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 3), 6);
+
+  src_view.offset = 1;
+  src_view.length = 1;
+  EXPECT_EQ(ArrowArrayAppendArrayView(&dst, &src_view, &error), ENOTSUP);
+  EXPECT_STREQ(error.message, "Can't append a sliced run-end encoded array view");
+
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -33,6 +33,7 @@
 #include <arrow/c/bridge.h>
 #include <arrow/compare.h>
 #include <arrow/config.h>
+#include <arrow/scalar.h>
 #include <arrow/util/decimal.h>
 
 #if defined(NANOARROW_BUILD_TESTS_WITH_ARROW) && defined(ARROW_VERSION_MAJOR) && \
@@ -5088,17 +5089,17 @@ TEST(ArrayMoveSharedTest, ArrayWithNullBuffers) {
   ArrowArrayRelease(&shared);
 }
 
-static ArrowErrorCode AppendArrayViewForTest(const struct ArrowArrayView* src,
-                                             struct ArrowArray* dst,
-                                             struct ArrowError* error) {
+static ArrowErrorCode AppendStorageFromArrayViewForTest(const struct ArrowArrayView* src,
+                                                        struct ArrowArray* dst,
+                                                        struct ArrowError* error) {
   NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromArrayView(dst, src, error));
   NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(dst));
   NANOARROW_RETURN_NOT_OK(ArrowArrayAppendStorageFromArrayView(dst, src, error));
   return ArrowArrayFinishBuildingDefault(dst, error);
 }
 
-static void ExpectPrimitiveArrayViewAppendIdentical(struct ArrowArray* src,
-                                                    enum ArrowType type) {
+static void ExpectPrimitiveStorageAppendIdentical(struct ArrowArray* src,
+                                                  enum ArrowType type) {
   struct ArrowError error;
   struct ArrowArrayView src_view;
   ArrowArrayViewInitFromType(&src_view, type);
@@ -5106,7 +5107,7 @@ static void ExpectPrimitiveArrayViewAppendIdentical(struct ArrowArray* src,
       << error.message;
 
   struct ArrowArray dst;
-  ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+  ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
       << error.message;
   struct ArrowArrayView dst_view;
   ArrowArrayViewInitFromType(&dst_view, type);
@@ -5124,7 +5125,7 @@ static void ExpectPrimitiveArrayViewAppendIdentical(struct ArrowArray* src,
   ArrowArrayViewReset(&src_view);
 }
 
-TEST(ArrayTest, ArrayAppendArrayViewPrimitiveTypes) {
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewPrimitiveTypes) {
   struct ArrowArray array;
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INT64), NANOARROW_OK);
@@ -5132,28 +5133,28 @@ TEST(ArrayTest, ArrayAppendArrayViewPrimitiveTypes) {
   ASSERT_EQ(ArrowArrayAppendInt(&array, -42), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendNull(&array, 1), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_INT64);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_INT64);
   ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_UINT64), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendUInt(&array, UINT64_MAX), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_UINT64);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_UINT64);
   ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_DOUBLE), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendDouble(&array, 1.25), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_DOUBLE);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_DOUBLE);
   ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_STRING), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayStartAppending(&array), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayAppendString(&array, "some value"_asv), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_STRING);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_STRING);
   ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_INTERVAL_MONTHS), NANOARROW_OK);
@@ -5163,7 +5164,7 @@ TEST(ArrayTest, ArrayAppendArrayViewPrimitiveTypes) {
   interval.months = 42;
   ASSERT_EQ(ArrowArrayAppendInterval(&array, &interval), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_INTERVAL_MONTHS);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_INTERVAL_MONTHS);
   ArrowArrayRelease(&array);
 
   ASSERT_EQ(ArrowArrayInitFromType(&array, NANOARROW_TYPE_DECIMAL128), NANOARROW_OK);
@@ -5173,11 +5174,11 @@ TEST(ArrayTest, ArrayAppendArrayViewPrimitiveTypes) {
   ArrowDecimalSetInt(&decimal, 1234);
   ASSERT_EQ(ArrowArrayAppendDecimal(&array, &decimal), NANOARROW_OK);
   ASSERT_EQ(ArrowArrayFinishBuildingDefault(&array, nullptr), NANOARROW_OK);
-  ExpectPrimitiveArrayViewAppendIdentical(&array, NANOARROW_TYPE_DECIMAL128);
+  ExpectPrimitiveStorageAppendIdentical(&array, NANOARROW_TYPE_DECIMAL128);
   ArrowArrayRelease(&array);
 }
 
-TEST(ArrayTest, ArrayAppendArrayViewNestedAndSliced) {
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewNestedAndSliced) {
   struct ArrowError error;
   struct ArrowSchema schema;
   ArrowSchemaInit(&schema);
@@ -5209,7 +5210,7 @@ TEST(ArrayTest, ArrayAppendArrayViewNestedAndSliced) {
   src_view.null_count = 1;
 
   struct ArrowArray dst;
-  ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+  ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
       << error.message;
   EXPECT_EQ(dst.length, 2);
   EXPECT_EQ(dst.children[0]->length, 2);
@@ -5229,7 +5230,7 @@ TEST(ArrayTest, ArrayAppendArrayViewNestedAndSliced) {
   ArrowSchemaRelease(&schema);
 }
 
-TEST(ArrayTest, ArrayAppendArrayViewUnions) {
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewUnions) {
   for (enum ArrowType union_type :
        {NANOARROW_TYPE_DENSE_UNION, NANOARROW_TYPE_SPARSE_UNION}) {
     struct ArrowError error;
@@ -5253,7 +5254,7 @@ TEST(ArrayTest, ArrayAppendArrayViewUnions) {
     ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
     ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
     struct ArrowArray dst;
-    ASSERT_EQ(AppendArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+    ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
         << error.message;
     EXPECT_EQ(dst.length, 2);
 
@@ -5271,7 +5272,7 @@ TEST(ArrayTest, ArrayAppendArrayViewUnions) {
   }
 }
 
-TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncoded) {
   struct ArrowError error;
   struct ArrowSchema schema;
   ArrowSchemaInit(&schema);
@@ -5304,14 +5305,20 @@ TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
   ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 2), 5);
   EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 3), 6);
+  ArrowArrayViewReset(&dst_view);
 
   src_view.offset = 1;
   src_view.length = 1;
   ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
       << error.message;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
   EXPECT_EQ(dst.length, 7);
   EXPECT_EQ(dst.children[0]->length, 5);
   EXPECT_EQ(dst.children[1]->length, 5);
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 4), 7);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(dst_view.children[1], 4), "a"_asv);
 
   ArrowArrayViewReset(&dst_view);
   ArrowArrayRelease(&dst);
@@ -5319,3 +5326,359 @@ TEST(ArrayTest, ArrayAppendArrayViewRunEndEncoded) {
   ArrowArrayRelease(&src);
   ArrowSchemaRelease(&schema);
 }
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedWidthSlicedValidity) {
+  struct ArrowError error;
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromType(&src, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, 3), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+  src_view.offset = 1;
+  src_view.length = 3;
+  src_view.null_count = 1;
+
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromType(&dst, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&dst, 10), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
+      << error.message;
+
+  struct ArrowArray all_valid;
+  ASSERT_EQ(ArrowArrayInitFromType(&all_valid, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&all_valid), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&all_valid, 4), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&all_valid, 5), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&all_valid, &error), NANOARROW_OK);
+  struct ArrowArrayView all_valid_view;
+  ArrowArrayViewInitFromType(&all_valid_view, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewSetArray(&all_valid_view, &all_valid, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &all_valid_view, &error),
+            NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
+
+  struct ArrowArrayView dst_view;
+  ArrowArrayViewInitFromType(&dst_view, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_EQ(dst.length, 9);
+  EXPECT_EQ(dst.null_count, 2);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 0), 10);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 1), 1);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 2));
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 3), 3);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 4), 4);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 5), 5);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 7));
+
+  struct ArrowArray dst_all_valid;
+  ASSERT_EQ(ArrowArrayInitFromType(&dst_all_valid, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst_all_valid), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst_all_valid, &all_valid_view, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(dst_all_valid.buffers[0], nullptr);
+
+  ArrowArrayRelease(&dst_all_valid);
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayViewReset(&all_valid_view);
+  ArrowArrayRelease(&all_valid);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewErrors) {
+  struct ArrowError error;
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromType(&src, NANOARROW_TYPE_INT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, INT8_MAX + 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, NANOARROW_TYPE_INT64);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromType(&dst, NANOARROW_TYPE_INT8), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EINVAL);
+  EXPECT_NE(error.message[0], '\0');
+  EXPECT_EQ(dst.length, 0);
+
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+
+  struct ArrowSchema list_schema;
+  ASSERT_EQ(ArrowSchemaInitFromType(&list_schema, NANOARROW_TYPE_LIST), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(list_schema.children[0], NANOARROW_TYPE_NA), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &list_schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(src.children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &list_schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &list_schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  dst.children[0]->length = INT32_MAX;
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EOVERFLOW);
+  EXPECT_NE(error.message[0], '\0');
+
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&list_schema);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewDictionary) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ASSERT_EQ(ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_INT8), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaAllocateDictionary(&schema), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.dictionary, NANOARROW_TYPE_STRING),
+            NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.dictionary, "a"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.dictionary, "b"_asv), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, 0), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(&src, 0), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  ASSERT_EQ(
+      ArrowArrayAppendStorageFromArrayView(dst.dictionary, src_view.dictionary, &error),
+      NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuilding(&dst, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK)
+      << error.message;
+
+  struct ArrowArrayView dst_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  int identical = 0;
+  ASSERT_EQ(ArrowArrayViewCompare(&src_view, &dst_view, NANOARROW_COMPARE_IDENTICAL,
+                                  &identical, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(identical, 1) << error.message;
+
+  struct ArrowArray plain_dst;
+  ASSERT_EQ(ArrowArrayInitFromType(&plain_dst, NANOARROW_TYPE_INT8), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&plain_dst), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&plain_dst, &src_view, &error), EINVAL);
+  EXPECT_STREQ(error.message,
+               "Can't append storage when exactly one of source and destination is "
+               "dictionary-encoded");
+
+  struct ArrowArrayView plain_view;
+  ArrowArrayViewInitFromType(&plain_view, NANOARROW_TYPE_INT8);
+  ASSERT_EQ(ArrowArrayViewSetArray(&plain_view, &plain_dst, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &plain_view, &error), EINVAL);
+  EXPECT_STREQ(error.message,
+               "Can't append storage when exactly one of source and destination is "
+               "dictionary-encoded");
+
+  ArrowArrayViewReset(&plain_view);
+  ArrowArrayRelease(&plain_dst);
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}
+
+#if defined(NANOARROW_BUILD_TESTS_WITH_ARROW)
+
+enum class ArrowCppAppendValueKind { kSigned, kUnsigned, kString };
+
+static std::shared_ptr<Array> BuildArrowCppAppendArray(
+    const std::shared_ptr<DataType>& type, ArrowCppAppendValueKind value_kind) {
+  auto maybe_builder = MakeBuilder(type);
+  ARROW_EXPECT_OK(maybe_builder.status());
+  auto builder = std::move(maybe_builder).ValueUnsafe();
+
+  for (int i = 0; i < 3; i++) {
+    if (i == 1) {
+      ARROW_EXPECT_OK(builder->AppendNull());
+      continue;
+    }
+
+    std::shared_ptr<Scalar> scalar;
+    switch (value_kind) {
+      case ArrowCppAppendValueKind::kSigned: {
+        auto maybe_scalar = MakeScalar(type, (int64_t)(i == 0 ? -1 : 42));
+        ARROW_EXPECT_OK(maybe_scalar.status());
+        scalar = maybe_scalar.ValueUnsafe();
+        break;
+      }
+      case ArrowCppAppendValueKind::kUnsigned: {
+        auto maybe_scalar = MakeScalar(type, (uint64_t)(i == 0 ? 1 : 42));
+        ARROW_EXPECT_OK(maybe_scalar.status());
+        scalar = maybe_scalar.ValueUnsafe();
+        break;
+      }
+      case ArrowCppAppendValueKind::kString: {
+        auto maybe_scalar = MakeScalar(type, std::string(i == 0 ? "abc" : "def"));
+        ARROW_EXPECT_OK(maybe_scalar.status());
+        scalar = maybe_scalar.ValueUnsafe();
+        break;
+      }
+    }
+
+    ARROW_EXPECT_OK(builder->AppendScalar(*scalar));
+  }
+
+  auto maybe_array = builder->Finish();
+  ARROW_EXPECT_OK(maybe_array.status());
+  return maybe_array.ValueUnsafe();
+}
+
+static std::shared_ptr<Array> BuildArrowCppAppendListArray(
+    const std::shared_ptr<DataType>& type) {
+  auto child_builder = std::make_shared<Int32Builder>();
+  if (type->id() == Type::LIST) {
+    ListBuilder builder(default_memory_pool(), child_builder, type);
+    ARROW_EXPECT_OK(builder.Append());
+    ARROW_EXPECT_OK(child_builder->Append(1));
+    ARROW_EXPECT_OK(child_builder->Append(2));
+    ARROW_EXPECT_OK(builder.AppendNull());
+    ARROW_EXPECT_OK(builder.Append());
+    ARROW_EXPECT_OK(child_builder->Append(3));
+    auto maybe_array = builder.Finish();
+    ARROW_EXPECT_OK(maybe_array.status());
+    return maybe_array.ValueUnsafe();
+  } else {
+    LargeListBuilder builder(default_memory_pool(), child_builder, type);
+    ARROW_EXPECT_OK(builder.Append());
+    ARROW_EXPECT_OK(child_builder->Append(1));
+    ARROW_EXPECT_OK(child_builder->Append(2));
+    ARROW_EXPECT_OK(builder.AppendNull());
+    ARROW_EXPECT_OK(builder.Append());
+    ARROW_EXPECT_OK(child_builder->Append(3));
+    auto maybe_array = builder.Finish();
+    ARROW_EXPECT_OK(maybe_array.status());
+    return maybe_array.ValueUnsafe();
+  }
+}
+
+static void ExpectArrowCppStorageAppendEquals(const std::shared_ptr<Array>& src,
+                                              const std::shared_ptr<Array>& expected) {
+  struct ArrowError error;
+  struct ArrowArray src_array;
+  struct ArrowSchema src_schema;
+  ARROW_EXPECT_OK(ExportArray(*src, &src_array, &src_schema));
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &src_schema, &error), NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src_array, &error), NANOARROW_OK)
+      << error.message;
+
+  struct ArrowSchema dst_schema;
+  ARROW_EXPECT_OK(ExportType(*expected->type(), &dst_schema));
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &dst_schema, &error), NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayFinishBuilding(&dst, NANOARROW_VALIDATION_LEVEL_FULL, &error),
+            NANOARROW_OK)
+      << error.message;
+
+  auto maybe_actual = ImportArray(&dst, &dst_schema);
+  ARROW_EXPECT_OK(maybe_actual.status());
+  EXPECT_TRUE(maybe_actual.ValueUnsafe()->Equals(expected))
+      << maybe_actual.ValueUnsafe()->ToString() << "\n!=\n"
+      << expected->ToString();
+
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src_array);
+  ArrowSchemaRelease(&src_schema);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewArrowCppSignedIntegers) {
+  std::vector<std::shared_ptr<DataType>> types = {int8(), int16(), int32(), int64()};
+  for (const auto& src_type : types) {
+    auto src = BuildArrowCppAppendArray(src_type, ArrowCppAppendValueKind::kSigned);
+    for (const auto& dst_type : types) {
+      SCOPED_TRACE(src_type->ToString() + " -> " + dst_type->ToString());
+      auto expected =
+          BuildArrowCppAppendArray(dst_type, ArrowCppAppendValueKind::kSigned);
+      ExpectArrowCppStorageAppendEquals(src, expected);
+    }
+  }
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewArrowCppUnsignedIntegers) {
+  std::vector<std::shared_ptr<DataType>> types = {uint8(), uint16(), uint32(), uint64()};
+  for (const auto& src_type : types) {
+    auto src = BuildArrowCppAppendArray(src_type, ArrowCppAppendValueKind::kUnsigned);
+    for (const auto& dst_type : types) {
+      SCOPED_TRACE(src_type->ToString() + " -> " + dst_type->ToString());
+      auto expected =
+          BuildArrowCppAppendArray(dst_type, ArrowCppAppendValueKind::kUnsigned);
+      ExpectArrowCppStorageAppendEquals(src, expected);
+    }
+  }
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewArrowCppStrings) {
+  std::vector<std::shared_ptr<DataType>> types = {utf8(), large_utf8()};
+  for (const auto& src_type : types) {
+    auto src = BuildArrowCppAppendArray(src_type, ArrowCppAppendValueKind::kString);
+    for (const auto& dst_type : types) {
+      SCOPED_TRACE(src_type->ToString() + " -> " + dst_type->ToString());
+      auto expected =
+          BuildArrowCppAppendArray(dst_type, ArrowCppAppendValueKind::kString);
+      ExpectArrowCppStorageAppendEquals(src, expected);
+    }
+  }
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewArrowCppBinary) {
+  std::vector<std::shared_ptr<DataType>> types = {binary(), large_binary()};
+  for (const auto& src_type : types) {
+    auto src = BuildArrowCppAppendArray(src_type, ArrowCppAppendValueKind::kString);
+    for (const auto& dst_type : types) {
+      SCOPED_TRACE(src_type->ToString() + " -> " + dst_type->ToString());
+      auto expected =
+          BuildArrowCppAppendArray(dst_type, ArrowCppAppendValueKind::kString);
+      ExpectArrowCppStorageAppendEquals(src, expected);
+    }
+  }
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewArrowCppLists) {
+  std::vector<std::shared_ptr<DataType>> types = {list(int32()), large_list(int32())};
+  for (const auto& src_type : types) {
+    auto src = BuildArrowCppAppendListArray(src_type);
+    for (const auto& dst_type : types) {
+      SCOPED_TRACE(src_type->ToString() + " -> " + dst_type->ToString());
+      auto expected = BuildArrowCppAppendListArray(dst_type);
+      ExpectArrowCppStorageAppendEquals(src, expected);
+    }
+  }
+}
+
+#endif

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5230,7 +5230,7 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewNestedAndSliced) {
   ArrowSchemaRelease(&schema);
 }
 
-TEST(ArrayTest, ArrayAppendStorageFromArrayViewUnions) {
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsUnions) {
   for (enum ArrowType union_type :
        {NANOARROW_TYPE_DENSE_UNION, NANOARROW_TYPE_SPARSE_UNION}) {
     struct ArrowError error;
@@ -5254,17 +5254,11 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewUnions) {
     ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
     ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
     struct ArrowArray dst;
-    ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
-        << error.message;
-    EXPECT_EQ(dst.length, 2);
+    ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), ENOTSUP);
+    EXPECT_EQ(dst.length, 0);
+    EXPECT_EQ(std::string(error.message), "Appending array views is not supported for " +
+                                              std::string(ArrowTypeString(union_type)));
 
-    struct ArrowArrayView dst_view;
-    ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
-    ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
-    EXPECT_EQ(ArrowArrayViewUnionTypeId(&dst_view, 0), 0);
-    EXPECT_EQ(ArrowArrayViewUnionTypeId(&dst_view, 1), 1);
-
-    ArrowArrayViewReset(&dst_view);
     ArrowArrayRelease(&dst);
     ArrowArrayViewReset(&src_view);
     ArrowArrayRelease(&src);
@@ -5393,6 +5387,45 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedWidthSlicedValidity) {
   ArrowArrayViewReset(&dst_view);
   ArrowArrayViewReset(&all_valid_view);
   ArrowArrayRelease(&all_valid);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedWidthChunkedValidity) {
+  constexpr int64_t kLength = 2050;
+  struct ArrowError error;
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromType(&src, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  for (int64_t i = 0; i < kLength; i++) {
+    if (i % 3 == 0) {
+      ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+    } else {
+      ASSERT_EQ(ArrowArrayAppendInt(&src, i), NANOARROW_OK);
+    }
+  }
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+  EXPECT_EQ(dst.length, kLength);
+  EXPECT_EQ(dst.null_count, 684);
+
+  struct ArrowArrayView dst_view;
+  ArrowArrayViewInitFromType(&dst_view, NANOARROW_TYPE_INT32);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 1023));
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 1024), 1024);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(&dst_view, 2048), 2048);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 2049));
+
+  ArrowArrayViewReset(&dst_view);
   ArrowArrayRelease(&dst);
   ArrowArrayViewReset(&src_view);
   ArrowArrayRelease(&src);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5398,6 +5398,92 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedWidthSlicedValidity) {
   ArrowArrayRelease(&src);
 }
 
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedToVariableWidth) {
+  struct ArrowError error;
+
+  struct ArrowSchema fixed_binary_schema;
+  ArrowSchemaInit(&fixed_binary_schema);
+  ASSERT_EQ(ArrowSchemaSetTypeFixedSize(&fixed_binary_schema,
+                                        NANOARROW_TYPE_FIXED_SIZE_BINARY, 3),
+            NANOARROW_OK);
+  struct ArrowArray fixed_binary;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&fixed_binary, &fixed_binary_schema, &error),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&fixed_binary), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendBytes(&fixed_binary, {{"abc"}, 3}), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&fixed_binary, &error), NANOARROW_OK);
+  struct ArrowArrayView fixed_binary_view;
+  ASSERT_EQ(
+      ArrowArrayViewInitFromSchema(&fixed_binary_view, &fixed_binary_schema, &error),
+      NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&fixed_binary_view, &fixed_binary, &error),
+            NANOARROW_OK);
+
+  struct ArrowArray binary;
+  ASSERT_EQ(ArrowArrayInitFromType(&binary, NANOARROW_TYPE_BINARY), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&binary), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&binary, &fixed_binary_view, &error),
+            NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&binary, &error), NANOARROW_OK);
+  struct ArrowArrayView binary_view;
+  ArrowArrayViewInitFromType(&binary_view, NANOARROW_TYPE_BINARY);
+  ASSERT_EQ(ArrowArrayViewSetArray(&binary_view, &binary, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(&binary_view, 0), "abc"_asv);
+
+  ArrowArrayViewReset(&binary_view);
+  ArrowArrayRelease(&binary);
+  ArrowArrayViewReset(&fixed_binary_view);
+  ArrowArrayRelease(&fixed_binary);
+  ArrowSchemaRelease(&fixed_binary_schema);
+
+  struct ArrowSchema fixed_list_schema;
+  ArrowSchemaInit(&fixed_list_schema);
+  ASSERT_EQ(
+      ArrowSchemaSetTypeFixedSize(&fixed_list_schema, NANOARROW_TYPE_FIXED_SIZE_LIST, 2),
+      NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(fixed_list_schema.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
+  struct ArrowArray fixed_list;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&fixed_list, &fixed_list_schema, &error),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&fixed_list), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(fixed_list.children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(fixed_list.children[0], 2), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&fixed_list), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&fixed_list, &error), NANOARROW_OK);
+  struct ArrowArrayView fixed_list_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&fixed_list_view, &fixed_list_schema, &error),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&fixed_list_view, &fixed_list, &error), NANOARROW_OK);
+
+  struct ArrowSchema list_schema;
+  ASSERT_EQ(ArrowSchemaInitFromType(&list_schema, NANOARROW_TYPE_LIST), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(list_schema.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
+  struct ArrowArray list;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&list, &list_schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&list), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&list, &fixed_list_view, &error),
+            NANOARROW_OK)
+      << error.message;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&list, &error), NANOARROW_OK);
+  struct ArrowArrayView list_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&list_view, &list_schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&list_view, &list, &error), NANOARROW_OK);
+  EXPECT_EQ(ArrowArrayViewListChildOffset(&list_view, 0), 0);
+  EXPECT_EQ(ArrowArrayViewListChildOffset(&list_view, 1), 2);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(list_view.children[0], 0), 1);
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(list_view.children[0], 1), 2);
+
+  ArrowArrayViewReset(&list_view);
+  ArrowArrayRelease(&list);
+  ArrowSchemaRelease(&list_schema);
+  ArrowArrayViewReset(&fixed_list_view);
+  ArrowArrayRelease(&fixed_list);
+  ArrowSchemaRelease(&fixed_list_schema);
+}
+
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewErrors) {
   struct ArrowError error;
   struct ArrowArray src;

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5322,7 +5322,7 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncoded) {
   struct ArrowError error;
   struct ArrowSchema schema;
   ArrowSchemaInit(&schema);
-  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
   ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
 
   struct ArrowArray src;
@@ -5373,6 +5373,85 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncoded) {
   ArrowSchemaRelease(&schema);
 }
 
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncodedLengthOverflow) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_INT32), NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[1], 42), NANOARROW_OK);
+  src.length = 1;
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+  dst.length = INT64_MAX;
+
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EOVERFLOW);
+  EXPECT_STREQ(error.message,
+               "Expected run-end encoded destination length plus source length to fit "
+               "in int64 but found 9223372036854775807 and 1");
+  EXPECT_EQ(dst.children[0]->length, 0);
+  EXPECT_EQ(dst.children[1]->length, 0);
+
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewStructWithRunEndEncodedChild) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(schema.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0]->children[1], NANOARROW_TYPE_STRING),
+            NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendNull(&src, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendInt(src.children[0]->children[0], 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayAppendString(src.children[0]->children[1], "value"_asv),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK) << error.message;
+
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+
+  struct ArrowArrayView dst_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  EXPECT_TRUE(ArrowArrayViewIsNull(&dst_view, 0));
+  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0]->children[0], 0), 1);
+  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(dst_view.children[0]->children[1], 0),
+            "value"_asv);
+
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}
+
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsNullToRunEndEncoded) {
   struct ArrowError error;
   struct ArrowArrayView src_view;
@@ -5389,10 +5468,43 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsNullToRunEndEncoded) {
 
   EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EINVAL);
   EXPECT_STREQ(error.message,
-               "Can't append null storage to an array with run-end encoded storage");
+               "Can't append null storage to an array whose null representation "
+               "requires appending to run-end encoded storage");
   EXPECT_EQ(dst.length, 0);
   EXPECT_EQ(dst.children[0]->length, 0);
   EXPECT_EQ(dst.children[1]->length, 0);
+
+  ArrowArrayRelease(&dst);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayViewReset(&src_view);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsNullToNestedRunEndEncoded) {
+  struct ArrowError error;
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, NANOARROW_TYPE_NA);
+  src_view.length = 1;
+
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema, 1), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(schema.children[0], NANOARROW_TYPE_INT32),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[0]->children[1], NANOARROW_TYPE_STRING),
+            NANOARROW_OK);
+
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EINVAL);
+  EXPECT_STREQ(error.message,
+               "Can't append null storage to an array whose null representation "
+               "requires appending to run-end encoded storage");
+  EXPECT_EQ(dst.length, 0);
+  EXPECT_EQ(dst.children[0]->length, 0);
+  EXPECT_EQ(dst.children[0]->children[0]->length, 0);
+  EXPECT_EQ(dst.children[0]->children[1]->length, 0);
 
   ArrowArrayRelease(&dst);
   ArrowSchemaRelease(&schema);

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5230,6 +5230,58 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewNestedAndSliced) {
   ArrowSchemaRelease(&schema);
 }
 
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewNestedDecimal) {
+  struct ArrowError error;
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema, 2), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetName(schema.children[0], "scalar"), NANOARROW_OK);
+  ASSERT_EQ(
+      ArrowSchemaSetTypeDecimal(schema.children[0], NANOARROW_TYPE_DECIMAL128, 10, 2),
+      NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetName(schema.children[1], "values"), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_LIST), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetTypeDecimal(schema.children[1]->children[0],
+                                      NANOARROW_TYPE_DECIMAL128, 10, 2),
+            NANOARROW_OK);
+
+  struct ArrowArray src;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+  struct ArrowDecimal decimal;
+  ArrowDecimalInit(&decimal, 128, 10, 2);
+  ArrowDecimalSetInt(&decimal, 1234);
+  ASSERT_EQ(ArrowArrayAppendDecimal(src.children[0], &decimal), NANOARROW_OK);
+  ArrowDecimalSetInt(&decimal, 5678);
+  ASSERT_EQ(ArrowArrayAppendDecimal(src.children[1]->children[0], &decimal),
+            NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(src.children[1]), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishElement(&src), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK) << error.message;
+
+  struct ArrowArrayView src_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+  struct ArrowArray dst;
+  ASSERT_EQ(AppendStorageFromArrayViewForTest(&src_view, &dst, &error), NANOARROW_OK)
+      << error.message;
+
+  struct ArrowArrayView dst_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+  int identical = 0;
+  ASSERT_EQ(ArrowArrayViewCompare(&src_view, &dst_view, NANOARROW_COMPARE_IDENTICAL,
+                                  &identical, &error),
+            NANOARROW_OK);
+  EXPECT_EQ(identical, 1) << error.message;
+
+  ArrowArrayViewReset(&dst_view);
+  ArrowArrayRelease(&dst);
+  ArrowArrayViewReset(&src_view);
+  ArrowArrayRelease(&src);
+  ArrowSchemaRelease(&schema);
+}
+
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsUnions) {
   for (enum ArrowType union_type :
        {NANOARROW_TYPE_DENSE_UNION, NANOARROW_TYPE_SPARSE_UNION}) {
@@ -5319,6 +5371,32 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncoded) {
   ArrowArrayViewReset(&src_view);
   ArrowArrayRelease(&src);
   ArrowSchemaRelease(&schema);
+}
+
+TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsNullToRunEndEncoded) {
+  struct ArrowError error;
+  struct ArrowArrayView src_view;
+  ArrowArrayViewInitFromType(&src_view, NANOARROW_TYPE_NA);
+  src_view.length = 1;
+
+  struct ArrowSchema schema;
+  ArrowSchemaInit(&schema);
+  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT32), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+  struct ArrowArray dst;
+  ASSERT_EQ(ArrowArrayInitFromSchema(&dst, &schema, &error), NANOARROW_OK);
+  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+
+  EXPECT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), EINVAL);
+  EXPECT_STREQ(error.message,
+               "Can't append null storage to an array with run-end encoded storage");
+  EXPECT_EQ(dst.length, 0);
+  EXPECT_EQ(dst.children[0]->length, 0);
+  EXPECT_EQ(dst.children[1]->length, 0);
+
+  ArrowArrayRelease(&dst);
+  ArrowSchemaRelease(&schema);
+  ArrowArrayViewReset(&src_view);
 }
 
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewFixedWidthSlicedValidity) {

--- a/src/nanoarrow/common/array_test.cc
+++ b/src/nanoarrow/common/array_test.cc
@@ -5319,58 +5319,67 @@ TEST(ArrayTest, ArrayAppendStorageFromArrayViewRejectsUnions) {
 }
 
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncoded) {
-  struct ArrowError error;
-  struct ArrowSchema schema;
-  ArrowSchemaInit(&schema);
-  ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, NANOARROW_TYPE_INT16), NANOARROW_OK);
-  ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING), NANOARROW_OK);
+  for (enum ArrowType run_end_type :
+       {NANOARROW_TYPE_INT16, NANOARROW_TYPE_INT32, NANOARROW_TYPE_INT64}) {
+    SCOPED_TRACE(ArrowTypeString(run_end_type));
+    struct ArrowError error;
+    struct ArrowSchema schema;
+    ArrowSchemaInit(&schema);
+    ASSERT_EQ(ArrowSchemaSetTypeRunEndEncoded(&schema, run_end_type), NANOARROW_OK);
+    ASSERT_EQ(ArrowSchemaSetType(schema.children[1], NANOARROW_TYPE_STRING),
+              NANOARROW_OK);
 
-  struct ArrowArray src;
-  ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 2), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 3), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "a"_asv), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendString(src.children[1], "b"_asv), NANOARROW_OK);
-  src.length = 3;
-  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
+    struct ArrowArray src;
+    ASSERT_EQ(ArrowArrayInitFromSchema(&src, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayStartAppending(&src), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 2), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendInt(src.children[0], 3), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendString(src.children[1], "a"_asv), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendString(src.children[1], "b"_asv), NANOARROW_OK);
+    src.length = 3;
+    ASSERT_EQ(ArrowArrayFinishBuildingDefault(&src, &error), NANOARROW_OK);
 
-  struct ArrowArrayView src_view;
-  ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
-  struct ArrowArray dst;
-  ASSERT_EQ(ArrowArrayInitFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
-  EXPECT_EQ(dst.length, 6);
+    struct ArrowArrayView src_view;
+    ASSERT_EQ(ArrowArrayViewInitFromSchema(&src_view, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayViewSetArray(&src_view, &src, &error), NANOARROW_OK);
+    struct ArrowArray dst;
+    ASSERT_EQ(ArrowArrayInitFromArrayView(&dst, &src_view, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayStartAppending(&dst), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error),
+              NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error),
+              NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK)
+        << error.message;
+    EXPECT_EQ(dst.length, 6);
 
-  struct ArrowArrayView dst_view;
-  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 2), 5);
-  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 3), 6);
-  ArrowArrayViewReset(&dst_view);
+    struct ArrowArrayView dst_view;
+    ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+    EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 2), 5);
+    EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 3), 6);
+    ArrowArrayViewReset(&dst_view);
 
-  src_view.offset = 1;
-  src_view.length = 1;
-  ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
-      << error.message;
-  ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK) << error.message;
-  EXPECT_EQ(dst.length, 7);
-  EXPECT_EQ(dst.children[0]->length, 5);
-  EXPECT_EQ(dst.children[1]->length, 5);
-  ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
-  ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
-  EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 4), 7);
-  EXPECT_EQ(ArrowArrayViewGetStringUnsafe(dst_view.children[1], 4), "a"_asv);
+    src_view.offset = 1;
+    src_view.length = 1;
+    ASSERT_EQ(ArrowArrayAppendStorageFromArrayView(&dst, &src_view, &error), NANOARROW_OK)
+        << error.message;
+    ASSERT_EQ(ArrowArrayFinishBuildingDefault(&dst, &error), NANOARROW_OK)
+        << error.message;
+    EXPECT_EQ(dst.length, 7);
+    EXPECT_EQ(dst.children[0]->length, 5);
+    EXPECT_EQ(dst.children[1]->length, 5);
+    ASSERT_EQ(ArrowArrayViewInitFromSchema(&dst_view, &schema, &error), NANOARROW_OK);
+    ASSERT_EQ(ArrowArrayViewSetArray(&dst_view, &dst, &error), NANOARROW_OK);
+    EXPECT_EQ(ArrowArrayViewGetIntUnsafe(dst_view.children[0], 4), 7);
+    EXPECT_EQ(ArrowArrayViewGetStringUnsafe(dst_view.children[1], 4), "a"_asv);
 
-  ArrowArrayViewReset(&dst_view);
-  ArrowArrayRelease(&dst);
-  ArrowArrayViewReset(&src_view);
-  ArrowArrayRelease(&src);
-  ArrowSchemaRelease(&schema);
+    ArrowArrayViewReset(&dst_view);
+    ArrowArrayRelease(&dst);
+    ArrowArrayViewReset(&src_view);
+    ArrowArrayRelease(&src);
+    ArrowSchemaRelease(&schema);
+  }
 }
 
 TEST(ArrayTest, ArrayAppendStorageFromArrayViewRunEndEncodedLengthOverflow) {

--- a/src/nanoarrow/common/buffer_test.cc
+++ b/src/nanoarrow/common/buffer_test.cc
@@ -647,6 +647,16 @@ TEST(BitmapTest, BitmapTestAppendInt8Unsafe) {
     EXPECT_EQ(ArrowBitGet(bitmap.buffer.data, i), test_values[i - 136]);
   }
 
+  // Append fewer values than are needed to complete the current byte
+  int8_t short_values[] = {1, 0, 1};
+  ASSERT_EQ(ArrowBitmapReserve(&bitmap, 3), NANOARROW_OK);
+  ArrowBitmapAppendInt8Unsafe(&bitmap, short_values, 3);
+  EXPECT_EQ(bitmap.size_bits, 207);
+  EXPECT_EQ(bitmap.buffer.size_bytes, 26);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(ArrowBitGet(bitmap.buffer.data, 204 + i), short_values[i]);
+  }
+
   ArrowBitmapReset(&bitmap);
 }
 
@@ -700,6 +710,16 @@ TEST(BitmapTest, BitmapTestAppendInt32Unsafe) {
   }
   for (int i = 136; i < 204; i++) {
     EXPECT_EQ(ArrowBitGet(bitmap.buffer.data, i), test_values[i - 136]);
+  }
+
+  // Append fewer values than are needed to complete the current byte
+  int32_t short_values[] = {1, 0, 1};
+  ASSERT_EQ(ArrowBitmapReserve(&bitmap, 3), NANOARROW_OK);
+  ArrowBitmapAppendInt32Unsafe(&bitmap, short_values, 3);
+  EXPECT_EQ(bitmap.size_bits, 207);
+  EXPECT_EQ(bitmap.buffer.size_bytes, 26);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(ArrowBitGet(bitmap.buffer.data, 204 + i), short_values[i]);
   }
 
   ArrowBitmapReset(&bitmap);

--- a/src/nanoarrow/common/inline_buffer.h
+++ b/src/nanoarrow/common/inline_buffer.h
@@ -635,6 +635,10 @@ static inline void ArrowBitmapAppendInt8Unsafe(struct ArrowBitmap* bitmap,
   // First byte
   if ((out_i_cursor % 8) != 0) {
     int64_t n_partial_bits = _ArrowRoundUpToMultipleOf8(out_i_cursor) - out_i_cursor;
+    if (n_partial_bits > n_remaining) {
+      n_partial_bits = n_remaining;
+    }
+
     for (int i = 0; i < n_partial_bits; i++) {
       ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, values[i]);
     }
@@ -685,6 +689,10 @@ static inline void ArrowBitmapAppendInt32Unsafe(struct ArrowBitmap* bitmap,
   // First byte
   if ((out_i_cursor % 8) != 0) {
     int64_t n_partial_bits = _ArrowRoundUpToMultipleOf8(out_i_cursor) - out_i_cursor;
+    if (n_partial_bits > n_remaining) {
+      n_partial_bits = n_remaining;
+    }
+
     for (int i = 0; i < n_partial_bits; i++) {
       ArrowBitSetTo(bitmap->buffer.data, out_i_cursor++, (uint8_t)values[i]);
     }

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -122,8 +122,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArraySetValidityBitmap)
 #define ArrowArraySetBuffer NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArraySetBuffer)
 #define ArrowArrayReserve NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayReserve)
-#define ArrowArrayAppendArrayView \
-  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayAppendArrayView)
+#define ArrowArrayAppendStorageFromArrayView \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayAppendStorageFromArrayView)
 #define ArrowArrayFinishBuilding \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayFinishBuilding)
 #define ArrowArrayFinishBuildingDefault \
@@ -1034,13 +1034,14 @@ static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array);
 NANOARROW_DLL ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
                                                int64_t additional_size_elements);
 
-/// \brief Append the contents of an ArrowArrayView to an ArrowArray
+/// \brief Append storage from an ArrowArrayView to an ArrowArray
 ///
-/// Appends each logical element of array_view to array. array must have been
-/// initialized with the same storage type and layout as array_view and prepared
-/// using ArrowArrayStartAppending(). Dictionary values referenced by array_view
-/// are not copied. Returns ENOTSUP for unsupported storage types.
-NANOARROW_DLL ArrowErrorCode ArrowArrayAppendArrayView(
+/// Appends each logical storage element of array_view to array. array must have
+/// been initialized with compatible storage and prepared using
+/// ArrowArrayStartAppending(). Dictionary values referenced by array_view are
+/// not copied; dictionary-encoded inputs require a dictionary-encoded output.
+/// Returns EINVAL for incompatible storage and ENOTSUP for unsupported storage.
+NANOARROW_DLL ArrowErrorCode ArrowArrayAppendStorageFromArrayView(
     struct ArrowArray* array, const struct ArrowArrayView* array_view,
     struct ArrowError* error);
 

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -122,6 +122,8 @@
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArraySetValidityBitmap)
 #define ArrowArraySetBuffer NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArraySetBuffer)
 #define ArrowArrayReserve NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayReserve)
+#define ArrowArrayAppendArrayView \
+  NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayAppendArrayView)
 #define ArrowArrayFinishBuilding \
   NANOARROW_SYMBOL(NANOARROW_NAMESPACE, ArrowArrayFinishBuilding)
 #define ArrowArrayFinishBuildingDefault \
@@ -1031,6 +1033,16 @@ static inline ArrowErrorCode ArrowArrayStartAppending(struct ArrowArray* array);
 /// that occur using the item-wise appenders.
 NANOARROW_DLL ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
                                                int64_t additional_size_elements);
+
+/// \brief Append the contents of an ArrowArrayView to an ArrowArray
+///
+/// Appends each logical element of array_view to array. array must have been
+/// initialized with the same storage type and layout as array_view and prepared
+/// using ArrowArrayStartAppending(). Dictionary values referenced by array_view
+/// are not copied. Returns ENOTSUP for unsupported storage types.
+NANOARROW_DLL ArrowErrorCode ArrowArrayAppendArrayView(
+    struct ArrowArray* array, const struct ArrowArrayView* array_view,
+    struct ArrowError* error);
 
 /// \brief Append a null value to an array
 static inline ArrowErrorCode ArrowArrayAppendNull(struct ArrowArray* array, int64_t n);

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1043,6 +1043,8 @@ NANOARROW_DLL ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
 /// Struct children are matched by position. Logical type metadata not carried by
 /// ArrowArrayView, including struct field names and decimal precision and scale,
 /// must be checked by the caller.
+/// array_view must not reference storage owned by array or its children because an
+/// append may reallocate and invalidate that storage.
 /// Returns EINVAL for incompatible storage and ENOTSUP for unsupported storage.
 NANOARROW_DLL ArrowErrorCode ArrowArrayAppendStorageFromArrayView(
     struct ArrowArray* array, const struct ArrowArrayView* array_view,

--- a/src/nanoarrow/nanoarrow.h
+++ b/src/nanoarrow/nanoarrow.h
@@ -1040,6 +1040,9 @@ NANOARROW_DLL ArrowErrorCode ArrowArrayReserve(struct ArrowArray* array,
 /// been initialized with compatible storage and prepared using
 /// ArrowArrayStartAppending(). Dictionary values referenced by array_view are
 /// not copied; dictionary-encoded inputs require a dictionary-encoded output.
+/// Struct children are matched by position. Logical type metadata not carried by
+/// ArrowArrayView, including struct field names and decimal precision and scale,
+/// must be checked by the caller.
 /// Returns EINVAL for incompatible storage and ENOTSUP for unsupported storage.
 NANOARROW_DLL ArrowErrorCode ArrowArrayAppendStorageFromArrayView(
     struct ArrowArray* array, const struct ArrowArrayView* array_view,


### PR DESCRIPTION
## Summary

- add `ArrowArrayAppendArrayView()` as a core array-building API
- append primitive, nested, union, list-view, and run-end encoded values from an `ArrowArrayView`
- preserve source slicing semantics and report unsupported sliced run-end encoded inputs
- add direct native coverage for primitive, nested/sliced, union, and run-end encoded arrays

## Context

This extracts the generic array-view appender from #928 as requested in review. It is independently useful and will be the prerequisite for a separate dictionary-delta decoding PR; #928 no longer contains the appender or decoder changes.

## Validation

- native CMake build passed
- native CTest suite: 334/334 passed (4 optional codec tests skipped)
