### PR TITLE
ci: strip README badges from the generated docs homepage

### DIFF
--- a/ci/scripts/build-docs.sh
+++ b/ci/scripts/build-docs.sh
@@ -82,8 +82,10 @@ main() {
    pushd docs
 
 
-   # Use the README as the docs homepage
-   pandoc ../README.md --from markdown --to rst -s -o source/README_generated.rst
+   # Use the README as the docs homepage. Badges are stripped: the CSP on
+   # arrow.apache.org only allows images from *.apache.org.
+   sed -e '/^\[!\[/d' ../README.md | \
+     pandoc --from markdown --to rst -s -o source/README_generated.rst
 
    # Use R README as the getting started guide for R
    pandoc ../r/README.md --from markdown --to rst -s -o source/getting-started/r.rst


### PR DESCRIPTION
The three README badges always render as broken images on
https://arrow.apache.org/nanoarrow/. The ASF site sends
`Content-Security-Policy: ... img-src 'self' data: https://*.apache.org/ ...`,
which blocks `codecov.io` and `img.shields.io`.

This removes them from the generated docs homepage only; they still render on
GitHub. They can be re-added later by fetching the SVGs at build time and
serving them from `_static/`.

edit: attached screenshot
<img width="907" height="613" alt="Screenshot 2026-09-12 114021" src="https://github.com/user-attachments/assets/c52eb4d3-767a-4cea-8c80-36252a5b2d43" />
